### PR TITLE
feat(contract-099): validate remove auth negative matrix

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -161,7 +161,7 @@ Operational teams should:
 Auth gaps on `remove` are high-impact — an unauthorized removal erases a contributor's identity mapping without their consent.
 The full failure surface is documented here and covered by automated unit tests in `src/lib.rs` (search for `#113`).
 
-Cross-reference: [verify/revoke_verification negative matrix](#verify-and-revoke_verification-auth-negative-matrix) · [ABI reference](ABI.md#removecaller-address-github_username-string---resultcontracterrror)
+Cross-reference: [verify/revoke_verification negative matrix](#verify-and-revoke_verification-auth-negative-matrix) (Issue #114) · [ABI reference](ABI.md#removecaller-address-github_username-string---resultcontracterror)
 
 | # | Scenario | Expected error | Code | Test |
 |---|----------|---------------|------|------|

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -156,6 +156,43 @@ Operational teams should:
 
 ---
 
+## Remove Auth Negative Matrix
+
+Auth gaps on `remove` are high-impact — an unauthorized removal erases a contributor's identity mapping without their consent.
+The full failure surface is documented here and covered by automated unit tests in `src/lib.rs` (search for `#113`).
+
+Cross-reference: [verify/revoke_verification negative matrix](#verify-and-revoke_verification-auth-negative-matrix) · [ABI reference](ABI.md#removecaller-address-github_username-string---resultcontracterrror)
+
+| # | Scenario | Expected error | Code | Test |
+|---|----------|---------------|------|------|
+| 1 | Contract not yet initialized | `NotInitialized` | 2 | `test_remove_negative_not_initialized` |
+| 2 | Username not registered | `NotRegistered` | 4 | `test_remove_negative_not_registered` |
+| 3 | Caller is a random address (not admin, not registrant) | `NotAuthorized` | 3 | `test_remove_negative_wrong_caller_random_address` |
+| 4 | **Registrant removes their own record** _(happy path)_ | `Ok(())` | — | `test_remove_positive_registrant_can_remove_own` |
+| 5 | **Admin removes any registration** _(happy path)_ | `Ok(())` | — | `test_remove_positive_admin_can_remove_any` |
+| 6 | Third-party address with no role | `NotAuthorized` | 3 | `test_remove_negative_third_party_no_role` |
+| 7 | `Role::Upgrader` holder (not registrant) | `NotAuthorized` | 3 | `test_remove_negative_upgrader_role_cannot_remove` |
+| 8 | `Role::Verifier` holder (not registrant) | `NotAuthorized` | 3 | `test_remove_negative_verifier_role_cannot_remove` |
+| 9 | Contract is paused | `Paused` | 7 | `test_remove_negative_paused` |
+
+### Auth rules for `remove`
+
+```
+caller == admin   →  allowed
+caller == record.stellar_address  →  allowed
+otherwise         →  NotAuthorized (code 3)
+```
+
+The `caller` address is a required argument because Soroban contracts cannot inspect the
+transaction source account without an explicit argument. Passing `caller` allows the contract
+to call `caller.require_auth()` and then check the above conditions in a single, auditable step.
+
+No special role (Upgrader, Verifier, or any future custom role) grants remove rights.
+Only the two identities above may remove a record — by design, to prevent privilege-escalation
+vectors where a broadly-held operational role could silently wipe contributor mappings.
+
+---
+
 ## Responsible Disclosure
 
 If you discover a security vulnerability:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2588,4 +2588,286 @@ mod test {
             assert_eq!(TrustBridgeContract::get_role(env.clone(), verifier.clone()), Some(Role::Verifier));
         });
     }
+
+    // ── Issue #113: remove auth negative matrix ──────────────────────────────
+    //
+    // Matrix of all unauthorized / invalid `remove` call paths and their
+    // expected ContractError codes.  Each test corresponds to exactly one cell
+    // in the table published in docs/SECURITY.md.
+    //
+    // | # | Scenario                             | Expected error      | Code |
+    // |---|--------------------------------------|---------------------|------|
+    // | 1 | Contract not initialized             | NotInitialized      |  2   |
+    // | 2 | Username not registered              | NotRegistered       |  4   |
+    // | 3 | Caller is neither admin nor registrant | NotAuthorized     |  3   |
+    // | 4 | Registrant removes own record         | Ok (happy path)     |  —   |
+    // | 5 | Admin removes any record              | Ok (happy path)     |  —   |
+    // | 6 | Third-party address (no role)         | NotAuthorized       |  3   |
+    // | 7 | Upgrader-role holder (not admin/owner)| NotAuthorized       |  3   |
+    // | 8 | Verifier-role holder (not admin/owner)| NotAuthorized       |  3   |
+    // | 9 | Contract is paused                    | Paused              |  7   |
+
+    /// #113-cell-1: remove before initialization returns NotInitialized (code 2).
+    #[test]
+    fn test_remove_negative_not_initialized() {
+        let env = Env::default();
+        let caller = Address::generate(&env);
+        let contract_id = env.register(TrustBridgeContract, ());
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            let result = TrustBridgeContract::remove(
+                env.clone(),
+                caller.clone(),
+                username(&env, "octocat"),
+            );
+            assert_eq!(
+                result,
+                Err(ContractError::NotInitialized),
+                "remove before init must return NotInitialized (code {})",
+                ContractError::NotInitialized.code()
+            );
+            assert_eq!(ContractError::NotInitialized.code(), 2);
+        });
+    }
+
+    /// #113-cell-2: remove on an unregistered username returns NotRegistered (code 4).
+    #[test]
+    fn test_remove_negative_not_registered() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            let result = TrustBridgeContract::remove(
+                env.clone(),
+                user.clone(),
+                username(&env, "ghost"),
+            );
+            assert_eq!(
+                result,
+                Err(ContractError::NotRegistered),
+                "remove for non-existent username must return NotRegistered (code {})",
+                ContractError::NotRegistered.code()
+            );
+            assert_eq!(ContractError::NotRegistered.code(), 4);
+        });
+    }
+
+    /// #113-cell-3: caller is a random address (not admin, not registrant) → NotAuthorized (code 3).
+    #[test]
+    fn test_remove_negative_wrong_caller_random_address() {
+        let env = Env::default();
+        let (_admin, user, other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+            )
+            .unwrap();
+            let result = TrustBridgeContract::remove(
+                env.clone(),
+                other.clone(), // wrong caller
+                username(&env, "octocat"),
+            );
+            assert_eq!(
+                result,
+                Err(ContractError::NotAuthorized),
+                "random-address remove must return NotAuthorized (code {})",
+                ContractError::NotAuthorized.code()
+            );
+            assert_eq!(ContractError::NotAuthorized.code(), 3);
+            // Registration must be intact
+            assert!(TrustBridgeContract::has_record(env.clone(), username(&env, "octocat")));
+        });
+    }
+
+    /// #113-cell-4 (happy path): registrant can remove their own record.
+    #[test]
+    fn test_remove_positive_registrant_can_remove_own() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+            )
+            .unwrap();
+            TrustBridgeContract::remove(
+                env.clone(),
+                user.clone(), // registrant
+                username(&env, "octocat"),
+            )
+            .unwrap();
+            assert!(
+                !TrustBridgeContract::has_record(env.clone(), username(&env, "octocat")),
+                "record must be gone after registrant self-removes"
+            );
+        });
+    }
+
+    /// #113-cell-5 (happy path): admin can remove any registration.
+    #[test]
+    fn test_remove_positive_admin_can_remove_any() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+            )
+            .unwrap();
+            TrustBridgeContract::remove(
+                env.clone(),
+                admin.clone(), // admin
+                username(&env, "octocat"),
+            )
+            .unwrap();
+            assert!(
+                !TrustBridgeContract::has_record(env.clone(), username(&env, "octocat")),
+                "record must be gone after admin removes"
+            );
+        });
+    }
+
+    /// #113-cell-6: third-party address with no role cannot remove another user's record.
+    #[test]
+    fn test_remove_negative_third_party_no_role() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        let stranger = Address::generate(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "alice"),
+                user.clone(),
+            )
+            .unwrap();
+            let result = TrustBridgeContract::remove(
+                env.clone(),
+                stranger.clone(), // no role
+                username(&env, "alice"),
+            );
+            assert_eq!(
+                result,
+                Err(ContractError::NotAuthorized),
+                "no-role third party must not be allowed to remove (code {})",
+                ContractError::NotAuthorized.code()
+            );
+        });
+    }
+
+    /// #113-cell-7: Upgrader-role holder (not the registrant) cannot remove.
+    #[test]
+    fn test_remove_negative_upgrader_role_cannot_remove() {
+        let env = Env::default();
+        let (_admin, user, upgrader, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_role(env.clone(), upgrader.clone(), Role::Upgrader).unwrap();
+        });
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+            )
+            .unwrap();
+            let result = TrustBridgeContract::remove(
+                env.clone(),
+                upgrader.clone(), // Upgrader role, but not registrant or admin
+                username(&env, "octocat"),
+            );
+            assert_eq!(
+                result,
+                Err(ContractError::NotAuthorized),
+                "Upgrader-role holder must not be allowed to remove (code {})",
+                ContractError::NotAuthorized.code()
+            );
+        });
+    }
+
+    /// #113-cell-8: Verifier-role holder (not the registrant) cannot remove.
+    #[test]
+    fn test_remove_negative_verifier_role_cannot_remove() {
+        let env = Env::default();
+        let (_admin, user, verifier, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_role(env.clone(), verifier.clone(), Role::Verifier).unwrap();
+        });
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+            )
+            .unwrap();
+            let result = TrustBridgeContract::remove(
+                env.clone(),
+                verifier.clone(), // Verifier role, but not registrant or admin
+                username(&env, "octocat"),
+            );
+            assert_eq!(
+                result,
+                Err(ContractError::NotAuthorized),
+                "Verifier-role holder must not be allowed to remove (code {})",
+                ContractError::NotAuthorized.code()
+            );
+        });
+    }
+
+    /// #113-cell-9: remove while contract is paused returns Paused (code 7).
+    #[test]
+    fn test_remove_negative_paused() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+            )
+            .unwrap();
+        });
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::pause(env.clone()).unwrap();
+        });
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            let result = TrustBridgeContract::remove(
+                env.clone(),
+                user.clone(),
+                username(&env, "octocat"),
+            );
+            assert_eq!(
+                result,
+                Err(ContractError::Paused),
+                "remove while paused must return Paused (code {})",
+                ContractError::Paused.code()
+            );
+            assert_eq!(ContractError::Paused.code(), 7);
+            // Registration must still be intact
+            assert!(TrustBridgeContract::has_record(env.clone(), username(&env, "octocat")));
+        });
+    }
+
+    /// #113-verify-error-codes: all remove-relevant error codes match their ABI discriminants.
+    #[test]
+    fn test_remove_negative_error_codes_match_abi() {
+        // Verify the codes used in the remove auth matrix match the ABI table.
+        assert_eq!(ContractError::NotInitialized.code(), 2);
+        assert_eq!(ContractError::NotAuthorized.code(), 3);
+        assert_eq!(ContractError::NotRegistered.code(), 4);
+        assert_eq!(ContractError::Paused.code(), 7);
+    }
 }


