### PR TITLE
docs(contract): propose future registration cooldown design

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -191,3 +191,35 @@ lto = true
 - **TTL extension:** Persistent entries may need periodic TTL extension on mainnet; document in [DEPLOYMENT.md](DEPLOYMENT.md).
 - **Username normalization:** Consider enforcing lowercase GitHub handles off-chain and in client SDKs.
 - **Multisig admin:** Admin address can be a multisig or smart account — no contract changes required.
+## Future Proposal: Registration Cooldown
+
+This proposal is for a future contract version only. It is not implemented in the current contract and does not change current storage or runtime behavior.
+
+A registration cooldown can reduce rapid re-registration spam and username squatting churn by requiring a minimum delay between successful `register()` calls for the same username or address. The suggested policy is based on ledger timestamps and a per-username cooldown window.
+
+### Proposed state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Register : register()
+    Register --> Success : registration succeeds
+    Success --> CooldownActive : store last_register_timestamp
+    CooldownActive --> Attempt : new registration attempt
+    Attempt --> Reject : if cooldown active
+    Attempt --> Register : if cooldown expired
+```
+
+### Why a cooldown is desirable
+
+- Prevents automated or accidental rapid re-registrations that can overwhelm indexers and off-chain workflows.
+- Makes quick username churn more expensive, reducing incentives for username squatting and repeated remove/re-register loops.
+- Gives the dashboard and verification process more predictable time to reconcile state after a registration update.
+
+### Design notes
+
+- Proposed storage representation: extend `ContributorRecord` with `last_registered_at: u64`, or alternatively store a separate key such as `(Symbol("reg_cooldown"), github_username) -> u64`.
+- Estimated storage/rent impact: one additional 8-byte timestamp per registration record, plus whatever Soroban rent overhead already applies to the existing per-entry storage value. If stored as a separate key, the impact is larger because it adds a whole extra storage entry.
+- Address-change re-register: the cooldown should apply to the username being updated, so a re-register attempt during the cooldown window would be rejected even if the Stellar address changes.
+- Admin remove: admin-driven removal may be treated as orthogonal to the cooldown. A future design decision can choose whether `remove()` clears the cooldown or leaves it in place to prevent churn from repeated add/remove cycles.
+- Future verification flow: cooldown is enforcement on `register()` only. Verification status remains a separate concern; if a record is re-registered after cooldown expiry, the existing verification policy can still decide whether `verified` persists or resets based on address change.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -51,6 +51,14 @@ The admin address is **immutable** after `initialize`. Recommendations:
   the verified count decreases, and any later `verify()` applies to the new
   address only.
 
+### Future registration cooldown proposal
+
+A registration cooldown is a planned design proposal for a future contract version. It is not part of the current contract behavior.
+
+- Cooldown reduces rapid registration spam by rejecting repeated `register()` calls for the same username within a ledger timestamp window.
+- It also reduces username squatting churn by making repeated remove/re-register cycles more expensive.
+- No current contract logic or storage behavior changes are introduced by this proposal; it is documented here as a design consideration only.
+
 ---
 
 ## Input Validation


### PR DESCRIPTION
Closes #136

---

[Summary of documentation updates]
Added a new Future Proposal: Registration Cooldown section to [ARCHITECTURE.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Explicitly marked as future design only, not implemented
Explained why cooldown is desirable
Added a state machine flow using Mermaid
Described proposed storage representation and estimated storage/rent impact
Noted interactions with address-change re-register, admin remove, and future verification flow
Added a short Future registration cooldown proposal note to [SECURITY.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Explained spam reduction and squatting churn reduction
Clarified this is a future contract version proposal with no current behavior change

[Contract behavior]
Confirmed no contract logic, storage behavior, events, or Rust source code were modified as part of this change.