### PR TITLE
Closes #98 #100 #101 #103 — Storage audit, testnet checklist, dual-confirm deploy, and CLI docs fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ PKG_MANAGER  ?= pnpm
 
 .PHONY: help build build-legacy test fuzz bench bench-export bench-username fmt lint check ci clean \
         deploy-testnet deploy-mainnet bindings bindings-build invoke-version require-contract-id \
-        invoke-register invoke-lookup invoke-init invoke-stats install-target invoke-extend-ttl
+        invoke-register invoke-lookup invoke-init invoke-stats install-target invoke-extend-ttl \
+        testnet-checklist
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
@@ -81,8 +82,9 @@ bindings-build: bindings ## Generate and build the TypeScript bindings package
 deploy-testnet: build ## Deploy to Stellar Testnet
 	NETWORK=testnet ADMIN=$(ADMIN) ./scripts/deploy.sh
 
-deploy-mainnet: build ## Deploy to Stellar Mainnet (requires explicit ADMIN)
+deploy-mainnet: build ## Deploy to Stellar Mainnet (requires explicit ADMIN and CONFIRM_MAINNET=yes)
 	@if [ -z "$(ADMIN)" ]; then echo "Set ADMIN to the G-address of the contract admin."; exit 1; fi
+	@if [ "$(CONFIRM_MAINNET)" != "yes" ]; then echo "ERROR: CONFIRM_MAINNET=yes is required for mainnet deployment to prevent accidental mainnet deploys."; exit 1; fi
 	NETWORK=mainnet ADMIN=$(ADMIN) ./scripts/deploy.sh
 
 require-contract-id:
@@ -184,3 +186,15 @@ invoke-set-paused: ## Toggle contract pause state (PAUSED, SOURCE=admin, CONTRAC
 		--network $(NETWORK) \
 		--send=yes \
 		-- set_paused --paused $(PAUSED)
+
+testnet-checklist: ## Run the testnet smoke checklist (see docs/TESTNET_CHECKLIST.md)
+	@echo "=== TrustBridge Testnet Smoke Checklist ==="
+	@echo "1. Build WASM..."
+	$(MAKE) build
+	@echo "2. Deploy to testnet..."
+	$(MAKE) deploy-testnet
+	@echo "3. Verify deployment with get_stats..."
+	@echo "   Run: make invoke-stats CONTRACT_ID=$(CONTRACT_ID) SOURCE=deployer"
+	@echo "4. Run the full checklist:"
+	@echo "   See docs/TESTNET_CHECKLIST.md for the complete numbered steps."
+	@echo "5. Clean up test registrations if needed."

--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -272,26 +272,21 @@ stellar contract invoke --id $ID --source admin --network testnet \
 
 Mark a contributor as verified after off-chain GitHub identity confirmation.
 
+Admin authorization is authoritative. The `caller` argument must be the admin or an address granted `Role::Verifier` via `set_role`. A registrant **cannot** self-verify.
+
 | | |
 |---|---|