### PR DESCRIPTION
Closes #113

## Summary

Builds an explicit negative-test matrix for `remove`: wrong caller, non-admin/non-owner, not registered, not initialized, plus role-holder and paused-state cells — each asserted against the correct `ContractError`.

## Scope

- **`docs/SECURITY.md`** — new "Remove Auth Negative Matrix" section: a 9-row table (scenario → expected error → code → test name), the auth rule (`caller == admin || caller == record.stellar_address`, otherwise `NotAuthorized`), and a note on why no role (Upgrader/Verifier) grants remove rights. Cross-linked to the verify/revoke matrix from #114.
- **`src/lib.rs`** — 10 new unit tests under `#113`, each mapped 1:1 to a matrix row:
  - `test_remove_negative_not_initialized` → `NotInitialized` (2)
  - `test_remove_negative_not_registered` → `NotRegistered` (4)
  - `test_remove_negative_wrong_caller_random_address` → `NotAuthorized` (3)
  - `test_remove_positive_registrant_can_remove_own` → happy path
  - `test_remove_positive_admin_can_remove_any` → happy path
  - `test_remove_negative_third_party_no_role` → `NotAuthorized` (3)
  - `test_remove_negative_upgrader_role_cannot_remove` → `NotAuthorized` (3)
  - `test_remove_negative_verifier_role_cannot_remove` → `NotAuthorized` (3)
  - `test_remove_negative_paused` → `Paused` (7)
  - `test_remove_negative_error_codes_match_abi` → codes match the ABI discriminant table

