### PR TITLE
feat(contract): reregister-after-remove, empty-index-on-last-remove, …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,11 @@ GITHUB_USER ?=
 STELLAR_ADDR ?=
 BENCH_OUT   ?= bench-results.txt
 NORM_BENCH_OUT ?= bench-username-normalization.txt
+MAX_USERNAME_BENCH_OUT ?= bench-max-username-register.txt
 BINDINGS_DIR ?= bindings/typescript
 PKG_MANAGER  ?= pnpm
 
-.PHONY: help build build-legacy test fuzz bench bench-export bench-username fmt lint check ci clean \
+.PHONY: help build build-legacy test fuzz bench bench-export bench-username bench-max-username fmt lint check ci clean \
         deploy-testnet deploy-mainnet bindings bindings-build invoke-version require-contract-id \
         invoke-register invoke-lookup invoke-init invoke-stats install-target invoke-extend-ttl
 
@@ -50,6 +51,10 @@ bench-export: ## Write export CPU benchmark results to $(BENCH_OUT)
 bench-username: ## Write username case-normalization benchmark results to $(NORM_BENCH_OUT)
 	cargo test test_bench_username_case_normalization -- --nocapture --test-threads=1 | tee $(NORM_BENCH_OUT)
 	@echo "Benchmark results written to $(NORM_BENCH_OUT)"
+
+bench-max-username: ## Write max-length (39-char) username register benchmark results to $(MAX_USERNAME_BENCH_OUT)
+	cargo test test_bench_max_length_username_register -- --nocapture --test-threads=1 | tee $(MAX_USERNAME_BENCH_OUT)
+	@echo "Benchmark results written to $(MAX_USERNAME_BENCH_OUT)"
 
 fmt: ## Check formatting
 	cargo fmt --all -- --check

--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -249,6 +249,16 @@ and decrements `verified` only when that removed record was verified. Removing
 an unverified record while another verified record remains must leave
 `verified` unchanged; this is covered by the Wave #46 regression test.
 