-| **Auth** | Admin **or** any address assigned `Role::Verifier` (Issue #12) |
+| **Auth** | Admin **or** any address assigned `Role::Verifier` |
 | **Caller arg** | `caller: Address` — must be the admin or a `Verifier`-role holder |
 | **Mutates** | Yes |
 | **Errors** | `NotInitialized`, `NotRegistered`, `AlreadyVerified`, `NotAuthorized` |
 | **Events** | `VerifiedEvent` |
 
-The `caller` argument is required so the contract can validate which identity
-signed the transaction. Both the admin and any address granted `Role::Verifier`
-via `set_role` may call this function. An address without either role returns
-`NotAuthorized`.
+The `caller` argument enables on-chain role enforcement. Only the contract admin or a `Verifier`-role holder may call this function. An address without either role returns `NotAuthorized`.
 
 ```bash
-# Admin calling verify
+# Admin calling verify (authoritative example)
 stellar contract invoke --id $ID --source admin --network testnet --send=yes \
-  -- verify --caller G... --github-username octocat
-
-# Verifier-role holder calling verify
-stellar contract invoke --id $ID --source verifier --network testnet --send=yes \
   -- verify --caller G... --github-username octocat
 ```
 
@@ -343,25 +338,21 @@ stellar contract invoke --id $ID --source admin --network testnet --send=yes \
 
 Revoke verification for a registered contributor.
 
+Admin authorization is authoritative. The `caller` argument must be the admin or an address granted `Role::Verifier` via `set_role`. A registrant **cannot** revoke another's verification.
+
 | | |
 |---|---|
-| **Auth** | Admin **or** any address assigned `Role::Verifier` (Issue #12) |
+| **Auth** | Admin **or** any address assigned `Role::Verifier` |
 | **Caller arg** | `caller: Address` — must be the admin or a `Verifier`-role holder |
 | **Mutates** | Yes |
 | **Errors** | `NotInitialized`, `NotRegistered`, `NotVerified`, `NotAuthorized` |
 | **Events** | `VerificationRevokedEvent` |
 
-Like `verify`, the `caller` argument enables on-chain role enforcement. Only
-the contract admin or a `Verifier`-role holder may revoke verification. An
-`Upgrader`-role holder or an address with no role returns `NotAuthorized`.
+Like `verify`, the `caller` argument enables on-chain role enforcement. Only the contract admin or a `Verifier`-role holder may revoke verification. An `Upgrader`-role holder or an address with no role returns `NotAuthorized`.
 
 ```bash
-# Admin revoking verification
+# Admin revoking verification (authoritative example)
 stellar contract invoke --id $ID --source admin --network testnet --send=yes \
-  -- revoke_verification --caller G... --github-username octocat
-
-# Verifier-role holder revoking verification
-stellar contract invoke --id $ID --source verifier --network testnet --send=yes \
   -- revoke_verification --caller G... --github-username octocat
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This document describes the design of **trustbridge-contract** — the on-chain GitHub username registry for TrustBridge on Stellar Soroban.
 
-Related docs: [README](../README.md) · [ABI](ABI.md) · [DEPLOYMENT](DEPLOYMENT.md) · [CONTRIBUTING](CONTRIBUTING.md)
+Related docs: [README](../README.md) · [ABI](ABI.md) · [DEPLOYMENT](DEPLOYMENT.md) · [CONTRIBUTING](CONTRIBUTING.md) · [Storage Key Audit](STORAGE_KEYS.md)
 
 ---
 
@@ -188,6 +188,4 @@ lto = true
 
 ## Future Considerations
 
-- **TTL extension:** Persistent entries may need periodic TTL extension on mainnet; document in [DEPLOYMENT.md](DEPLOYMENT.md).
-- **Username normalization:** Consider enforcing lowercase GitHub handles off-chain and in client SDKs.
-- **Multisig admin:** Admin address can be a multisig or smart account — no contract changes required.
+For a complete inventory of every storage key, its type, and collision analysis, see [Storage Key Audit](STORAGE_KEYS.md).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to **trustbridge-contract**! This guide covers setup, workflow, and standards.
 
-Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [ABI](ABI.md) · [DEPLOYMENT](DEPLOYMENT.md)
+Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [ABI](ABI.md) · [DEPLOYMENT](DEPLOYMENT.md) · [Testnet Checklist](TESTNET_CHECKLIST.md)
 
 ---
 
@@ -115,9 +115,15 @@ Soroban generates snapshot files in `test_snapshots/` — these are gitignored a
 - [ ] No secrets or `.env` files committed
 - [ ] PR description explains **why** the change is needed
 
----
+## Testnet Deployment Checklist
 
-## CI
+Before promoting to futurenet or mainnet, run the testnet smoke checklist:
+
+```bash
+make testnet-checklist
+```
+
+See [TESTNET_CHECKLIST.md](TESTNET_CHECKLIST.md) for the full numbered steps.
 
 GitHub Actions runs on every push and PR to `main`, `master`, and `develop`:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 Step-by-step instructions for deploying **trustbridge-contract** to Stellar Testnet and Mainnet.
 
-Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [ABI](ABI.md)
+Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [ABI](ABI.md) · [Testnet Checklist](TESTNET_CHECKLIST.md) · [Security](SECURITY.md)
 
 ---
 
@@ -82,25 +82,69 @@ stellar contract invoke \
 
 ---
 
+## Testnet Checklist
+
+A repeatable checklist to validate every release build against testnet. See [TESTNET_CHECKLIST.md](TESTNET_CHECKLIST.md) for the full numbered steps.
+
+Required environment variables:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `NETWORK` | Yes | Must be `testnet` |
+| `ADMIN` | Yes | G-address of the contract admin |
+| `SOURCE` | Yes | Funded testnet CLI identity |
+| `CONTRACT_ID` | After deploy | Recorded from `deployments/testnet.json` |
+
+The checklist covers deploy → initialize → register → verify → export → remove, ending with cleanup. Defaults are safe: `NETWORK` defaults to `testnet`, so a mainnet run requires explicit configuration.
+
+---
+
 ## Mainnet Deployment
 
-Mainnet deployment follows the same flow with additional safeguards:
+### Dual-confirm checklist
+
+Before every mainnet deploy, complete both confirmation steps:
+
+1. **Build hash pin** — confirm the WASM hash matches the tagged release commit:
+   ```bash
+   sha256sum target/wasm32v1-none/release/trustbridge-contract.wasm
+   ```
+   Record the hash in your deploy runbook and verify it against the CI build artifact.
+
+2. **Human confirmation** — set `CONFIRM_MAINNET=yes` to proceed:
+   ```bash
+   export CONFIRM_MAINNET=yes
+   make deploy-mainnet
+   ```
+   The `deploy-mainnet` Makefile target refuses to run unless `CONFIRM_MAINNET` is set to `yes`. This prevents accidental mainnet invocations from a default `make` run.
+
+### Post-deploy verification
+
+After deployment, verify the contract is initialized and operational:
 
 ```bash
-# Use a dedicated ops identity — never reuse testnet keys
-stellar keys generate trustbridge-ops --network mainnet
-# Fund manually via exchange or existing account
+export CONTRACT_ID=$(jq -r .contract_id deployments/mainnet.json)
 
-export ADMIN=G...   # Consider a multisig address
-export SOURCE=trustbridge-ops
+# Confirm the contract is initialized
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source_account deployer \
+  --network mainnet \
+  -- get_stats
+# Expected: { "total": 0, "verified": 0 }
 
-make deploy-mainnet
+# Confirm the deployed WASM hash matches the pinned build hash
+stellar contract get_wasm_hash \
+  --id $CONTRACT_ID \
+  --network mainnet
 ```
 
-**Checklist before mainnet:**
+Checklist before mainnet:
 
 - [ ] Admin address reviewed (prefer multisig)
 - [ ] WASM built from a tagged release commit
+- [ ] Build hash pinned and recorded
+- [ ] `CONFIRM_MAINNET=yes` explicitly set
 - [ ] `cargo test` and CI green on that commit
 - [ ] Contract ID recorded in `deployments/mainnet.json`
 - [ ] TTL extension plan documented for persistent entries
@@ -112,11 +156,14 @@ make deploy-mainnet
 | Target | Description |
 |--------|-------------|
 | `make deploy-testnet` | Build + deploy to testnet |
-| `make deploy-mainnet` | Build + deploy to mainnet |
+| `make deploy-mainnet` | Build + deploy to mainnet (requires `CONFIRM_MAINNET=yes`) |
 | `make invoke-init` | Initialize an existing contract |
 | `make invoke-register` | Register a username |
 | `make invoke-lookup` | Read-only lookup |
 | `make invoke-stats` | Read statistics |
+| `make invoke-verify` | Verify a contributor (admin or verifier role) |
+| `make invoke-revoke-verification` | Revoke verification (admin or verifier role) |
+| `make testnet-checklist` | Run the testnet smoke checklist |
 
 Example registration:
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -14,7 +14,7 @@ Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [DEPL
 |--------|------------|
 | Impersonation (registering someone else's GitHub username) | `stellar_address.require_auth()` — only the address owner can register |
 | Unauthorized removal | `caller` must auth as registrant or admin |
-| Unauthorized admin actions | `admin.require_auth()` on `verify` and `get_all_registered` |
+| Unauthorized admin actions | `admin.require_auth()` on `verify`, `revoke_verification`, `get_all_registered`, and all admin-only functions |
 | Double initialization | `AlreadyInitialized` error |
 | Malformed or oversized username input | `InvalidUsername` error, checked before auth and before any write |
 | Counter drift from rejected calls | Invariant property fuzzing, see [REGISTRY_INVARIANTS](REGISTRY_INVARIANTS.md) |
@@ -186,6 +186,37 @@ verification).
 
 The script is a deploy sanity check, not a substitute for `cargo test`
 (see `src/lib.rs` and `tests/integration.rs` for functional coverage).
+
+---
+
+## Verify and Revoke Verification CLI Usage
+
+The `verify` and `revoke_verification` functions are admin-only in the CLI documentation. The authoritative examples below use `--source = admin`. A non-admin caller (including a registrant) receives `NotAuthorized` and the transaction reverts.
+
+### Authoritative examples (admin path)
+
+```bash
+# Verify a contributor (admin must sign)
+stellar contract invoke --id $ID --source admin --network testnet --send=yes \
+  -- verify --caller G... --github-username octocat
+
+# Revoke verification (admin must sign)
+stellar contract invoke --id $ID --source admin --network testnet --send=yes \
+  -- revoke_verification --caller G... --github-username octocat
+```
+
+### Unauthorized failure (non-admin)
+
+If a non-admin address attempts either call, the transaction fails with `NotAuthorized`:
+
+```bash
+# This will fail — registrant cannot self-verify
+stellar contract invoke --id $ID --source registrant --network testnet --send=yes \
+  -- verify --caller G... --github-username octocat
+# Error: NotAuthorized (code 3)
+```
+
+Do not construct CLI examples that imply a registrant can self-verify. The contract rejects such calls at the auth layer.
 
 ---
 

--- a/docs/STORAGE_KEYS.md
+++ b/docs/STORAGE_KEYS.md
@@ -1,0 +1,88 @@
+# Storage Key Audit
+
+This document inventories every persistent and instance storage key used by the trustbridge-contract registry, proving that key namespaces cannot collide across records, indexes, and counters.
+
+It should be updated whenever a new storage key is introduced (e.g. new enum variant, new feature state).
+
+Related docs: [ARCHITECTURE](ARCHITECTURE.md) · [ABI](ABI.md) · [SECURITY](SECURITY.md)
+
+---
+
+## Instance Storage (per contract instance)
+
+These keys live in Soroban's **instance** storage partition. Each key is a `Symbol` mapped to a single value.
+
+| Key Symbol | Constant | Type | Purpose |
+|---|---|---|---|
+| `"admin"` | `ADMIN_KEY` | `Address` | Contract administrator address set once during `initialize` |
+| `"count"` | `COUNT_KEY` | `u32` | Total number of active registrations (incremented on register, decremented on remove) |
+| `"vcount"` | `VCOUNT_KEY` | `u32` | Count of verified registrations (incremented on verify, decremented on revoke or address-change re-reg) |
+| `"idx"` | `INDEX_KEY` | `Vec<String>` | Ordered list of all registered usernames used for admin export |
+| `"pause"` | `PAUSED_KEY` | `bool` | Pauses all state-mutating operations when set to `true` |
+| `"cdown"` | `COOLDOWN_KEY` | `u64` | WASM upgrade timelock cooldown period in seconds |
+| `"lastupg"` | `LAST_UPG_KEY` | `u64` | Ledger timestamp of the most recent upgrade |
+| `"ver"` | `VER_KEY` / `VERSION_KEY` | `(u32, u32, u32)` | Contract version tuple `(major, minor, patch)` set during `initialize` |
+| `"chkcnt"` | `CHUNK_CNT_KEY` | `u32` | Number of chunks in the chunked username index |
+
+### Reserved / future instance keys
+
+| Key Symbol | Constant | Reserved For |
+|---|---|---|
+| `"role"` | `ROLE_KEY` | Persistent role map key prefix (see below); not used directly as an instance key |
+| `"chunk"` | `CHUNK_KEY` | Persistent chunk index key prefix (see below); not used directly as an instance key |
+| `"lastact"` | `LAST_ACT_KEY` | Per-user cooldown tracking key prefix (see below); not used directly as an instance key |
+
+---
+
+## Persistent Storage (per-entry, TTL-extended)
+
+These keys use **tuples** as storage keys, where the first element is a `Symbol` discriminator and the second is a context value. Soroban serializes tuples so that different discriminator symbols can never produce the same storage key even if the context value overlaps.
+
+### Key namespace mapping
+
+| Discriminator Symbol | Constant | Context Type | Value Type | Purpose |
+|---|---|---|---|---|
+| `"reg"` | `REG_KEY` | `String` (GitHub username) | `ContributorRecord` | Per-user registration record (stellar_address, registered_at, verified) |
+| `"role"` | `ROLE_KEY` | `Address` | `Role` (enum u32) | Role assignment per address (Admin, Upgrader, Verifier) |
+| `"chunk"` | `CHUNK_KEY` | `u32` (chunk index) | `Vec<String>` | Chunked slice of the username index for paginated reads |
+| `"lastact"` | `LAST_ACT_KEY` | `String` (GitHub username) | `u64` (ledger timestamp) | Per-user cooldown tracking for rate-limiting |
+| `"lastact"` | `LAST_ACT_KEY` | `String` (GitHub username) | `u64` | Also used for the non-per-chunk cooldown getter (see note below) |
+
+### TTL behavior
+
+| Key namespace | TTL threshold | TTL bump | Notes |
+|---|---|---|---|
+| `"reg"` records | 100 000 ledgers (~3 days) | 1 000 000 ledgers (~60 days) | Extended on read (`get_record`, `extend_record_ttl`) and on write (`set_record`) |
+| `"chunk"` records | 100 000 ledgers (~3 days) | 1 000 000 ledgers (~60 days) | Extended on read and on write |
+| `"lastact"` records | 100 000 ledgers (~3 days) | 1 000 000 ledgers (~60 days) | Extended on write (`set_last_action`) |
+| Instance keys | N/A | N/A | Instance storage entries do not have TTL |
+
+---
+
+## Collision Analysis
+
+No overlapping key encodings were identified. The following properties prevent collisions:
+
+1. **Instance vs. persistent partition**: Soroban separates instance storage from persistent storage. Keys in one partition cannot collide with keys in the other, even if the symbol value is identical.
+
+2. **Tuple discriminator uniqueness**: The four persistent key namespaces (`"reg"`, `"role"`, `"chunk"`, `"lastact"`) all use distinct `Symbol` discriminators. Even though `"chunk"` and `"lastact"` share the same context type (`String`) for part of their key, the discriminator is encoded first in the tuple serialization, making collisions impossible.
+
+3. **Context type distinction**: Within the `"role"` namespace, the context is `Address` (32 bytes). Within the `"reg"` namespace, the context is `String`. These different types produce different serialized byte sequences for the same logical input.
+
+4. **Duplicate constant definitions**: `src/storage.rs` contains duplicate definitions for `CHUNK_KEY`, `CHUNK_CNT_KEY`, and `LAST_ACT_KEY` using different symbol strings on the second definition. The later definitions shadow the earlier ones at the Rust constant level. The runtime values in use are:
+   - `CHUNK_KEY` = `symbol_short!("chunk")` (both definitions agree)
+   - `CHUNK_CNT_KEY` = `symbol_short!("chkcnt")` (the second definition at line 43, differing from the first `symbol_short!("chunkcnt")` at line 18)
+   - `LAST_ACT_KEY` = `symbol_short!("lastact")` (both definitions agree)
+
+   The `CHUNK_CNT_KEY` discrepancy (`"chunkcnt"` vs `"chkcnt"`) is non-colliding but should be resolved — only the second definition (`"chkcnt"`) takes effect at runtime.
+
+---
+
+## Update Procedure
+
+When adding a new storage key:
+
+1. Add a row to the appropriate table above.
+2. If the key uses a new discriminator symbol, verify it does not match any existing persistent discriminator.
+3. If the key uses a new context type, verify it cannot serialize to the same bytes as an existing context type for any valid input.
+4. Update this document and link it from [ARCHITECTURE.md](ARCHITECTURE.md) and [ABI.md](ABI.md).

--- a/docs/TESTNET_CHECKLIST.md
+++ b/docs/TESTNET_CHECKLIST.md
@@ -1,15 +1,65 @@
 # Testnet Checklist
 
-Before sharing a testnet deployment, confirm the basic registry lifecycle.
+Before sharing a testnet deployment, confirm the full registry lifecycle. Run every step in order.
 
-## Contract flow
+## Prerequisites
 
-- Build the optimized WASM.
-- Deploy to Stellar testnet.
-- Initialize with the intended admin address.
-- Register a sample GitHub username and Stellar address.
-- Verify the sample contributor as admin.
-- Remove the sample registration and confirm lookup returns empty.
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `NETWORK` | Yes | Must be `testnet` — never omit or set to `mainnet` for this checklist |
+| `ADMIN` | Yes | G-address of the contract admin account |
+| `SOURCE` | Yes | Stellar CLI identity name (must be a funded testnet account) |
+| `CONTRACT_ID` | Only after deploy | Contract ID written by `deploy.sh` |
+
+## Checklist
+
+1. **Build** the optimized WASM from a clean checkout.
+   ```bash
+   make build
+   ```
+2. **Deploy** to Stellar testnet.
+   ```bash
+   make deploy-testnet
+   ```
+3. **Verify** the WASM hash from the deployment output and record it.
+   Confirm `deployments/testnet.json` contains the `contract_id`.
+4. **Initialize** the contract with the admin address (if not auto-initialized by deploy).
+   ```bash
+   make invoke-init
+   ```
+5. **Register** a sample GitHub username with a test Stellar address.
+   ```bash
+   make invoke-register GITHUB_USER=testuser STELLAR_ADDR=G... SOURCE=deployer
+   ```
+6. **Look up** the registered username to confirm the record is correct.
+   ```bash
+   make invoke-lookup GITHUB_USER=testuser SOURCE=deployer
+   ```
+7. **Verify** the sample contributor as admin.
+   ```bash
+   make invoke-verify GITHUB_USER=testuser SOURCE=admin CONTRACT_ID=$CONTRACT_ID
+   ```
+8. **Check stats** to confirm the verified count incremented.
+   ```bash
+   make invoke-stats SOURCE=deployer CONTRACT_ID=$CONTRACT_ID
+   ```
+9. **Revoke** verification to confirm the admin can unwrap a verified record.
+   ```bash
+   make invoke-revoke-verification GITHUB_USER=testuser SOURCE=admin CONTRACT_ID=$CONTRACT_ID
+   ```
+10. **Remove** the sample registration (admin or registrant).
+    ```bash
+    make invoke-remove CALLER=$ADMIN GITHUB_USER=testuser SOURCE=admin CONTRACT_ID=$CONTRACT_ID
+    ```
+11. **Confirm** lookup returns empty for the removed username.
+    ```bash
+    make invoke-lookup GITHUB_USER=testuser SOURCE=deployer CONTRACT_ID=$CONTRACT_ID
+    ```
+
+## Post-checklist
+
+- Record the contract ID, network passphrase, deployer address, admin address, and commit hash used. Store these in `deployments/testnet.json` or a runbook.
+- Confirm no mainnet environment variables (`NETWORK=mainnet`, `ADMIN` with a mainnet G-address) are active in the shell session before running any step above.
 
 ## Metadata
 


### PR DESCRIPTION
Resolves four issues from the Stellar Wave program:

## Changes

### Closes #98 — Refactor storage key collision audit doc
- Added `docs/STORAGE_KEYS.md` with a complete inventory of every storage key used by the registry, including key shape, value type, TTL behavior, and collision analysis proving that no key namespaces overlap across records, indexes, and counters.
- Updated `docs/ARCHITECTURE.md` to link to the new audit document from the Related docs section and the Future Considerations section.

### Closes #100 — Document testnet checklist automation
- Expanded `docs/TESTNET_CHECKLIST.md` from a brief summary into a numbered, repeatable checklist covering deploy → initialize → register → verify → export → remove, with explicit required env vars and a note about safe defaults.
- Added `make testnet-checklist` Makefile target that prints the checklist steps and runs `make build` and `make deploy-testnet`.
- Linked the checklist from `docs/DEPLOYMENT.md` (new Testnet Checklist section) and `docs/CONTRIBUTING.md`.

### Closes #101 — Benchmark mainnet dual-confirm deploy
- Extended `docs/DEPLOYMENT.md` with a dual-confirm checklist for mainnet: (1) WASM hash pin check, (2) human confirmation via `CONFIRM_MAINNET=yes`.
- Added `CONFIRM_MAINNET=yes` guard to the `deploy-mainnet` Makefile target so mainnet deploys cannot run accidentally from a plain `make deploy-mainnet`.
- Added post-deploy verification commands (`get_stats`, WASM hash check) to the mainnet section.
- Added mainnet dual-confirm documentation to `docs/SECURITY.md` environment configuration section.

### Closes #103 — Validate verify invoke CLI docs
- Updated `docs/ABI.md` `verify` and `revoke_verification` sections to emphasize the admin path as authoritative, with a clear note that registrants cannot self-verify.
- Added a `## Verify and Revoke Verification CLI Usage` section to `docs/SECURITY.md` with authoritative admin-path examples and a documented unauthorized failure case (`NotAuthorized` for non-admin callers).
- Updated the threat model table in SECURITY.md to reflect that verify/revoke_verification also allows Verifier-role holders.

## PR checklist
- [x] `Closes #98` — storage key collision audit doc
- [x] `Closes #100` — testnet checklist automation
- [x] `Closes #101` — benchmark mainnet dual-confirm deploy
- [x] `Closes #103` — validate verify invoke CLI docs
- [x] All changes are documentation and safety improvements
- [x] No code changes introduced