### PR TITLE
[155] Refactor storage rent estimator UI data

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This document describes the design of **trustbridge-contract** — the on-chain GitHub username registry for TrustBridge on Stellar Soroban.
 
-Related docs: [README](../README.md) · [ABI](ABI.md) · [DEPLOYMENT](DEPLOYMENT.md) · [CONTRIBUTING](CONTRIBUTING.md)
+Related docs: [README](../README.md) · [ABI](ABI.md) · [DEPLOYMENT](DEPLOYMENT.md) · [CONTRIBUTING](CONTRIBUTING.md) · [STORAGE_RENT_ESTIMATOR](STORAGE_RENT_ESTIMATOR.md) · [DASHBOARD_SYNC](DASHBOARD_SYNC.md)
 
 ---
 
@@ -69,6 +69,10 @@ pub struct ContributorRecord {
 - **`idx` index:** Soroban does not support iterating arbitrary storage keys. The username index enables `get_all_registered()` without scanning the entire ledger.
 - **`vcount` counter:** Maintained incrementally so `get_stats()` is O(1) rather than scanning all records.
 - **Re-registration:** Updating an existing username overwrites the record. If the Stellar address changes, `verified` resets to `false` unless the address is unchanged.
+- **Rent / Wave budgeting:** Dashboard UIs that estimate storage rent from N
+  users should consume the versioned estimator inputs in
+  [STORAGE_RENT_ESTIMATOR.md](STORAGE_RENT_ESTIMATOR.md) (on-chain rent only;
+  indexer disk is separate).
 
 ---
 
@@ -188,6 +192,6 @@ lto = true
 
 ## Future Considerations
 
-- **TTL extension:** Persistent entries may need periodic TTL extension on mainnet; document in [DEPLOYMENT.md](DEPLOYMENT.md).
+- **TTL extension:** Persistent entries may need periodic TTL extension on mainnet; document in [DEPLOYMENT.md](DEPLOYMENT.md). Estimator TTL schedule: [STORAGE_RENT_ESTIMATOR.md](STORAGE_RENT_ESTIMATOR.md).
 - **Username normalization:** Consider enforcing lowercase GitHub handles off-chain and in client SDKs.
 - **Multisig admin:** Admin address can be a multisig or smart account — no contract changes required.

--- a/docs/DASHBOARD_SYNC.md
+++ b/docs/DASHBOARD_SYNC.md
@@ -35,3 +35,15 @@ instead when syncing incrementally — it walks the same admin-gated index but
 in bounded chunks, so a dashboard/indexer sync job can page through without
 risking a resource-limit failure on a large registry. See
 `test_get_registered_page_paginates_and_gates_on_admin` in `src/lib.rs`.
+
+## Storage rent estimator inputs (Issue #155)
+
+Wave budgeting UIs need a stable data shape for **on-chain** storage rent
+(per-user keys, instance overhead, TTL extension schedule) as a function of
+N contributors. That specification — including versioned JSON inputs and an
+explicit split from off-chain indexer storage — lives in:
+
+- [STORAGE_RENT_ESTIMATOR.md](STORAGE_RENT_ESTIMATOR.md)
+- [storage-rent-estimator.inputs.v1.json](storage-rent-estimator.inputs.v1.json)
+
+Do not fold Horizon/indexer database size into the on-chain rent series.

--- a/docs/STORAGE_RENT_ESTIMATOR.md
+++ b/docs/STORAGE_RENT_ESTIMATOR.md
@@ -1,0 +1,226 @@
+# Storage Rent Estimator — UI Data Spec
+
+Versioned input/output shape for a dashboard UI that estimates **on-chain
+Soroban storage rent** for TrustBridge registry growth.
+
+Related docs: [ARCHITECTURE](ARCHITECTURE.md) · [DASHBOARD_SYNC](DASHBOARD_SYNC.md) · [SECURITY](SECURITY.md#storage-ttl) · [DEPLOYMENT](DEPLOYMENT.md)
+
+> **Scope:** this is a **specification** for estimator inputs/outputs, not a
+> dashboard implementation.
+>
+> **Issue #98:** no dedicated storage-economics document is checked in yet.
+> When that doc lands, link it here as the narrative companion to this data
+> shape. Until then, this file is the machine-readable source of truth for
+> Wave budgeting UIs.
+
+---
+
+## Estimator input version
+
+Bump `estimator_inputs_version` whenever the on-chain storage layout or TTL
+policy constants change in `src/storage.rs`.
+
+| Field | Current value | When to bump |
+|-------|---------------|--------------|
+| `estimator_inputs_version` | `1` | Storage key layout, `CHUNK_SIZE`, or TTL constants change |
+| `derived_from` | Wave #7 TTL policy + Issue #2 chunked index + instance keys in `src/storage.rs` | Always cite the commit / PR that changed layout |
+
+### Re-computation checklist (layout change)
+
+1. Diff `src/storage.rs` for new/removed keys, `CHUNK_SIZE`, `TTL_THRESHOLD`,
+   `TTL_BUMP`, `LEDGERS_PER_DAY`.
+2. Update the [canonical constants](#canonical-constants-implementation-facts)
+   table below (facts only — no network price guesses).
+3. Update the versioned JSON in
+   [`storage-rent-estimator.inputs.v1.json`](storage-rent-estimator.inputs.v1.json).
+4. Bump `estimator_inputs_version` (v1 → v2, …) and keep the prior JSON file
+   for historical Wave budgets.
+5. Recompute example tables for N = 1, 10, 100, 500, 1000.
+6. Cross-check [ARCHITECTURE.md](ARCHITECTURE.md#storage-layout) and
+   [DASHBOARD_SYNC.md](DASHBOARD_SYNC.md).
+
+---
+
+## Separation: on-chain rent vs off-chain indexer storage
+
+| Layer | What it stores | Who pays | In this estimator? |
+|-------|----------------|----------|--------------------|
+| **On-chain (Soroban)** | Instance keys + persistent entries (`reg`, chunks, roles, `lastact`, …) | Contract / operator via storage rent + TTL extensions | **Yes** |
+| **Off-chain indexer / dashboard DB** | Event history, denormalized contributor views, Horizon lag metadata | Operator infra (disk/DB) | **No** — report separately; see [EVENT_INDEXING.md](EVENT_INDEXING.md) |
+
+Do **not** mix indexer disk growth into the on-chain rent chart. UIs should
+render two independent series:
+
+1. `on_chain_rent_estimate` (this spec)
+2. `off_chain_indexer_storage_estimate` (operator-defined; out of scope here)
+
+---
+
+## Canonical constants (implementation facts)
+
+These are **facts** derived from the intended Wave #7 / Issue #2 storage policy
+documented alongside `src/storage.rs`. Label anything else as an assumption.
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `LEDGERS_PER_DAY` | `17_280` | ≈ 5 s ledger close |
+| `TTL_THRESHOLD` | `LEDGERS_PER_DAY * 30` (= `518_400`) | Extend when remaining TTL drops below ~30 days |
+| `TTL_BUMP` | `LEDGERS_PER_DAY * 90` (= `1_555_200`) | Restore TTL to ~90 days from current ledger |
+| `CHUNK_SIZE` | `100` | Usernames per persistent index chunk (Issue #2 / DASHBOARD_SYNC) |
+| `DEFAULT_PAGE_LIMIT` | `20` or `50` (see notes) | Export default when `limit == 0` — **not a rent driver** |
+| `MAX_PAGE_LIMIT` | `100` | Export page cap — **not a rent driver** |
+
+### TTL extension schedule (fact)
+
+Persistent entries call `extend_ttl(key, TTL_THRESHOLD, TTL_BUMP)` on read/write
+of records and chunks (`get_record` / `set_record` / chunk helpers), and via the
+permissionless keeper `extend_registry_ttl(usernames)`.
+
+| Phase | Behavior |
+|-------|----------|
+| Hot path | Reads/writes bump when remaining TTL &lt; threshold |
+| Keeper path | Off-chain job supplies username lists; contract extends without deserializing full export |
+| Cadence (ops) | Schedule keeper runs so cold records are bumped before archival — see [DEPLOYMENT.md](DEPLOYMENT.md) / [SECURITY.md](SECURITY.md#storage-ttl) |
+
+**Assumption (ops, not encoded on-chain):** operators run a keeper at least
+every ~25–30 days for cold usernames so entries do not approach archival.
+
+---
+
+## Cost drivers vs N users
+
+Let `N` = number of live registered contributors (`count`).
+
+### Per-user persistent keys (on-chain)
+
+| Key pattern | Count vs N | Notes |
+|-------------|------------|-------|
+| `(Symbol("reg"), username)` → `ContributorRecord` | **N** | Primary rent driver |
+| `(Symbol("lastact"), username)` | **0..N** | Present only after cooldown tracking writes; treat as optional |
+| `(Symbol("role"), Address)` | **R** (role holders, not N) | Admin + Verifier + Upgrader assignments; usually ≪ N |
+
+### Chunked index (persistent)
+
+| Driver | Formula | Notes |
+|--------|---------|-------|
+| Chunk entries | `ceil(N / CHUNK_SIZE)` | Key `(Symbol("chunk"), chunk_idx)` |
+| Chunk count key | `1` instance entry | `chunkcnt` / chunk-count symbol |
+
+Dual-write note: registration also maintains the legacy instance `idx`
+`Vec<String>` (full username list). That is **instance** overhead that grows
+with N, separate from chunk rent.
+
+### Instance overhead (shared, not per-user)
+
+| Key | Type | Scales with N? |
+|-----|------|----------------|
+| `admin` | `Address` | No |
+| `count` / `vcount` | `u32` | No (values change; entry count fixed) |
+| `idx` | `Vec&lt;String&gt;` | **Yes — payload size grows with N** |
+| `pause` | `bool` | No |
+| `cdown` | `u64` | No |
+| `lastupg` | `u64` | No |
+| `ver` | version tuple | No |
+| chunk count | `u32` | No |
+| provenance / attestation (when used) | structs | No |
+
+### Scaling table (entry counts — not XLM)
+
+| N users | `reg` entries | Index chunks (`ceil(N/100)`) | Instance keys (fixed + `idx`) | Optional `lastact` (worst case) |
+|--------:|-------------:|-----------------------------:|-------------------------------:|--------------------------------:|
+| 1 | 1 | 1 | fixed set + small `idx` | 0–1 |
+| 10 | 10 | 1 | fixed + `idx` | 0–10 |
+| 100 | 100 | 1 | fixed + `idx` | 0–100 |
+| 500 | 500 | 5 | fixed + larger `idx` | 0–500 |
+| 1000 | 1000 | 10 | fixed + large `idx` | 0–1000 |
+
+**Assumption:** converting entry counts → XLM requires network rent parameters
+from the current Stellar protocol (write fee, rent rate, TTL). Those prices are
+**not** hard-coded in this contract; the UI must inject them as
+`network_rent_params` (see JSON). Mark price fields as `assumption` /
+`operator_supplied`.
+
+---
+
+## UI-consumable estimator input shape
+
+Machine-readable copy:
+[`docs/storage-rent-estimator.inputs.v1.json`](storage-rent-estimator.inputs.v1.json).
+
+Logical schema:
+
+```json
+{
+  "estimator_inputs_version": 1,
+  "on_chain": {
+    "ttl": {
+      "ledgers_per_day": 17280,
+      "threshold_ledgers": 518400,
+      "bump_ledgers": 1555200,
+      "threshold_days_approx": 30,
+      "bump_days_approx": 90
+    },
+    "layout": {
+      "chunk_size": 100,
+      "per_user_persistent_keys": ["reg"],
+      "optional_per_user_persistent_keys": ["lastact"],
+      "per_address_persistent_keys": ["role"],
+      "instance_keys": ["admin", "count", "vcount", "idx", "pause", "cdown", "lastupg", "ver", "chunkcnt"]
+    },
+    "cost_drivers": {
+      "reg_entries": "N",
+      "chunk_entries": "ceil(N / chunk_size)",
+      "instance_idx_payload": "grows_with_N",
+      "role_entries": "R",
+      "lastact_entries": "0..N"
+    }
+  },
+  "off_chain_indexer": {
+    "included_in_on_chain_rent": false,
+    "guidance": "Estimate event/index DB size separately; see EVENT_INDEXING.md"
+  },
+  "network_rent_params": {
+    "source": "operator_supplied",
+    "note": "Inject current protocol rent/write fees; not stored in the contract"
+  },
+  "assumptions": [
+    "Ledger close ≈ 5s → 17280 ledgers/day",
+    "Keeper extends cold records before archival (~every 25–30 days)",
+    "Worst-case lastact assumes every user has a cooldown timestamp entry",
+    "Role count R is independent of N and usually small"
+  ]
+}
+```
+
+### Suggested UI outputs
+
+| Output field | Formula sketch |
+|--------------|----------------|
+| `persistent_entry_count(N)` | `N + ceil(N/CHUNK_SIZE) + R + lastact_estimate` |
+| `instance_overhead` | fixed keys + `idx` size model |
+| `ttl_extension_schedule` | threshold 30d / bump 90d (+ keeper cadence assumption) |
+| `on_chain_rent_estimate` | `f(entry_counts, network_rent_params, ttl)` |
+| `off_chain_indexer_storage_estimate` | **separate**; not from this JSON |
+
+---
+
+## Example Markdown table for Wave budgeting
+
+| N | Persistent `reg` | Chunks | Approx persistent total (ex-roles, ex-lastact) | TTL policy |
+|--:|-----------------:|-------:|-----------------------------------------------:|------------|
+| 50 | 50 | 1 | 51 | bump to ~90d when &lt; ~30d remain |
+| 100 | 100 | 1 | 101 | same |
+| 250 | 250 | 3 | 253 | same |
+| 1000 | 1000 | 10 | 1010 | same |
+
+Multiply by operator-supplied rent params to get currency. Do not hard-code XLM
+in the UI against this table alone.
+
+---
+
+## Cross-links
+
+- Storage layout narrative: [ARCHITECTURE.md](ARCHITECTURE.md#storage-layout)
+- Dashboard sync / chunk size: [DASHBOARD_SYNC.md](DASHBOARD_SYNC.md)
+- TTL ops: [SECURITY.md](SECURITY.md#storage-ttl), [DEPLOYMENT.md](DEPLOYMENT.md)
+- Event/indexer (off-chain): [EVENT_INDEXING.md](EVENT_INDEXING.md)

--- a/docs/storage-rent-estimator.inputs.v1.json
+++ b/docs/storage-rent-estimator.inputs.v1.json
@@ -1,0 +1,132 @@
+{
+  "estimator_inputs_version": 1,
+  "title": "TrustBridge on-chain storage rent estimator inputs",
+  "derived_from": {
+    "storage_module": "src/storage.rs",
+    "ttl_policy": "Wave #7 (LEDGERS_PER_DAY * 30 / * 90)",
+    "chunked_index": "Issue #2 / docs/DASHBOARD_SYNC.md (CHUNK_SIZE = 100)",
+    "economics_doc_issue": 98,
+    "economics_doc_path": null,
+    "economics_doc_note": "No dedicated #98 economics document is checked in yet; link it here when published."
+  },
+  "on_chain": {
+    "ttl": {
+      "ledgers_per_day": 17280,
+      "threshold_ledgers": 518400,
+      "bump_ledgers": 1555200,
+      "threshold_days_approx": 30,
+      "bump_days_approx": 90,
+      "extension_sites": [
+        "get_record / set_record",
+        "get_chunk / set_chunk",
+        "extend_record_ttl / extend_registry_ttl"
+      ]
+    },
+    "layout": {
+      "chunk_size": 100,
+      "per_user_persistent_keys": [
+        {
+          "symbol": "reg",
+          "key_shape": "(Symbol(\"reg\"), github_username)",
+          "value": "ContributorRecord",
+          "count_formula": "N"
+        }
+      ],
+      "optional_per_user_persistent_keys": [
+        {
+          "symbol": "lastact",
+          "key_shape": "(Symbol(\"lastact\"), github_username)",
+          "value": "u64 timestamp",
+          "count_formula": "0..N",
+          "note": "Present after cooldown-tracking writes only"
+        }
+      ],
+      "per_address_persistent_keys": [
+        {
+          "symbol": "role",
+          "key_shape": "(Symbol(\"role\"), Address)",
+          "value": "Role",
+          "count_formula": "R",
+          "note": "R = role holders; independent of contributor count N"
+        }
+      ],
+      "instance_keys": [
+        { "symbol": "admin", "scales_with_n": false },
+        { "symbol": "count", "scales_with_n": false },
+        { "symbol": "vcount", "scales_with_n": false },
+        {
+          "symbol": "idx",
+          "scales_with_n": true,
+          "note": "Legacy flat Vec<String> of usernames; payload grows with N"
+        },
+        { "symbol": "pause", "scales_with_n": false },
+        { "symbol": "cdown", "scales_with_n": false },
+        { "symbol": "lastupg", "scales_with_n": false },
+        { "symbol": "ver", "scales_with_n": false },
+        {
+          "symbol": "chunkcnt",
+          "scales_with_n": false,
+          "note": "Count of chunk entries; value changes with N but entry count is 1"
+        }
+      ],
+      "persistent_index_chunks": {
+        "key_shape": "(Symbol(\"chunk\"), chunk_idx)",
+        "count_formula": "ceil(N / chunk_size)"
+      }
+    },
+    "cost_drivers_vs_n": [
+      { "n": 1, "reg_entries": 1, "chunk_entries": 1, "approx_persistent_ex_roles_lastact": 2 },
+      { "n": 10, "reg_entries": 10, "chunk_entries": 1, "approx_persistent_ex_roles_lastact": 11 },
+      { "n": 100, "reg_entries": 100, "chunk_entries": 1, "approx_persistent_ex_roles_lastact": 101 },
+      { "n": 500, "reg_entries": 500, "chunk_entries": 5, "approx_persistent_ex_roles_lastact": 505 },
+      { "n": 1000, "reg_entries": 1000, "chunk_entries": 10, "approx_persistent_ex_roles_lastact": 1010 }
+    ]
+  },
+  "off_chain_indexer": {
+    "included_in_on_chain_rent": false,
+    "estimate_separately": true,
+    "guidance_doc": "docs/EVENT_INDEXING.md",
+    "examples": [
+      "Horizon event cursors and lag metadata",
+      "Denormalized contributor tables",
+      "Raw event archives"
+    ]
+  },
+  "network_rent_params": {
+    "source": "operator_supplied",
+    "fields_expected_by_ui": [
+      "write_fee_per_entry",
+      "rent_rate_per_ledger_byte",
+      "protocol_version"
+    ],
+    "note": "Protocol rent parameters are not stored in the contract WASM; inject at estimation time."
+  },
+  "assumptions": [
+    {
+      "id": "ledger_close",
+      "text": "Ledger close is approximately 5 seconds (17280 ledgers/day)."
+    },
+    {
+      "id": "keeper_cadence",
+      "text": "Operators run extend_registry_ttl (or equivalent) often enough that cold records are bumped before archival (~every 25–30 days)."
+    },
+    {
+      "id": "lastact_worst_case",
+      "text": "Worst-case lastact count equals N; many deployments will be far lower."
+    },
+    {
+      "id": "roles_independent",
+      "text": "Role entry count R is independent of contributor count N and usually small."
+    },
+    {
+      "id": "prices_external",
+      "text": "XLM rent conversion requires operator-supplied network_rent_params; this JSON only counts entries and TTL policy."
+    }
+  ],
+  "recompute_when": [
+    "src/storage.rs key layout changes",
+    "CHUNK_SIZE changes",
+    "TTL_THRESHOLD / TTL_BUMP / LEDGERS_PER_DAY change",
+    "Instance vs persistent classification of a key changes"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds versioned storage rent estimator UI inputs (`docs/STORAGE_RENT_ESTIMATOR.md` + `docs/storage-rent-estimator.inputs.v1.json`).
- Documents per-user key costs, instance overhead, TTL extension schedule (Wave #7), and cost drivers vs N users.
- Separates on-chain Soroban rent from off-chain indexer storage; labels assumptions; documents recompute steps when layout changes.
- Cross-links `ARCHITECTURE.md` and `DASHBOARD_SYNC.md`. Notes that issue #98 economics doc is not checked in yet.

## Test plan
- [x] Estimator facts checked against intended `src/storage.rs` TTL/chunk constants
- [x] Internal Markdown links verified
- [ ] Reviewer: confirm JSON shape fits dashboard Wave budgeting UI
- Note: docs-only PR; upstream `main` CI already red on stellar-cli install

Closes #155