+Empty-registry invariant (Issue #92): removing the **last** registered
+contributor returns the registry to a clean empty state — `get_stats()`
+reports `{total: 0, verified: 0}`, the username index is empty
+(`get_all_registered`, `get_registered_page`, and the paginated export paths
+all return zero records with `has_more: false`), and every lookup
+(`get_address`, `has_record`) reports absence. No stale index entry or
+non-zero counter survives. A subsequent registration on the now-empty
+registry proceeds exactly as it would on a never-used one. Covered by
+`test_remove_last_user_returns_registry_to_empty_state` in `src/lib.rs`.
+
 ---
 
 ### `get_all_registered() -> Result<Vec<(String, Address)>, ContractError>`
@@ -268,7 +278,7 @@ stellar contract invoke --id $ID --source admin --network testnet \
 
 ---
 
-### `verify(github_username: String) -> Result<(), ContractError>`
+### `verify(caller: Address, github_username: String) -> Result<(), ContractError>`
 
 Mark a contributor as verified after off-chain GitHub identity confirmation.
 
@@ -339,7 +349,7 @@ stellar contract invoke --id $ID --source admin --network testnet --send=yes \
 
 ---
 
-### `revoke_verification(github_username: String) -> Result<(), ContractError>`
+### `revoke_verification(caller: Address, github_username: String) -> Result<(), ContractError>`
 
 Revoke verification for a registered contributor.
 
@@ -375,6 +385,15 @@ Returns the number of verified registrations.
 |---|---|
 | **Auth** | None |
 | **Mutates** | No |
+
+**Parity invariant (Issue #90):** `get_verified_count()` always equals
+`get_stats().verified`, and both always equal the number of stored records
+with `verified == true`. This holds after every path that touches
+verification state — `register` (including an address-change re-register),
+`verify`, `revoke_verification`, and `remove` — including on an empty
+registry and across repeated verify/revoke cycles. See
+[REGISTRY_INVARIANTS.md#verification](REGISTRY_INVARIANTS.md#verification)
+and `test_verified_count_parity_across_all_mutation_paths` in `src/lib.rs`.
 
 ```bash
 stellar contract invoke --id $ID --source deployer --network testnet \
@@ -728,8 +747,9 @@ benchmark suite lives with the unit tests in `src/lib.rs` under the
 `env.cost_estimate().budget()`.
 
 ```bash
-make bench            # print CPU/memory cost for every benchmarked operation
-make bench-export     # export-only run, results written to bench-results.txt
+make bench              # print CPU/memory cost for every benchmarked operation
+make bench-export       # export-only run, results written to bench-results.txt
+make bench-max-username # register at the max-length username, written to bench-max-username-register.txt
 ```
 
 Output is CSV so it can be diffed between branches:
@@ -750,6 +770,7 @@ get_all_registered,100,...,...
 | `test_bench_username_case_normalization` | `usernames_match` at 10, 50, 100, 200 comparisons (`make bench-username`) |
 | `test_bench_core_operation_cpu_cost` | `register`, `get_address`, `get_stats` |
 | `test_bench_failure_path_costs_less_than_success` | Rejected `verify` versus accepted `verify` |
+| `test_bench_max_length_username_register` | `register` at a 1-character username versus the maximum accepted length (`MAX_USERNAME_LEN`, currently 39 — read `max_username_len()` rather than hardcoding it) (`make bench-max-username`, Issue #91) |
 
 ### Regression guards
 
@@ -767,6 +788,27 @@ asserts on shape rather than fixed numbers:
   here.
 - A rejected call costs **strictly less** than the equivalent accepted call, so
   a missing-username lookup cannot become a cheap way to burn ledger budget.
+- The max-length username register costs **at least as much** as a
+  1-character register, and no more than **5x** that baseline. `register`'s
+  extra work for a longer username is a fixed-size copy into the 39-byte
+  validation buffer, not a nested or per-character scan, so a wide gap over
+  the baseline signals a complexity regression rather than expected growth.
+  Since `MAX_USERNAME_LEN` (39) is pinned by an assertion in
+  `test_bench_max_length_username_register`, an incompatible change to the
+  username length policy fails the benchmark outright instead of silently
+  benchmarking a username that no longer represents the worst case.
+
+### Max-length username register — expected range (Issue #91)
+
+`make bench-max-username` prints one CSV line for a 1-character register and
+one for a 39-character (`MAX_USERNAME_LEN`) register. As with the other
+benchmarks, absolute instruction counts drift between `soroban-sdk` releases —
+what matters is the **ratio** between the two lines, which the test enforces
+must stay within 5x. Re-run after any change to `register`, `is_valid_github_username`,
+or the storage/index write path, and compare the new ratio against the
+previous CSV output committed alongside the change (or against
+`bench-max-username-register.txt` from the prior run) to catch a regression
+before it reaches testnet.
 
 ### Caveats
 

--- a/docs/REGISTRY_INVARIANTS.md
+++ b/docs/REGISTRY_INVARIANTS.md
@@ -35,6 +35,16 @@ Related docs: [ABI](ABI.md) · [ARCHITECTURE](ARCHITECTURE.md) · [SECURITY](SEC
 | I7 | A rejected operation moves no counter and mutates no record | `test_fuzz_failure_paths_leave_invariants_intact` |
 | I8 | Counters never underflow, including removal attempts against an empty registry | `test_fuzz_counters_never_underflow_on_empty_registry` |
 
+### `get_verified_count()` / `get_stats().verified` parity (Issue #90)
+
+I3 above is also exercised directly, outside the fuzz suite, by
+`test_verified_count_parity_across_all_mutation_paths` in `src/lib.rs`. That
+test asserts `get_verified_count()` and `get_stats().verified` agree after
+every mutation path that touches verification state — `register` (including
+an address-change re-register), `verify`, `revoke_verification`, `remove`,
+a re-verify cycle, and the empty registry — so the two counters cannot drift
+apart silently. See [ABI.md#get_verified_count---u32](ABI.md#get_verified_count---u32).
+
 ### Verification carry-over rule
 
 Re-registering an existing username keeps `verified == true` **only** when the

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -18,6 +18,7 @@ Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [DEPL
 | Double initialization | `AlreadyInitialized` error |
 | Malformed or oversized username input | `InvalidUsername` error, checked before auth and before any write |
 | Counter drift from rejected calls | Invariant property fuzzing, see [REGISTRY_INVARIANTS](REGISTRY_INVARIANTS.md) |
+| Stale trust surviving a remove → re-register cycle (a new registrant inheriting the previous owner's verified status or address binding) | `remove` unconditionally clears the stored record; `register` on a removed username always starts a fresh, unverified record — see [Re-registration After Remove](#re-registration-after-remove) (Issue #93) |
 | Compromised or unpinned RPC client dependency | Crate validation checklist below |
 
 ### Out of Scope (handled off-chain)
@@ -50,6 +51,36 @@ The admin address is **immutable** after `initialize`. Recommendations:
   re-registered to a different Stellar address, the record becomes unverified,
   the verified count decreases, and any later `verify()` applies to the new
   address only.
+
+---
+
+## Re-registration After Remove
+
+Stale storage after `remove` is a security smell: a new registrant must not
+inherit the previous owner's verified status or address binding (Issue #93).
+
+`remove` clears the stored record entirely — it does not leave a tombstone.
+Consequently, registering a username that was previously removed is
+indistinguishable on-chain from registering it for the first time:
+
+- `registered_at` is set to the current ledger timestamp — nothing carries
+  over from the removed record.
+- `verified` starts `false` regardless of whether the removed record was
+  verified. The admin (or a `Verifier`-role holder) must verify the new
+  registration independently; no prior verification is honored.
+- The new registration binds to whichever Stellar address signs the
+  `register` call — it need not be, and is not required to relate to, the
+  address that was removed.
+- This holds for **both** removal paths: a self-remove by the registrant and
+  an admin-initiated remove authorize the same clearing behavior, since
+  `remove` does not distinguish who triggered it once the record is gone.
+- Removing a username that was never registered (or already removed) fails
+  with `NotRegistered` and mutates nothing — there is no stale state for a
+  negative case to leak.
+
+Covered by `test_self_remove_then_reregister_new_address_requires_reverification`,
+`test_admin_remove_then_reregister_new_address_requires_reverification`, and
+`test_remove_unknown_username_returns_not_registered` in `src/lib.rs`.
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,8 @@ use crate::storage::{
     add_to_index, get_admin, get_cooldown as storage_get_cooldown, get_count, get_index,
     get_last_upgrade, get_record, get_registered_paginated_internal, get_role as storage_get_role,
     get_stats as read_stats, get_verified_count as storage_get_verified_count,
-    get_version as storage_get_version, has_record, is_admin_caller, is_in_cooldown,
+    get_version as storage_get_version, has_record, has_role_or_admin, is_admin_caller,
+    is_in_cooldown,
     is_paused as storage_is_paused, remove_from_index, remove_record,
     remove_role as storage_remove_role, require_initialized, require_not_paused,
     set_cooldown as storage_set_cooldown, set_count, set_last_action, set_last_upgrade,
@@ -645,8 +646,11 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Marks a contributor as verified after an off-chain GitHub identity check. Admin-only.
-    pub fn verify(env: Env, github_username: String) -> Result<(), ContractError> {
+    /// Marks a contributor as verified after an off-chain GitHub identity check.
+    ///
+    /// Callable by the contract admin **or** any address assigned the
+    /// `Role::Verifier` role (Issue #12 — verifier role separation).
+    pub fn verify(env: Env, caller: Address, github_username: String) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
 
@@ -784,6 +788,22 @@ mod test {
 
     fn username(env: &Env, name: &str) -> String {
         String::from_str(env, name)
+    }
+
+    /// Asserts `get_verified_count()` and `get_stats().verified` agree on
+    /// `expected` (Issue #90). Both APIs are checked together so future
+    /// mutation paths cannot let the two counters drift apart silently.
+    fn assert_verified_parity(env: &Env, expected: u32) {
+        assert_eq!(
+            TrustBridgeContract::get_verified_count(env.clone()),
+            expected,
+            "get_verified_count() diverged from the expected verified count"
+        );
+        assert_eq!(
+            TrustBridgeContract::get_stats(env.clone()).verified,
+            expected,
+            "get_stats().verified diverged from the expected verified count"
+        );
     }
 
     // ── Basic registration / lookup ──────────────────────────────────────────
@@ -2587,5 +2607,259 @@ mod test {
             let _ = target;
             assert_eq!(TrustBridgeContract::get_role(env.clone(), verifier.clone()), Some(Role::Verifier));
         });
+    }
+
+    // ── Issue #90: get_verified_count() / get_stats().verified parity ────────
+
+    /// `get_verified_count()` and `get_stats().verified` must never diverge,
+    /// across every path that touches verification state: register, verify,
+    /// revoke_verification, address-change re-register, and remove — plus the
+    /// empty registry and a re-verify cycle (Issue #90).
+    #[test]
+    fn test_verified_count_parity_across_all_mutation_paths() {
+        let env = Env::default();
+        let (admin, user, other, contract_id) = setup(&env);
+        env.mock_all_auths();
+
+        env.as_contract(&contract_id, || {
+            // Empty registry.
+            assert_verified_parity(&env, 0);
+
+            // register: a fresh, unverified registration does not move the count.
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone()).unwrap();
+            assert_verified_parity(&env, 0);
+
+            // verify.
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat")).unwrap();
+            assert_verified_parity(&env, 1);
+
+            // revoke_verification.
+            TrustBridgeContract::revoke_verification(env.clone(), admin.clone(), username(&env, "octocat")).unwrap();
+            assert_verified_parity(&env, 0);
+
+            // Re-verify cycle.
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat")).unwrap();
+            assert_verified_parity(&env, 1);
+
+            // Address-change re-register clears verification.
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), other.clone()).unwrap();
+            assert_verified_parity(&env, 0);
+
+            // Verify the new address, then remove the verified record.
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat")).unwrap();
+            assert_verified_parity(&env, 1);
+            TrustBridgeContract::remove(env.clone(), other.clone(), username(&env, "octocat")).unwrap();
+            assert_verified_parity(&env, 0);
+
+            // Removing an unverified record must leave an unrelated verified
+            // record's count untouched.
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user.clone()).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), other.clone()).unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "bob")).unwrap();
+            assert_verified_parity(&env, 1);
+            TrustBridgeContract::remove(env.clone(), user.clone(), username(&env, "alice")).unwrap();
+            assert_verified_parity(&env, 1);
+        });
+    }
+
+    // ── Issue #92: remove of last registered user returns to empty state ────
+
+    /// Removing the sole registered contributor must return the registry to a
+    /// clean empty state: no stale index entries, zero counters, every lookup
+    /// reporting absence — and a subsequent registration must still work
+    /// exactly as it would on a never-used registry (Issue #92).
+    #[test]
+    fn test_remove_last_user_returns_registry_to_empty_state() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        let name = username(&env, "octocat");
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), name.clone(), user.clone()).unwrap();
+        });
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::remove(env.clone(), user.clone(), name.clone()).unwrap();
+        });
+
+        env.as_contract(&contract_id, || {
+            let stats = TrustBridgeContract::get_stats(env.clone());
+            assert_eq!(stats.total, 0, "total must be zero after removing the sole registrant");
+            assert_eq!(stats.verified, 0, "verified must be zero after removing the sole registrant");
+            assert_eq!(TrustBridgeContract::get_verified_count(env.clone()), 0);
+
+            assert!(TrustBridgeContract::get_address(env.clone(), name.clone()).is_none());
+            assert!(!TrustBridgeContract::has_record(env.clone(), name.clone()));
+        });
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            let all = TrustBridgeContract::get_all_registered(env.clone()).unwrap();
+            assert_eq!(all.len(), 0, "username index must be empty after removing the sole registrant");
+
+            let page = TrustBridgeContract::get_registered_page(env.clone(), 0, 10).unwrap();
+            assert_eq!(page.len(), 0, "index page must be empty after removing the sole registrant");
+
+            let export = TrustBridgeContract::get_registered_paginated(env.clone(), 0, 10).unwrap();
+            assert_eq!(export.records.len(), 0);
+            assert_eq!(export.total, 0);
+            assert!(!export.has_more);
+            assert_eq!(export.next_cursor, None);
+        });
+
+        // Re-registering after the registry has gone fully empty must still work.
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), name.clone(), user.clone()).unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(TrustBridgeContract::get_stats(env.clone()).total, 1);
+            assert!(!TrustBridgeContract::get_address(env.clone(), name.clone())
+                .unwrap()
+                .verified);
+            assert_eq!(
+                TrustBridgeContract::get_address(env.clone(), name.clone())
+                    .unwrap()
+                    .stellar_address,
+                user
+            );
+        });
+    }
+
+    // ── Issue #93: re-registration after remove ──────────────────────────────
+
+    /// Negative case for Issue #93: removing an unknown username must still
+    /// fail with `NotRegistered`, leaving nothing to clean up.
+    #[test]
+    fn test_remove_unknown_username_returns_not_registered() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            let result = TrustBridgeContract::remove(env.clone(), user.clone(), username(&env, "ghost"));
+            assert_eq!(result, Err(ContractError::NotRegistered));
+        });
+    }
+
+    /// Self-remove, then re-register the same username at a *new* Stellar
+    /// address: the new registration must succeed, start unverified, bind to
+    /// the new address, and require a fresh admin verification — no trust or
+    /// address binding carries over from the removed owner (Issue #93).
+    #[test]
+    fn test_self_remove_then_reregister_new_address_requires_reverification() {
+        let env = Env::default();
+        let (admin, user, new_owner, contract_id) = setup(&env);
+        let name = username(&env, "octocat");
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), name.clone(), user.clone()).unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), name.clone()).unwrap();
+            TrustBridgeContract::remove(env.clone(), user.clone(), name.clone()).unwrap();
+
+            TrustBridgeContract::register(env.clone(), name.clone(), new_owner.clone()).unwrap();
+
+            let record = TrustBridgeContract::get_address(env.clone(), name.clone()).unwrap();
+            assert_eq!(record.stellar_address, new_owner, "reregistration must bind to the new address");
+            assert!(!record.verified, "verified flag must not survive remove");
+            assert_eq!(TrustBridgeContract::get_stats(env.clone()).verified, 0);
+            assert_eq!(TrustBridgeContract::get_verified_count(env.clone()), 0);
+
+            // The admin must verify again before the new owner is trusted.
+            TrustBridgeContract::verify(env.clone(), admin.clone(), name.clone()).unwrap();
+            assert!(TrustBridgeContract::get_address(env.clone(), name.clone()).unwrap().verified);
+        });
+    }
+
+    /// Admin-remove, then re-register the same username at a *new* Stellar
+    /// address: same guarantees as the self-remove path — new address, no
+    /// carried-over verification (Issue #93).
+    #[test]
+    fn test_admin_remove_then_reregister_new_address_requires_reverification() {
+        let env = Env::default();
+        let (admin, user, new_owner, contract_id) = setup(&env);
+        let name = username(&env, "octocat");
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), name.clone(), user.clone()).unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), name.clone()).unwrap();
+            TrustBridgeContract::remove(env.clone(), admin.clone(), name.clone()).unwrap();
+
+            TrustBridgeContract::register(env.clone(), name.clone(), new_owner.clone()).unwrap();
+
+            let record = TrustBridgeContract::get_address(env.clone(), name.clone()).unwrap();
+            assert_eq!(record.stellar_address, new_owner, "reregistration must bind to the new address");
+            assert!(!record.verified, "verified flag must not survive remove");
+            assert_eq!(TrustBridgeContract::get_stats(env.clone()).verified, 0);
+            assert_eq!(TrustBridgeContract::get_verified_count(env.clone()), 0);
+        });
+    }
+
+    // ── Issue #91: max-length username register benchmark ───────────────────
+
+    /// Measures the metered cost of `register` at the maximum accepted GitHub
+    /// username length. Returns `(cpu_instructions, memory_bytes)`.
+    fn measure_register(github_username: &String, user: &Address, contract_id: &Address, env: &Env) -> (u64, u64) {
+        env.cost_estimate().budget().reset_default();
+        env.as_contract(contract_id, || {
+            TrustBridgeContract::register(env.clone(), github_username.clone(), user.clone()).unwrap();
+        });
+        let budget = env.cost_estimate().budget();
+        (budget.cpu_instruction_cost(), budget.memory_bytes_cost())
+    }
+
+    /// Benchmarks `register` at `MAX_USERNAME_LEN` (39 characters) — the
+    /// worst-case invoke budget for the operation, since a single-character
+    /// username is not representative of the string storage, index append,
+    /// and event payload work `register` actually does (Issue #91).
+    ///
+    /// Pins the length assumption this benchmark is built on: if
+    /// `MAX_USERNAME_LEN` ever changes, this test fails clearly instead of
+    /// silently benchmarking a username that no longer represents the
+    /// worst case.
+    #[test]
+    fn test_bench_max_length_username_register() {
+        assert_eq!(
+            MAX_USERNAME_LEN, 39,
+            "MAX_USERNAME_LEN changed — update the max-length benchmark username to match"
+        );
+
+        let env = Env::default();
+        let (_admin, user, other, contract_id) = setup(&env);
+        env.mock_all_auths();
+
+        let short_username = username(&env, "a");
+        let (short_cpu, short_mem) = measure_register(&short_username, &user, &contract_id, &env);
+
+        // Exactly MAX_USERNAME_LEN (39) characters.
+        let max_len_username = String::from_str(&env, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        assert_eq!(max_len_username.len(), MAX_USERNAME_LEN);
+        let (max_cpu, max_mem) = measure_register(&max_len_username, &other, &contract_id, &env);
+
+        std::println!("operation,size,cpu_instructions,memory_bytes");
+        std::println!("register,1,{},{}", short_cpu, short_mem);
+        std::println!("register,{},{},{}", MAX_USERNAME_LEN, max_cpu, max_mem);
+
+        assert!(max_cpu > 0, "max-length register was not metered");
+
+        // The max-length username must be at least as expensive as a
+        // single-character one — otherwise it would not be the worst case
+        // this benchmark claims to measure.
+        assert!(
+            max_cpu >= short_cpu,
+            "max-length register ({max_cpu}) was cheaper than a 1-character register ({short_cpu})"
+        );
+
+        // register's extra work for a longer username is a fixed-size copy
+        // into a 39-byte stack buffer, not a nested or quadratic scan, so the
+        // gap over the 1-character baseline should stay small. 5x headroom
+        // absorbs per-call overhead while still catching a regression that
+        // makes cost scale badly with username length.
+        let ceiling = short_cpu.max(1) * 5;
+        assert!(
+            max_cpu <= ceiling,
+            "max-length register CPU cost grew unexpectedly: {max_cpu} exceeds ceiling {ceiling} (baseline {short_cpu})"
+        );
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -340,6 +340,16 @@ pub fn add_to_index(env: &Env, github_username: &String) {
     }
 }
 
+/// Removes `github_username` from both the legacy flat index and the chunked
+/// index.
+///
+/// Empty-registry invariant (Issue #92): removing the last remaining entry
+/// must leave the legacy index at length 0 and the chunk that held it empty,
+/// not a stale hole — `get_all_registered`, `get_index_page`, and the export
+/// paths must all observe a clean empty registry afterward, and a subsequent
+/// registration must proceed exactly as it would on a never-used registry.
+/// Covered by `test_remove_last_user_returns_registry_to_empty_state` in
+/// `src/lib.rs`.
 pub fn remove_from_index(env: &Env, github_username: &String) {
     // 1. Legacy index update
     let index = get_index(env);


### PR DESCRIPTION
…max-length-username-bench, verified-count-parity

Document get_verified_count API parity
Fixes #90

Benchmark max length username register
Fixes #91

Integrate remove last user empty index
Fixes #92

Validate reregister after remove
Fixes #93