No auth logic in `remove` was weakened — every new test asserts against the existing behavior in `src/lib.rs` (`caller.require_auth()`, then `caller != admin && caller != record.stellar_address → NotAuthorized`). Two pre-existing tests already covered part of this matrix (`test_non_owner_cannot_remove`, `test_remove_missing_registration_fails`, `test_remove_requires_initialization`); this PR fills in the remaining role-holder and paused-state cells and gives the whole matrix a documented, named home.

## Acceptance criteria

- [x] Negative matrix documented (`docs/SECURITY.md`)
- [x] Automated tests cover each unauthorized/invalid case
- [x] Authorized self-remove and admin-remove still pass (covered as explicit happy-path rows, not just implied)
- [x] Error codes match ABI discriminants (asserted directly in `test_remove_negative_error_codes_match_abi` and cross-checked against `docs/ABI.md`)

## Notes

This repo currently has pre-existing compile breakage on `main` unrelated to this change (duplicate `storage.rs` constants/functions and a few other files from earlier merges) that predates this branch — `cargo test` cannot run end-to-end until that's fixed separately. Per the task instructions this PR does not attempt to fix that unrelated breakage; the `remove`-specific code path itself is internally consistent and the new tests are written to compile and pass once the surrounding build issue is resolved.

## Test plan

`cargo test` output could not be captured due to the pre-existing unrelated build breakage described above. The 10 new tests were reviewed line-by-line against `TrustBridgeContract::remove`'s actual auth logic in `src/lib.rs` to confirm each assertion matches current behavior.