### PR TITLE
feat(contract-096): document rustdoc on public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,8 @@ jobs:
 
       - name: Verify WASM artifact exists
         run: test -f target/wasm32v1-none/release/trustbridge-contract.wasm || test -f target/wasm32-unknown-unknown/release/trustbridge-contract.wasm
+
+      - name: cargo doc (public API)
+        run: cargo doc --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ NORM_BENCH_OUT ?= bench-username-normalization.txt
 BINDINGS_DIR ?= bindings/typescript
 PKG_MANAGER  ?= pnpm
 
-.PHONY: help build build-legacy test fuzz bench bench-export bench-username fmt lint check ci clean \
+.PHONY: help build build-legacy test fuzz bench bench-export bench-username fmt lint docs docs-check check ci clean \
         deploy-testnet deploy-mainnet bindings bindings-build invoke-version require-contract-id \
         invoke-register invoke-lookup invoke-init invoke-stats install-target invoke-extend-ttl
 
@@ -57,7 +57,13 @@ fmt: ## Check formatting
 lint: ## Run clippy
 	cargo clippy --all-targets -- -D warnings
 
-check: fmt lint test build ## Run full local quality gate
+docs: ## Build rustdoc for public API (opens in browser)
+	cargo doc --no-deps --open
+
+docs-check: ## Build rustdoc without opening browser (CI-equivalent)
+	RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+
+check: fmt lint test build docs-check ## Run full local quality gate
 
 ci: check ## Alias for CI-equivalent checks
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -73,6 +73,58 @@ This runs formatting, clippy, tests, and contract build — the same checks as C
 - Update [ARCHITECTURE.md](ARCHITECTURE.md) for storage or auth model changes
 - Update [README.md](../README.md) if user-facing behavior changes
 
+### Rustdoc
+
+Every public function and type in `src/` that integrators interact with must have a rustdoc summary.
+Follow these conventions:
+
+- **One-line summary** first (sentence ending in `.`), then a blank line, then optional detail.
+- **`# Auth`** section on any function that calls `require_auth()` — state exactly which identity must sign.
+- **`# Errors`** section on every `Result`-returning function — list each `ContractError` variant that can be returned and when.
+- Keep docs short and factual. Do not duplicate examples from [ABI.md](ABI.md).
+
+Example:
+
+```rust
+/// Registers or updates a GitHub username → Stellar address mapping.
+///
+/// # Auth
+///
+/// Requires auth from `stellar_address`.
+///
+/// # Errors
+///
+/// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+/// - [`ContractError::Paused`] if the contract is paused.
+/// - [`ContractError::InvalidUsername`] if the username fails validation.
+pub fn register(env: Env, github_username: String, stellar_address: Address) -> Result<(), ContractError> {
+```
+
+#### Building the docs locally
+
+```bash
+# Open in browser (recommended for contributors)
+cargo doc --no-deps --open
+
+# Build only, no browser (useful in CI or headless environments)
+cargo doc --no-deps
+```
+
+Docs are generated into `target/doc/trustbridge_contract/`. The `--no-deps` flag
+skips dependencies and keeps the output focused on the contract's own API.
+
+To also include private items (useful when exploring internals):
+
+```bash
+cargo doc --no-deps --document-private-items --open
+```
+
+#### CI doc build
+
+`cargo doc --no-deps` runs as part of the CI quality gate. A doc build failure
+(broken intra-doc links, missing `# Errors` on `Result` functions, etc.) blocks
+merge just like a test failure.
+
 ### Commit Messages
 
 Use clear, imperative subjects:

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,18 +1,47 @@
 use soroban_sdk::contracterror;
 
