### PR TITLE
feat(contract): harden admin immutability, export verified flags, ver…

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -27,6 +27,21 @@ struct Stats {
 }
 ```
 
+### ExportPage
+
+Returned by `get_registered_paginated` and `get_public_paginated`. Unlike
+`get_all_registered`, each entry is a full `ContributorRecord` — so `verified`
+is available directly, with no second call needed (Issue #96).
+
+```rust
+struct ExportPage {
+    records: Vec<(String, ContributorRecord)>,
+    next_cursor: Option<u32>,
+    total: u32,
+    has_more: bool,
+}
+```
+
 ### BatchSummary
 
 Returned by `batch_verify`. `success_rate` is an integer percentage.
@@ -84,6 +99,14 @@ One-time setup. Stores the admin address and zeroes counters.
 | **Auth** | None (protect at deployment time) |
 | **Mutates** | Yes |
 | **Errors** | `AlreadyInitialized` |
+
+**Admin immutability (Issue #97).** The admin address set here cannot be
+overwritten or silently replaced afterward: `initialize` is the only entry
+point that writes it, and a second call always fails with
+`AlreadyInitialized`, regardless of which admin address it names. No other
+function in this ABI mutates the admin. There is no on-chain admin-transfer
+API — rotating the admin means deploying a new contract instance. See
+[SECURITY.md § Admin Key Management](SECURITY.md#admin-key-management).
 
 ```bash
 stellar contract invoke --id $ID --source deployer --network testnet --send=yes \
@@ -162,6 +185,12 @@ removable.
 stellar contract invoke --id $ID --source deployer --network testnet --send=yes \
   -- register --github-username octocat --stellar-address G...
 ```
+
+**Multi-user register sequence (Issue #94).** For a reference fixture of
+`register` called for several users in sequence — expected `RegisteredEvent`
+order and `get_stats()` progression after each step — see
+`test_issue_94_multi_user_register_sequence` in `src/lib.rs` and
+[DASHBOARD_SYNC.md § Multi-user register sequence](DASHBOARD_SYNC.md#multi-user-register-sequence-issue-94).
 
 ---
 
@@ -266,6 +295,69 @@ stellar contract invoke --id $ID --source admin --network testnet \
   -- get_all_registered
 ```
 
+**No `verified` flag.** Entries are `(String, Address)` pairs only — there is
+no per-user verification status here. Consumers that need username, address,
+and verified together should use `get_registered_paginated` (admin) or
+`get_public_paginated` (public) instead, both documented below (Issue #96).
+
+---
+
+### `get_registered_page(offset: u32, limit: u32) -> Result<Vec<(String, Address)>, ContractError>`
+
+Admin-gated page of `(github_username, stellar_address)` pairs, for large
+registries where `get_all_registered` would exceed the per-invocation
+footprint limit. Same shape as `get_all_registered` — no `verified` flag; use
+`get_registered_paginated` for that.
+
+| | |
+|---|---|
+| **Auth** | Admin |
+| **Mutates** | No |
+| **Errors** | `NotInitialized` |
+
+---
+
+### `get_registered_paginated(cursor: u32, limit: u32) -> Result<ExportPage, ContractError>`
+
+Admin-gated paginated export. Each entry is a full `ContributorRecord`, so the
+`verified` bit travels with every row — no second call or cross-reference
+against `get_address` is needed to know verification status (Issue #96).
+
+| | |
+|---|---|
+| **Auth** | Admin |
+| **Mutates** | No |
+| **Errors** | `NotInitialized` |
+
+`limit = 0` defaults to `DEFAULT_PAGE_LIMIT` (20); any value above
+`MAX_PAGE_LIMIT` (100) is clamped down to it. `next_cursor` is `Some` while
+`has_more` is true; pass it back as `cursor` to continue.
+
+```bash
+stellar contract invoke --id $ID --source admin --network testnet \
+  -- get_registered_paginated --cursor 0 --limit 50
+```
+
+---
+
+### `get_public_paginated(cursor: u32, limit: u32) -> Result<ExportPage, ContractError>`
+
+Same `ExportPage` shape as `get_registered_paginated` — including the
+`verified` flag per record — but callable by anyone. This is the
+unauthenticated read path for dashboards and indexers that need
+username + address + verified without an admin key (Issue #96).
+
+| | |
+|---|---|
+| **Auth** | None |
+| **Mutates** | No |
+| **Errors** | `NotInitialized`, `Paused` |
+
+```bash
+stellar contract invoke --id $ID --source deployer --network testnet \
+  -- get_public_paginated --cursor 0 --limit 50
+```
+
 ---
 
 ### `verify(github_username: String) -> Result<(), ContractError>`
@@ -364,6 +456,17 @@ stellar contract invoke --id $ID --source admin --network testnet --send=yes \
 stellar contract invoke --id $ID --source verifier --network testnet --send=yes \
   -- revoke_verification --caller G... --github-username octocat
 ```
+
+**Verify → revoke → verify cycle (Issue #95).** `verify` and
+`revoke_verification` can be applied to the same username repeatedly without
+corrupting counters or storage: revoking decrements `verified`, and a
+subsequent `verify` succeeds and publishes a fresh `VerifiedEvent`. Only the
+`verified` flag and the `verified` counter change across the cycle — the
+record's `stellar_address` and `registered_at` are untouched. A `verify` call
+with no intervening `revoke_verification` still fails `AlreadyVerified`, even
+after the record has already been through one full cycle. Covered by
+`test_issue_95_verify_revoke_verify_cycle` and
+`test_issue_95_double_verify_without_revoke_fails_mid_cycle` in `src/lib.rs`.
 
 ---
 

--- a/docs/DASHBOARD_SYNC.md
+++ b/docs/DASHBOARD_SYNC.md
@@ -35,3 +35,48 @@ instead when syncing incrementally — it walks the same admin-gated index but
 in bounded chunks, so a dashboard/indexer sync job can page through without
 risking a resource-limit failure on a large registry. See
 `test_get_registered_page_paginates_and_gates_on_admin` in `src/lib.rs`.
+
+## Verified flags in exports (Issue #96)
+
+`get_all_registered` and `get_registered_page` return `(github_username,
+stellar_address)` pairs only — no `verified` bit. A dashboard that needs to
+know verification status alongside the address should use one of the two
+`ExportPage`-returning calls instead, both of which carry the full
+`ContributorRecord` (including `verified`) per entry:
+
+| Function | Auth | Use when |
+|---|---|---|
+| `get_registered_paginated(cursor, limit)` | Admin | Operator/admin-side sync jobs that already hold the admin key |
+| `get_public_paginated(cursor, limit)` | None | Public dashboard reads with no admin key available |
+
+Both accept a zero-based `cursor` and a `limit` (0 defaults to 20, capped at
+100), and return `{ records, next_cursor, total, has_more }`. Page forward by
+passing the previous response's `next_cursor` back in as `cursor` until
+`has_more` is `false`.
+
+Tests covering empty, all-unverified, and mixed registries live in
+`src/lib.rs`: `test_issue_96_paginated_export_verified_flags_empty_registry`,
+`test_issue_96_paginated_export_verified_flags_all_unverified`,
+`test_issue_96_paginated_export_verified_flags_mixed_registry`.
+
+## Multi-user register sequence (Issue #94)
+
+Reference fixture for integrators wiring a sync worker against `register`:
+three users, registered one at a time, with the expected event and stats
+progression at each step.
+
+| Step | Call | `RegisteredEvent` topic | `get_stats().total` after |
+|---|---|---|---|
+| 1 | `register("alice", addr1)` | `alice` | 1 |
+| 2 | `register("bob", addr2)` | `bob` | 2 |
+| 3 | `register("carol", addr3)` | `carol` | 3 |
+
+Each `register` call publishes exactly one `RegisteredEvent` (topic:
+`github_username`; data: `stellar_address`, `timestamp`), and `get_stats().total`
+increments by exactly one per step while `verified` stays at 0 throughout,
+since none of the three have been verified. After all three, every username
+resolves through `get_address` and `has_record`, and the entry count in
+`get_all_registered` / the paginated exports matches.
+
+Automated coverage: `test_issue_94_multi_user_register_sequence` in
+`src/lib.rs`.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -16,6 +16,7 @@ Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [DEPL
 | Unauthorized removal | `caller` must auth as registrant or admin |
 | Unauthorized admin actions | `admin.require_auth()` on `verify` and `get_all_registered` |
 | Double initialization | `AlreadyInitialized` error |
+| Admin storage mutated after init | No public setter writes `ADMIN_KEY` — only `initialize` does, gated by `AlreadyInitialized` (Issue #97) |
 | Malformed or oversized username input | `InvalidUsername` error, checked before auth and before any write |
 | Counter drift from rejected calls | Invariant property fuzzing, see [REGISTRY_INVARIANTS](REGISTRY_INVARIANTS.md) |
 | Compromised or unpinned RPC client dependency | Crate validation checklist below |
@@ -33,7 +34,24 @@ Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [DEPL
 
 ## Admin Key Management
 
-The admin address is **immutable** after `initialize`. Recommendations:
+The admin address is **immutable** after `initialize` (Issue #97). `initialize`
+is the only entry point that writes the `ADMIN_KEY` storage slot, and it does
+so exactly once: a second call fails with `AlreadyInitialized` regardless of
+which admin address it names. No other public function in the ABI — `pause`,
+`set_role`, `set_cooldown`, `migrate`, `upgrade`, etc. — mutates `ADMIN_KEY`.
+There is deliberately no admin-transfer API (see Notes on Issue #97); rotation
+means redeploying a new instance.
+
+Regression coverage in `src/lib.rs`:
+
+- `test_double_initialize_rejected_after_successful_init`,
+  `test_issue_97_second_initialize_rejected_with_different_admin` — a second
+  `initialize` always fails, even with a different admin address.
+- `test_issue_97_admin_unchanged_across_unrelated_operations` — the original
+  admin remains the only recognized admin across pause/unpause, role grants,
+  cooldown changes, verify, and migration.
+
+Recommendations:
 
 - Use a **multisig** or **smart account** as the admin G-address
 - Never commit private keys or seed phrases

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2588,4 +2588,272 @@ mod test {
             assert_eq!(TrustBridgeContract::get_role(env.clone(), verifier.clone()), Some(Role::Verifier));
         });
     }
+
+    // ── Issue #97: Harden immutable admin after init ──────────────────────────
+
+    /// A second `initialize` call must be rejected regardless of which admin
+    /// address it attempts to install, and the original admin must remain the
+    /// only recognized admin afterward (Issue #97).
+    #[test]
+    fn test_issue_97_second_initialize_rejected_with_different_admin() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let contract_id = env.register(TrustBridgeContract, ());
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::initialize(env.clone(), admin.clone()).unwrap();
+
+            let result = TrustBridgeContract::initialize(env.clone(), attacker.clone());
+            assert_eq!(result, Err(ContractError::AlreadyInitialized));
+
+            assert!(TrustBridgeContract::has_admin_role(env.clone(), admin.clone()));
+            assert!(!TrustBridgeContract::has_admin_role(env.clone(), attacker.clone()));
+        });
+    }
+
+    /// The admin recorded at `initialize` must survive every other mutating
+    /// entry point: nothing in the public API updates `ADMIN_KEY` after a
+    /// successful init (Issue #97).
+    #[test]
+    fn test_issue_97_admin_unchanged_across_unrelated_operations() {
+        let env = Env::default();
+        let (admin, user, verifier, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_role(env.clone(), verifier.clone(), Role::Verifier).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone()).unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat")).unwrap();
+            TrustBridgeContract::pause(env.clone()).unwrap();
+            TrustBridgeContract::unpause(env.clone()).unwrap();
+            TrustBridgeContract::set_cooldown(env.clone(), 10).unwrap();
+            TrustBridgeContract::migrate(env.clone(), (1, 1, 0)).unwrap();
+
+            assert!(TrustBridgeContract::has_admin_role(env.clone(), admin.clone()));
+            assert!(!TrustBridgeContract::has_admin_role(env.clone(), user.clone()));
+            assert!(!TrustBridgeContract::has_admin_role(env.clone(), verifier.clone()));
+        });
+    }
+
+    // ── Issue #96: Export with verified flags ──────────────────────────────────
+
+    /// Paginated export on an empty registry returns no records (Issue #96).
+    #[test]
+    fn test_issue_96_paginated_export_verified_flags_empty_registry() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            let page = TrustBridgeContract::get_registered_paginated(env.clone(), 0, 10).unwrap();
+            assert_eq!(page.records.len(), 0);
+            assert_eq!(page.total, 0);
+            assert!(!page.has_more);
+        });
+    }
+
+    /// Every record in an all-unverified registry reports `verified = false`
+    /// through the paginated export (Issue #96).
+    #[test]
+    fn test_issue_96_paginated_export_verified_flags_all_unverified() {
+        let env = Env::default();
+        let (_admin, user1, user2, contract_id) = setup(&env);
+        let user3 = Address::generate(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone()).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone()).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "carol"), user3.clone()).unwrap();
+
+            let page = TrustBridgeContract::get_registered_paginated(env.clone(), 0, 10).unwrap();
+            assert_eq!(page.records.len(), 3);
+            for i in 0..page.records.len() {
+                let (_name, record) = page.records.get(i).unwrap();
+                assert!(!record.verified);
+            }
+        });
+    }
+
+    /// A mixed verified/unverified registry surfaces the correct per-record
+    /// `verified` flag through both the admin and public paginated exports,
+    /// so consumers can obtain username + address + verified without a
+    /// second call or guessing (Issue #96).
+    #[test]
+    fn test_issue_96_paginated_export_verified_flags_mixed_registry() {
+        let env = Env::default();
+        let (admin, user1, user2, contract_id) = setup(&env);
+        let user3 = Address::generate(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone()).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone()).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "carol"), user3.clone()).unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "bob")).unwrap();
+
+            let admin_page = TrustBridgeContract::get_registered_paginated(env.clone(), 0, 10).unwrap();
+            assert_eq!(admin_page.records.len(), 3);
+
+            let public_page = TrustBridgeContract::get_public_paginated(env.clone(), 0, 10).unwrap();
+            assert_eq!(public_page.records.len(), 3);
+
+            for page in [&admin_page, &public_page] {
+                for i in 0..page.records.len() {
+                    let (name, record) = page.records.get(i).unwrap();
+                    let expected_verified = name == username(&env, "bob");
+                    assert_eq!(
+                        record.verified, expected_verified,
+                        "verified flag mismatch for {:?}", name
+                    );
+                }
+            }
+        });
+    }
+
+    // ── Issue #95: verify → revoke → verify cycle ──────────────────────────────
+
+    /// The full verify → revoke → verify cycle on one record must not
+    /// corrupt storage or counters: the verified counter returns to 1 after
+    /// the second verify, a fresh `VerifiedEvent` is published each time
+    /// verification is granted, and a `VerificationRevokedEvent` is
+    /// published on revoke. Storage keys for the record stay stable across
+    /// the cycle — only the `verified` flag and counters change (Issue #95).
+    #[test]
+    fn test_issue_95_verify_revoke_verify_cycle() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        let client = TrustBridgeContractClient::new(&env, &contract_id);
+        let name = username(&env, "octocat");
+
+        env.mock_all_auths();
+        client.register(&name, &user);
+
+        // First verify.
+        env.ledger().set_timestamp(1_000);
+        client.verify(&admin, &name);
+        let expected = VerifiedEvent {
+            github_username: name.clone(),
+            stellar_address: user.clone(),
+            timestamp: 1_000,
+        };
+        assert_eq!(
+            env.events().all(),
+            soroban_sdk::vec![&env, (contract_id.clone(), expected.topics(&env), expected.data(&env))],
+            "first verify must publish exactly one VerifiedEvent"
+        );
+        assert!(client.get_address(&name).unwrap().verified);
+        assert_eq!(client.get_verified_count(), 1);
+        assert_eq!(client.get_stats().verified, 1);
+
+        // Revoke.
+        env.ledger().set_timestamp(2_000);
+        client.revoke_verification(&admin, &name);
+        let expected = VerificationRevokedEvent {
+            github_username: name.clone(),
+            stellar_address: user.clone(),
+            timestamp: 2_000,
+        };
+        assert_eq!(
+            env.events().all(),
+            soroban_sdk::vec![&env, (contract_id.clone(), expected.topics(&env), expected.data(&env))],
+            "revoke must publish exactly one VerificationRevokedEvent"
+        );
+        assert!(!client.get_address(&name).unwrap().verified);
+        assert_eq!(client.get_verified_count(), 0);
+        assert_eq!(client.get_stats().verified, 0);
+
+        // Second verify, after revoke, must succeed and emit a fresh event.
+        env.ledger().set_timestamp(3_000);
+        client.verify(&admin, &name);
+        let expected = VerifiedEvent {
+            github_username: name.clone(),
+            stellar_address: user.clone(),
+            timestamp: 3_000,
+        };
+        assert_eq!(
+            env.events().all(),
+            soroban_sdk::vec![&env, (contract_id.clone(), expected.topics(&env), expected.data(&env))],
+            "second verify after revoke must publish a fresh VerifiedEvent"
+        );
+
+        // Counters and record state fully recover: verified count is back to
+        // 1, and the record's stable fields are untouched by the cycle.
+        let record = client.get_address(&name).unwrap();
+        assert!(record.verified);
+        assert_eq!(record.stellar_address, user);
+        assert_eq!(client.get_verified_count(), 1);
+        assert_eq!(client.get_stats().verified, 1);
+        assert_eq!(client.get_stats().total, 1);
+    }
+
+    /// Verifying twice without an intervening revoke must still fail with
+    /// `AlreadyVerified`, even mid-cycle after a prior revoke/verify round
+    /// trip — the cycle only reopens after an explicit revoke (Issue #95).
+    #[test]
+    fn test_issue_95_double_verify_without_revoke_fails_mid_cycle() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone()).unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat")).unwrap();
+            TrustBridgeContract::revoke_verification(env.clone(), admin.clone(), username(&env, "octocat")).unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat")).unwrap();
+
+            let result = TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"));
+            assert_eq!(result, Err(ContractError::AlreadyVerified));
+            assert_eq!(TrustBridgeContract::get_verified_count(env.clone()), 1);
+        });
+    }
+
+    // ── Issue #94: Expose multi-user register sequence ─────────────────────────
+
+    /// Reference fixture for dashboard/indexer integrators: registers three
+    /// users in sequence and asserts the `RegisteredEvent` published and the
+    /// `get_stats()` total after each step, so off-chain sync workers have a
+    /// documented, testable sequence to build against (Issue #94). See
+    /// `docs/DASHBOARD_SYNC.md` for the narrative version of this fixture.
+    #[test]
+    fn test_issue_94_multi_user_register_sequence() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        let client = TrustBridgeContractClient::new(&env, &contract_id);
+
+        let fixtures = [
+            (username(&env, "alice"), Address::generate(&env)),
+            (username(&env, "bob"), Address::generate(&env)),
+            (username(&env, "carol"), Address::generate(&env)),
+        ];
+
+        env.mock_all_auths();
+
+        for (i, (name, addr)) in fixtures.iter().enumerate() {
+            let timestamp = 1_000 + i as u64;
+            env.ledger().set_timestamp(timestamp);
+            client.register(name, addr);
+
+            // Exactly one RegisteredEvent per register call, in order.
+            let expected = RegisteredEvent {
+                github_username: name.clone(),
+                stellar_address: addr.clone(),
+                timestamp,
+            };
+            assert_eq!(
+                env.events().all(),
+                soroban_sdk::vec![&env, (contract_id.clone(), expected.topics(&env), expected.data(&env))],
+                "register #{} did not publish exactly one RegisteredEvent",
+                i + 1
+            );
+
+            // Stats total climbs by exactly one per registration.
+            assert_eq!(client.get_stats().total, (i + 1) as u32);
+            assert_eq!(client.get_stats().verified, 0);
+        }
+
+        // All three usernames resolve to their registered address, and the
+        // export is consistent for every one of them.
+        let all = client.get_all_registered();
+        assert_eq!(all.len(), fixtures.len() as u32);
+        for (name, addr) in fixtures.iter() {
+            assert_eq!(client.get_address(name).unwrap().stellar_address, *addr);
+            assert!(client.has_record(name));
+        }
+    }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -5,6 +5,11 @@ use crate::ContractError;
 // ── Storage keys ────────────────────────────────────────────────────────────
 
 pub const REG_KEY: Symbol = symbol_short!("reg");
+/// Storage key for the admin address. `initialize` is the **only** place
+/// that writes this key, gated by `AlreadyInitialized` so it can run once.
+/// No other public entry point mutates it — the admin is immutable after
+/// init; rotation requires redeploying a new instance. See
+/// `docs/SECURITY.md#admin-key-management` (Issue #97).
 pub const ADMIN_KEY: Symbol = symbol_short!("admin");
 pub const COUNT_KEY: Symbol = symbol_short!("count");
 pub const VCOUNT_KEY: Symbol = symbol_short!("vcount");


### PR DESCRIPTION
…ify/revoke cycle, multi-user register sequence

Add test and documentation coverage for four wave issues: admin immutability after init (#97), verified flags in paginated exports (#96), the verify -> revoke -> verify lifecycle (#95), and a multi-user register sequence fixture (#94).

Closes #94
Closes #95
Closes #96
Closes #97