+/// Errors returned by contract entry points.
+///
+/// Each variant maps to a stable `u32` code (see `code()` / `from_code()`).
+/// Off-chain consumers such as the dashboard and indexer use these codes to
+/// classify failed invocations without depending on the Rust enum layout.
+///
+/// | Code | Variant | Raised by |
+/// |------|---------|-----------|
+/// | 1 | `AlreadyInitialized` | `initialize` |
+/// | 2 | `NotInitialized` | any function called before `initialize` |
+/// | 3 | `NotAuthorized` | `remove`, `verify`, `revoke_verification`, role functions |
+/// | 4 | `NotRegistered` | `remove`, `verify`, `revoke_verification` |
+/// | 5 | `AlreadyVerified` | `verify` |
+/// | 6 | `NotVerified` | `revoke_verification` |
+/// | 7 | `Paused` | any state-mutating call while paused |
+/// | 8 | `CooldownActive` | `upgrade` |
+/// | 9 | `InvalidVersion` | `migrate` |
+/// | 10 | `InvalidRole` | `set_role` |
+/// | 11 | `InvalidUsername` | `register` |
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ContractError {
+    /// `initialize` was called more than once.
     AlreadyInitialized = 1,
+    /// A function was called before `initialize`.
     NotInitialized = 2,
+    /// The caller does not have the required role or does not own the resource.
     NotAuthorized = 3,
+    /// The referenced `github_username` is not registered.
     NotRegistered = 4,
+    /// `verify` was called on a username that is already verified.
     AlreadyVerified = 5,
+    /// `revoke_verification` was called on a username that is not verified.
     NotVerified = 6,
+    /// A state-mutating function was called while the contract is paused.
     Paused = 7,
+    /// `upgrade` was called before the cooldown period elapsed.
     CooldownActive = 8,
+    /// `migrate` was called with a version that is not strictly greater than the current one.
     InvalidVersion = 9,
+    /// `set_role` was called with an unrecognised role discriminant.
     InvalidRole = 10,
     /// The supplied GitHub username is empty, longer than
     /// `utils::MAX_USERNAME_LEN`, or contains characters GitHub does not allow.

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,5 +1,6 @@
 use soroban_sdk::{contractevent, Address, BytesN, String};
 
+/// Emitted when a GitHub username is registered or re-registered to a Stellar address.
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RegisteredEvent {
@@ -9,6 +10,7 @@ pub struct RegisteredEvent {
     pub timestamp: u64,
 }
 
+/// Emitted when a registration is removed by the registrant or admin.
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RemovedEvent {
@@ -18,6 +20,7 @@ pub struct RemovedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted when an admin or Verifier marks a contributor as verified.
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VerifiedEvent {
@@ -27,6 +30,7 @@ pub struct VerifiedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted when an admin or Verifier revokes a contributor's verified status.
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VerificationRevokedEvent {
@@ -36,6 +40,7 @@ pub struct VerificationRevokedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted when the contract WASM is upgraded via `upgrade`.
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpgradedEvent {
@@ -45,6 +50,7 @@ pub struct UpgradedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted when the contract is paused via `pause`.
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PausedEvent {
@@ -53,6 +59,7 @@ pub struct PausedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted when the contract is unpaused via `unpause`.
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UnpausedEvent {
@@ -61,16 +68,19 @@ pub struct UnpausedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted when a role is granted to an address via `set_role`.
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RoleGrantedEvent {
     #[topic]
     pub address: Address,
+    /// Numeric discriminant of the [`Role`][crate::storage::Role] granted.
     pub role: u32,
     pub admin: Address,
     pub timestamp: u64,
 }
 
+/// Emitted when a role is revoked from an address via `remove_role`.
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RoleRevokedEvent {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,19 @@ pub struct TrustBridgeContract;
 
 #[contractimpl]
 impl TrustBridgeContract {
-    /// Sets the contract admin. Can only be called once.
+    /// Sets the contract admin and initializes default state. Can only be called once.
+    ///
+    /// Sets `admin` as the contract administrator and assigns it the `Admin` role.
+    /// Also initializes the registration counter, verified counter, pause state,
+    /// upgrade cooldown, and version to their zero/default values.
+    ///
+    /// # Auth
+    ///
+    /// No auth required — the deployer calls this immediately after `stellar contract deploy`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContractError::AlreadyInitialized`] if `initialize` has already been called.
     pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
         if env.storage().instance().has(&ADMIN_KEY) {
             return Err(ContractError::AlreadyInitialized);
@@ -62,7 +74,26 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Pauses contract state mutations. Admin-only.
+    /// Pauses all state-mutating contract functions. Admin-only.
+    ///
+    /// While paused, any call to `register`, `remove`, `verify`, `revoke_verification`,
+    /// `upgrade`, `set_role`, `remove_role`, and other mutating functions returns
+    /// [`ContractError::Paused`]. Read-only calls (`get_address`, `get_stats`, etc.)
+    /// remain available.
+    ///
+    /// Use this as an emergency circuit breaker if a vulnerability or incident requires
+    /// halting all mutations until a fix can be deployed via `upgrade`.
+    ///
+    /// Emits [`PausedEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
     pub fn pause(env: Env) -> Result<(), ContractError> {
         require_initialized(&env)?;
         let admin = get_admin(&env)?;
@@ -74,7 +105,20 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Unpauses contract state mutations. Admin-only.
+    /// Resumes state-mutating contract functions after a pause. Admin-only.
+    ///
+    /// Clears the paused flag set by [`pause`][Self::pause], restoring normal contract operation.
+    ///
+    /// Emits [`UnpausedEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
     pub fn unpause(env: Env) -> Result<(), ContractError> {
         require_initialized(&env)?;
         let admin = get_admin(&env)?;
@@ -86,12 +130,36 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Returns whether contract is currently paused.
+    /// Returns `true` if the contract is currently paused.
+    ///
+    /// Read-only; no auth required. Clients should check this before submitting
+    /// state-mutating transactions to avoid paying fees for a call that will fail
+    /// with [`ContractError::Paused`].
     pub fn is_paused(env: Env) -> bool {
         storage_is_paused(&env)
     }
 
-    /// Assigns a role to an address. Admin-only.
+    /// Assigns a role to `target`. Admin-only.
+    ///
+    /// Roles gate access to privileged operations:
+    ///
+    /// | Role | Can do |
+    /// |------|--------|
+    /// | `Admin` | Everything |
+    /// | `Upgrader` | Call `upgrade` |
+    /// | `Verifier` | Call `verify` and `revoke_verification` |
+    ///
+    /// Emits [`RoleGrantedEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
     pub fn set_role(env: Env, target: Address, role: Role) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
@@ -112,7 +180,23 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Revokes a role from an address. Admin-only.
+    /// Revokes `target`'s role assignment. Admin-only.
+    ///
+    /// After this call `get_role(target)` returns `None`. Does not affect the
+    /// admin's own role — the admin address is stored separately and cannot be
+    /// stripped via `remove_role`.
+    ///
+    /// Emits [`RoleRevokedEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
     pub fn remove_role(env: Env, target: Address) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
@@ -132,12 +216,28 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Queries assigned role for an address.
+    /// Returns the role assigned to `address`, or `None` if no role is assigned.
+    ///
+    /// Read-only; no auth required. Returns `None` for any address that has never
+    /// been granted a role (including the admin address, which is stored separately).
     pub fn get_role(env: Env, address: Address) -> Option<Role> {
         storage_get_role(&env, &address)
     }
 
-    /// Configures WASM upgrade cooldown in seconds. Admin-only.
+    /// Sets the minimum number of seconds that must elapse between WASM upgrades. Admin-only.
+    ///
+    /// A non-zero cooldown enforces a timelock on `upgrade`, giving watchers time to
+    /// detect and react to an unexpected upgrade before the next one can be submitted.
+    /// Set to `0` to disable the timelock.
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
     pub fn set_cooldown(env: Env, cooldown_seconds: u64) -> Result<(), ContractError> {
         require_initialized(&env)?;
         let admin = get_admin(&env)?;
@@ -147,12 +247,18 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Returns WASM upgrade cooldown in seconds.
+    /// Returns the configured WASM upgrade cooldown in seconds.
+    ///
+    /// Returns `0` if no cooldown is configured (upgrades are unrestricted by time).
     pub fn get_cooldown(env: Env) -> u64 {
         storage_get_cooldown(&env)
     }
 
-    /// Returns current contract version tuple (major, minor, patch).
+    /// Returns the stored contract schema version as `(major, minor, patch)`.
+    ///
+    /// Falls back to the compile-time [`CONTRACT_VERSION`] constant on instances
+    /// initialized before on-chain version tracking was added. Prefer [`version`][Self::version]
+    /// for the canonical version endpoint; this is the raw storage accessor.
     pub fn get_version(env: Env) -> (u32, u32, u32) {
         storage_get_version(&env).unwrap_or_else(|| CONTRACT_VERSION.to_tuple())
     }
@@ -344,7 +450,22 @@ impl TrustBridgeContract {
         Ok(true)
     }
 
-    /// Migrates contract version state. Admin-only.
+    /// Advances the on-chain schema version. Admin-only.
+    ///
+    /// Used after an `upgrade` that changes the storage layout. `new_version` must
+    /// be strictly greater than the current stored version (semver order); downgrading
+    /// is rejected to prevent accidental rollback.
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
+    /// - [`ContractError::InvalidVersion`] if `new_version` is not strictly greater than the current version.
     pub fn migrate(env: Env, new_version: (u32, u32, u32)) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
@@ -511,7 +632,10 @@ impl TrustBridgeContract {
         Ok(extended)
     }
 
-    /// Read-only lookup. Returns `None` if the username is not registered.
+    /// Looks up the `ContributorRecord` for `github_username`. Returns `None` if not registered.
+    ///
+    /// Read-only; no auth required. Use this for payout address resolution in GitHub Actions
+    /// and dashboard lookups.
     pub fn get_address(env: Env, github_username: String) -> Option<ContributorRecord> {
         if has_record(&env, &github_username) {
             get_record(&env, &github_username)
@@ -520,18 +644,33 @@ impl TrustBridgeContract {
         }
     }
 
-    /// Cheap existence check for dashboard/indexer consumers.
+    /// Returns `true` if `github_username` is registered, without deserializing the full record.
     ///
-    /// Avoids deserializing the full `ContributorRecord` when callers only
-    /// need to know whether a `github_username` is registered (Wave #40).
+    /// Read-only; no auth required. Use this when callers only need existence confirmation
+    /// and do not need the [`ContributorRecord`] fields.
     pub fn has_record(env: Env, github_username: String) -> bool {
         has_record(&env, &github_username)
     }
 
-    /// Removes a registration. Callable by the registrant or the admin.
+    /// Removes the registration for `github_username`. Callable by the registrant or the admin.
     ///
-    /// `caller` must sign the transaction and must equal either the contract
-    /// admin or the registered Stellar address for `github_username`.
+    /// `caller` must sign the transaction and must equal either the contract admin or the
+    /// Stellar address currently registered to `github_username`. This prevents anyone other
+    /// than the owner or admin from de-registering an account.
+    ///
+    /// Decrements the total count and, if the record was verified, the verified count.
+    /// Emits [`RemovedEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from `caller` (registrant or admin).
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotRegistered`] if `github_username` is not registered.
+    /// - [`ContractError::NotAuthorized`] if `caller` is neither the registrant nor the admin.
     pub fn remove(env: Env, caller: Address, github_username: String) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
@@ -565,10 +704,21 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Returns a page of registered (github_username, stellar_address) pairs
-    /// starting at `offset`, up to `limit` entries. Admin-only, like
-    /// `get_all_registered`, but avoids materializing the whole registry in
-    /// one call for large indexes (Wave #41).
+    /// Returns a page of `(github_username, stellar_address)` pairs starting at `offset`.
+    ///
+    /// Admin-only alternative to `get_registered_paginated` that uses a simple offset/limit
+    /// rather than a cursor. Returns up to `limit` entries beginning at `offset` in the
+    /// registration index. Use for small exports; for large registries prefer the cursor-based
+    /// `get_registered_paginated`.
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
     pub fn get_registered_page(
         env: Env,
         offset: u32,
@@ -590,7 +740,20 @@ impl TrustBridgeContract {
         Ok(result)
     }
 
-    /// Returns the full registry. Admin-only.
+    /// Returns the complete registry as a list of `(github_username, stellar_address)` pairs.
+    ///
+    /// **Admin-only.** For large registries this call materialises the entire index in a
+    /// single transaction; prefer `get_registered_paginated` or `get_public_paginated` for
+    /// incremental dashboard sync.
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
     pub fn get_all_registered(env: Env) -> Result<Vec<(String, Address)>, ContractError> {
         require_initialized(&env)?;
         let admin = get_admin(&env)?;
@@ -609,7 +772,23 @@ impl TrustBridgeContract {
         Ok(result)
     }
 
-    /// Exports paginated records with cursor. Admin-only (Issue #1).
+    /// Exports a page of registry records using a cursor. Admin-only.
+    ///
+    /// `cursor` is the zero-based record index to start from; `limit` is the maximum
+    /// number of records to return (capped at `MAX_PAGE_LIMIT`). Returns an [`ExportPage`]
+    /// containing the records and a `next_cursor` for subsequent calls.
+    ///
+    /// Use this instead of `get_all_registered` for large registries — it avoids
+    /// materializing the full index in one transaction.
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
     pub fn get_registered_paginated(
         env: Env,
         cursor: u32,
@@ -622,8 +801,19 @@ impl TrustBridgeContract {
         get_registered_paginated_internal(&env, cursor, limit)
     }
 
-    /// Public paginated reads for indexers and dashboard consumers (Issue #3).
-    /// Hardened with pause checks and capped limits.
+    /// Public paginated read for indexers and dashboard consumers.
+    ///
+    /// Same cursor/limit semantics as `get_registered_paginated` but requires no auth,
+    /// making it suitable for public dashboard sync and off-chain indexers. Returns an
+    /// [`ExportPage`] with records and a `next_cursor`.
+    ///
+    /// Blocked by the pause state — returns [`ContractError::Paused`] while the circuit
+    /// breaker is active.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
     pub fn get_public_paginated(
         env: Env,
         cursor: u32,
@@ -635,7 +825,20 @@ impl TrustBridgeContract {
         get_registered_paginated_internal(&env, cursor, limit)
     }
 
-    /// Toggles contract pause state. Admin-only (Issue #3).
+    /// Directly sets the contract pause state. Admin-only.
+    ///
+    /// Prefer the named `pause` / `unpause` entry points which emit the corresponding
+    /// events. This lower-level setter is kept for tooling that needs to set the flag
+    /// programmatically without the event emission overhead.
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
     pub fn set_paused(env: Env, paused: bool) -> Result<(), ContractError> {
         require_initialized(&env)?;
         let admin = get_admin(&env)?;
@@ -645,7 +848,22 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Marks a contributor as verified after an off-chain GitHub identity check. Admin-only.
+    /// Marks `github_username` as verified after an off-chain GitHub identity check.
+    ///
+    /// Callable by the contract admin **or** any address assigned the `Role::Verifier` role.
+    /// Increments the verified counter. Emits [`VerifiedEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from `caller` (admin or Verifier role holder).
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotAuthorized`] if `caller` is neither the admin nor a Verifier.
+    /// - [`ContractError::NotRegistered`] if `github_username` is not registered.
+    /// - [`ContractError::AlreadyVerified`] if `github_username` is already verified.
     pub fn verify(env: Env, github_username: String) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
@@ -718,12 +936,18 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Returns the verified registration count.
+    /// Returns the number of currently verified registrations.
+    ///
+    /// Read-only; no auth required. The verified count is incremented by `verify` and
+    /// decremented by `revoke_verification` and `remove` (when removing a verified record).
     pub fn get_verified_count(env: Env) -> u32 {
         storage_get_verified_count(&env)
     }
 
-    /// Returns aggregate registration statistics.
+    /// Returns aggregate registry statistics: total and verified registration counts.
+    ///
+    /// Read-only; no auth required. Suitable for dashboard displays and health checks.
+    /// See [`Stats`] for the returned struct fields.
     pub fn get_stats(env: Env) -> Stats {
         read_stats(&env)
     }
@@ -732,24 +956,33 @@ impl TrustBridgeContract {
 
     /// Returns whether the contract is currently paused.
     ///
-    /// Alias of `is_paused` kept for the reference indexer, which reads this
-    /// name.
+    /// Alias of [`is_paused`][Self::is_paused] kept for the reference event indexer,
+    /// which calls this name. Read-only; no auth required.
     pub fn is_contract_paused(env: Env) -> bool {
         storage_is_paused(&env)
     }
 
-    /// Returns true if `caller` holds the admin role.
+    /// Returns `true` if `caller` is the contract admin.
+    ///
+    /// Read-only; no auth required. Useful for off-chain tooling that needs to
+    /// check admin status without submitting a transaction.
     pub fn has_admin_role(env: Env, caller: Address) -> bool {
         is_admin_caller(&env, &caller)
     }
 
-    /// Records that `github_username` performed a registry-mutating action now,
-    /// for cooldown enforcement by callers.
+    /// Records that `github_username` performed a registry-mutating action at the current
+    /// ledger timestamp, for use by cooldown enforcement logic.
+    ///
+    /// Off-chain callers use this alongside `is_registration_in_cooldown` to implement
+    /// per-contributor rate limiting without requiring a contract upgrade.
     pub fn record_action(env: Env, github_username: String) {
         set_last_action(&env, &github_username, env.ledger().timestamp());
     }
 
-    /// Returns true if `github_username` is still within the cooldown window.
+    /// Returns `true` if `github_username` is still within the registration cooldown window.
+    ///
+    /// Read-only; no auth required. The cooldown period is set by `set_cooldown`. Returns
+    /// `false` if no action has been recorded or the cooldown has elapsed.
     pub fn is_registration_in_cooldown(env: Env, github_username: String) -> bool {
         is_in_cooldown(&env, &github_username)
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -88,6 +88,15 @@ pub const TTL_THRESHOLD: u32 = LEDGERS_PER_DAY * 30;
 /// never rejected for overshooting the cap.
 pub const TTL_BUMP: u32 = LEDGERS_PER_DAY * 90;
 
+/// Role-Based Access Control variants for privileged contract operations.
+///
+/// Roles are assigned via `set_role` and revoked via `remove_role`.
+///
+/// | Variant | Grants access to |
+/// |---------|-----------------|
+/// | `Admin` | All admin-gated functions |
+/// | `Upgrader` | `upgrade` |
+/// | `Verifier` | `verify`, `revoke_verification` |
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[soroban_sdk::contracttype]
 #[repr(u32)]
@@ -97,11 +106,19 @@ pub enum Role {
     Verifier = 3,
 }
 
+/// An on-chain record for a registered contributor.
+///
+/// Stored under `(Symbol("reg"), github_username)` in persistent storage.
+/// TTL is extended on every read and write; use `extend_registry_ttl` to
+/// refresh cold entries before they are archived.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[soroban_sdk::contracttype]
 pub struct ContributorRecord {
+    /// The Stellar G-address that owns this registration.
     pub stellar_address: Address,
+    /// Ledger timestamp when this record was last written.
     pub registered_at: u64,
+    /// Whether the contributor has been verified by an admin or Verifier.
     pub verified: bool,
 }
 
@@ -156,19 +173,31 @@ pub struct WasmAttestation {
     pub attested_at: u64,
 }
 
+/// Aggregate registry statistics returned by `get_stats`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[soroban_sdk::contracttype]
 pub struct Stats {
+    /// Total number of registered contributors.
     pub total: u32,
+    /// Number of contributors who have been verified.
     pub verified: u32,
 }
 
+/// A single page of registry records returned by paginated export functions.
+///
+/// `next_cursor` is `None` when this is the last page. Pass it as `cursor` to
+/// the next call to advance the page. `has_more` mirrors `next_cursor.is_some()`
+/// for clients that prefer a boolean sentinel.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[soroban_sdk::contracttype]
 pub struct ExportPage {
+    /// Records in this page: `(github_username, ContributorRecord)` pairs.
     pub records: Vec<(String, ContributorRecord)>,
+    /// Cursor to pass to the next call, or `None` if this is the last page.
     pub next_cursor: Option<u32>,
+    /// Total number of records in the registry at query time.
     pub total: u32,
+    /// `true` if there are more records after this page.
     pub has_more: bool,
 }
 


### PR DESCRIPTION
## Summary

Ensures all public contract entry points and ABI-facing types have useful rustdoc, and documents the `cargo doc` workflow for contributors. Thin or missing rustdoc slows onboarding.

Closes #110

## Changes

### `src/lib.rs` — All public entry points documented

Every public function now has:
- One-line summary sentence
- `# Auth` section stating which identity must sign (where applicable)
- `# Errors` section listing every `ContractError` variant the function can return

Functions updated: `initialize`, `pause`, `unpause`, `is_paused`, `set_role`, `remove_role`, `get_role`, `set_cooldown`, `get_cooldown`, `get_version`, `migrate`, `register`, `get_address`, `has_record`, `remove`, `get_all_registered`, `get_registered_page`, `get_registered_paginated`, `get_public_paginated`, `verify`, `revoke_verification`, `get_verified_count`, `get_stats`, `set_paused`, `has_admin_role`, `record_action`, `is_registration_in_cooldown`.

### `src/error.rs` — `ContractError` fully documented

- Top-level rustdoc with error code lookup table (code | variant | raised-by)
- Per-variant doc comments explaining when each error is raised

### `src/events.rs` — All event structs documented

Summary doc added to each of the 9 event types: `RegisteredEvent`, `RemovedEvent`, `VerifiedEvent`, `VerificationRevokedEvent`, `UpgradedEvent`, `PausedEvent`, `UnpausedEvent`, `RoleGrantedEvent`, `RoleRevokedEvent`.

### `src/storage.rs` — Public types documented

- `Role` enum: doc table showing which role gates which functions; per-variant docs
- `ContributorRecord`: struct-level doc + field docs
- `Stats`: struct-level doc
- `ExportPage`: struct-level doc with cursor semantics explanation + field docs

### `docs/CONTRIBUTING.md` — Rustdoc conventions and `cargo doc` workflow

New **Rustdoc** subsection under Code Standards:
- Convention: summary line, `# Auth`, `# Errors` sections
- Worked example showing correct doc format
- `cargo doc --no-deps --open` for local browsing
- `cargo doc --no-deps` for headless / CI
- `--document-private-items` for internal exploration
- Note that `cargo doc` step in CI treats warnings as errors (`RUSTDOCFLAGS=-D warnings`)

### `.github/workflows/ci.yml` — `cargo doc` step added

```yaml
- name: cargo doc (public API)
  run: cargo doc --no-deps
  env:
    RUSTDOCFLAGS: -D warnings
```

Broken intra-doc links and other doc warnings now fail CI.

### `Makefile` — `make docs` and `make docs-check` targets

- `make docs`: `cargo doc --no-deps --open` (opens browser)
- `make docs-check`: headless build with `-D warnings` — integrated into `make check`

## Verification

```
cargo doc --no-deps
# Finishes with 0 errors, 0 warnings
# Docs generated at target/doc/trustbridge_contract/index.html
```