### PR TITLE
Fix broken merge build; resolve issues #53, #56, #57, #149

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ More examples (verify, remove, admin export): [docs/ABI.md](docs/ABI.md)
 | `get_address(github_username)` | None | ❌ | Lookup by username |
 | `remove(caller, github_username)` | `caller` (registrant or admin) | ✅ | Remove a registration |
 | `get_all_registered()` | Admin | ❌ | Export full registry |
-| `verify(github_username)` | Admin | ✅ | Mark as GitHub-verified |
-| `revoke_verification(github_username)` | Admin | ✅ | Clear a verification |
+| `verify(caller, github_username)` | Admin / Verifier | ✅ | Mark as GitHub-verified |
+| `revoke_verification(caller, github_username)` | Admin / Verifier | ✅ | Clear a verification |
 | `get_verified_count()` | None | ❌ | Verified registration count |
 | `get_stats()` | None | ❌ | `{ total, verified }` |
 | `version()` | None | ❌ | Deployed version as `(major, minor, patch)` |

--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -268,7 +268,7 @@ stellar contract invoke --id $ID --source admin --network testnet \
 
 ---
 
-### `verify(github_username: String) -> Result<(), ContractError>`
+### `verify(caller: Address, github_username: String) -> Result<(), ContractError>`
 
 Mark a contributor as verified after off-chain GitHub identity confirmation.
 
@@ -283,7 +283,10 @@ Mark a contributor as verified after off-chain GitHub identity confirmation.
 The `caller` argument is required so the contract can validate which identity
 signed the transaction. Both the admin and any address granted `Role::Verifier`
 via `set_role` may call this function. An address without either role returns
-`NotAuthorized`.
+`NotAuthorized`. Calling `verify` on a `github_username` that has never been
+registered returns `NotRegistered` rather than creating a record (Issue #57);
+`revoke_verification` guards the same way (see tests in `src/lib.rs` and
+`tests/integration.rs`).
 
 ```bash
 # Admin calling verify
@@ -339,7 +342,7 @@ stellar contract invoke --id $ID --source admin --network testnet --send=yes \
 
 ---
 
-### `revoke_verification(github_username: String) -> Result<(), ContractError>`
+### `revoke_verification(caller: Address, github_username: String) -> Result<(), ContractError>`
 
 Revoke verification for a registered contributor.
 
@@ -717,6 +720,72 @@ handshake costs no fees.
 
 A contract change that alters the ABI without a version bump leaves clients
 unable to detect the drift, so the bump is a review blocker.
+
+---
+
+## Cross-Contract Read Interface
+
+Sibling TrustBridge contracts (payout, attestation, and future Waves) can
+query registry state directly via Soroban's cross-contract call
+(`env.invoke_contract`), instead of duplicating registration/verification
+storage of their own. This section is the safe subset of the ABI for that use
+case — no new functions were added for it, only a fence around which existing
+ones are appropriate to call from another contract's execution context.
+
+### Safe to call cross-contract
+
+All of the following are read-only (no `.set`/`.remove` on storage) and
+require **no authorization** beyond the standard `require_not_paused` guard
+where noted, so a calling contract needs no signature from the registry's
+admin or any registrant to invoke them:
+
+| Function | Returns | Notes |
+|---|---|---|
+| `get_address(github_username)` | `Option<ContributorRecord>` | Core identity lookup |
+| `has_record(github_username)` | `bool` | Cheap existence check, avoids decoding the full record |
+| `get_public_paginated(cursor, limit)` | `Result<ExportPage, ContractError>` | Paginated read; fails with `Paused` while the registry is paused |
+| `get_stats()` | `Stats` | `{ total, verified }` |
+| `get_verified_count()` | `u32` | |
+| `get_role(address)` | `Option<Role>` | RBAC lookup, e.g. to gate a payout on `Role::Verifier` |
+| `is_paused()` / `is_contract_paused()` | `bool` | Check before a call that would otherwise fail on `Paused` |
+| `is_registration_in_cooldown(github_username)` | `bool` | |
+| `version()` | `(u32, u32, u32)` | |
+| `is_compatible(major, minor, patch)` | `bool` | Guard the same way a TypeScript client would (see version handshake above) |
+| `max_username_len()`, `is_username_valid(github_username)`, `usernames_match(a, b)` | — | Pure validation helpers, no storage access at all |
+
+`Version::supports_cross_contract_reads()` (`src/version.rs`) gates on this
+surface the same way `supports_batch_verify()` gates on the batched
+verification entry point, for a caller that wants to assert compatibility
+before invoking.
+
+### Not part of this surface: admin exports
+
+`get_all_registered`, `get_registered_page`, and `get_registered_paginated`
+call `admin.require_auth()` internally. A cross-contract invocation executes
+in the *calling* contract's authorization context — it cannot supply the
+registry admin's signature — so these calls will fail auth when invoked from
+another contract, regardless of caller identity. Sibling contracts needing a
+bulk export must go through the admin's own off-chain tooling, not a
+cross-contract call. This is deliberate: the registry has no notion of a
+"trusted contract" allowlist, so widening the export surface would mean any
+deployed contract could exfiltrate the full registry, not just the intended
+consumer.
+
+### Example: a hypothetical payout contract reading verification status
+
+```rust
+// From within another contract's implementation:
+let registry_id: Address = /* stored sibling contract ID */;
+let verified: Option<ContributorRecord> = env.invoke_contract(
+    &registry_id,
+    &Symbol::new(&env, "get_address"),
+    (github_username,).into_val(&env),
+);
+```
+
+No storage migration is required to adopt this: every function above already
+exists in the deployed 1.0.0 ABI, so a v0.1 consumer contract can start
+reading today without waiting on a TrustBridge registry upgrade.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,6 +186,32 @@ lto = true
 
 ---
 
+## Cross-Contract Composability
+
+Wave issue #149. Future TrustBridge contracts (payout, attestation) need to
+answer "is this GitHub username registered, and verified?" without
+maintaining a second copy of the registry. Soroban supports this natively:
+any contract can call another contract's public functions directly via
+`env.invoke_contract`, so no separate "reader" interface needed to be built —
+the registry's existing read functions (`get_address`, `has_record`,
+`get_stats`, `get_role`, …) already satisfy it.
+
+The one design decision this forces is which functions are *appropriate* to
+expose that way. A cross-contract call runs in the caller's authorization
+context, so a sibling contract can never supply the registry admin's
+signature — anything gated on `admin.require_auth()` (`get_all_registered`,
+`get_registered_page`, `get_registered_paginated`) is unreachable
+cross-contract by construction, not by an added check. That boundary, plus
+the full list of what *is* safe to call, is documented in
+[ABI.md § Cross-Contract Read Interface](ABI.md#cross-contract-read-interface).
+
+Because the safe surface is entirely existing, already-deployed functions,
+adopting it requires no storage migration and no new contract version for
+existing v0.1 consumers — `Version::supports_cross_contract_reads()` pins the
+compatibility floor at 1.0.0 for callers that want to assert it explicitly.
+
+---
+
 ## Future Considerations
 
 - **TTL extension:** Persistent entries may need periodic TTL extension on mainnet; document in [DEPLOYMENT.md](DEPLOYMENT.md).

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,15 @@ pub enum ContractError {
     /// The supplied GitHub username is empty, longer than
     /// `utils::MAX_USERNAME_LEN`, or contains characters GitHub does not allow.
     InvalidUsername = 11,
+    /// `attest_upgrade` was called with an `expires_at` not in the future, or a
+    /// live attestation lapsed before `upgrade` consumed it.
+    AttestationExpired = 12,
+    /// `upgrade` was called with a WASM hash that does not match the live
+    /// attestation.
+    UnattestedWasm = 13,
+    /// A batch call (e.g. `extend_registry_ttl`) was given zero or more items
+    /// than `batch::BatchConfig::max_batch_size` allows.
+    InvalidBatchSize = 14,
 }
 
 impl ContractError {
@@ -41,6 +50,9 @@ impl ContractError {
             9 => Some(ContractError::InvalidVersion),
             10 => Some(ContractError::InvalidRole),
             11 => Some(ContractError::InvalidUsername),
+            12 => Some(ContractError::AttestationExpired),
+            13 => Some(ContractError::UnattestedWasm),
+            14 => Some(ContractError::InvalidBatchSize),
             _ => None,
         }
     }
@@ -63,6 +75,9 @@ impl ContractError {
 // | 9    | InvalidVersion       | migrate                            |
 // | 10   | InvalidRole          | set_role                           |
 // | 11   | InvalidUsername      | register                           |
+// | 12   | AttestationExpired   | attest_upgrade, upgrade            |
+// | 13   | UnattestedWasm       | upgrade                            |
+// | 14   | InvalidBatchSize     | extend_registry_ttl                |
 //
 // `ContractError::from_code` is the reverse of this table for off-chain
 // consumers decoding a raw error code back into a typed variant.

--- a/src/error_context.rs
+++ b/src/error_context.rs
@@ -96,6 +96,9 @@ pub fn classify_error(error: ContractError) -> ErrorCategory {
         ContractError::InvalidVersion => ErrorCategory::Validation,
         ContractError::InvalidRole => ErrorCategory::Validation,
         ContractError::InvalidUsername => ErrorCategory::Validation,
+        ContractError::AttestationExpired => ErrorCategory::Transient,
+        ContractError::UnattestedWasm => ErrorCategory::Permanent,
+        ContractError::InvalidBatchSize => ErrorCategory::Validation,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,16 +19,19 @@ pub use version::Version;
 
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Vec};
 
+use crate::batch::BatchConfig;
 use crate::storage::{
-    add_to_index, get_admin, get_cooldown as storage_get_cooldown, get_count, get_index,
-    get_last_upgrade, get_record, get_registered_paginated_internal, get_role as storage_get_role,
-    get_stats as read_stats, get_verified_count as storage_get_verified_count,
-    get_version as storage_get_version, has_record, is_admin_caller, is_in_cooldown,
+    add_to_index, extend_record_ttl, get_admin, get_cooldown as storage_get_cooldown, get_count,
+    get_index, get_last_upgrade, get_record, get_registered_paginated_internal,
+    get_role as storage_get_role, get_stats as read_stats, get_verified_count as storage_get_verified_count,
+    get_version as storage_get_version, get_wasm_attestation, get_wasm_provenance,
+    has_record, has_role_or_admin, is_admin_caller, is_in_cooldown,
     is_paused as storage_is_paused, remove_from_index, remove_record,
-    remove_role as storage_remove_role, require_initialized, require_not_paused,
-    set_cooldown as storage_set_cooldown, set_count, set_last_action, set_last_upgrade,
-    set_paused as set_paused_state, set_record, set_role as storage_set_role, set_verified_count,
-    set_version, ADMIN_KEY,
+    remove_role as storage_remove_role, remove_wasm_attestation, require_initialized,
+    require_not_paused, set_cooldown as storage_set_cooldown, set_count, set_last_action,
+    set_last_upgrade, set_paused as set_paused_state, set_record, set_role as storage_set_role,
+    set_verified_count, set_version, set_wasm_attestation, set_wasm_provenance, WasmAttestation,
+    WasmProvenance, ADMIN_KEY,
 };
 use crate::utils::{eq_ignore_ascii_case, is_valid_github_username, MAX_USERNAME_LEN};
 
@@ -252,7 +255,7 @@ impl TrustBridgeContract {
         // update_current_contract_wasm the code answering these questions is
         // the new binary, and the record of what it replaced would be lost.
         let previous_wasm_hash = get_wasm_provenance(&env).map(|p| p.wasm_hash);
-        let version = storage_get_version(&env);
+        let version = storage_get_version(&env).unwrap_or_else(|| CONTRACT_VERSION.to_tuple());
 
         set_wasm_provenance(
             &env,
@@ -369,7 +372,7 @@ impl TrustBridgeContract {
         if require_initialized(&env).is_err() {
             return CONTRACT_VERSION.to_tuple();
         }
-        storage_get_version(&env)
+        storage_get_version(&env).unwrap_or_else(|| CONTRACT_VERSION.to_tuple())
     }
 
     /// Reports whether the deployed contract satisfies a client's minimum
@@ -645,8 +648,11 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Marks a contributor as verified after an off-chain GitHub identity check. Admin-only.
-    pub fn verify(env: Env, github_username: String) -> Result<(), ContractError> {
+    /// Marks a contributor as verified after an off-chain GitHub identity check.
+    ///
+    /// Callable by the contract admin **or** any address assigned the
+    /// `Role::Verifier` role (Issue #12 — verifier role separation).
+    pub fn verify(env: Env, caller: Address, github_username: String) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
 
@@ -1245,6 +1251,10 @@ mod test {
         });
     }
 
+    /// Issue #57: `verify` on a username with no registration fails closed
+    /// with `NotRegistered` instead of creating a verified record out of
+    /// nothing. Documented alongside the matching integration coverage in
+    /// `tests/integration.rs` and the error table in `docs/ABI.md`.
     #[test]
     fn test_verify_missing_registration_fails() {
         let env = Env::default();
@@ -1252,6 +1262,21 @@ mod test {
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
             let result = TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "missing"));
+            assert_eq!(result, Err(ContractError::NotRegistered));
+        });
+    }
+
+    /// Same not-registered guard on the other verification-mutating entry
+    /// point, so `verify` and `revoke_verification` stay consistent (Issue
+    /// #57).
+    #[test]
+    fn test_revoke_verification_missing_registration_fails() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            let result =
+                TrustBridgeContract::revoke_verification(env.clone(), admin.clone(), username(&env, "missing"));
             assert_eq!(result, Err(ContractError::NotRegistered));
         });
     }
@@ -1721,6 +1746,10 @@ mod test {
         });
     }
 
+    // Issue #53: every variant's numeric repr must match the table in
+    // error.rs, and stay in sync as new variants are added — a variant
+    // renumbered or added without a matching entry here breaks silently for
+    // off-chain consumers that decode raw u32 codes.
     #[test]
     fn test_error_codes_match_repr() {
         assert_eq!(ContractError::AlreadyInitialized.code(), 1);
@@ -1734,6 +1763,9 @@ mod test {
         assert_eq!(ContractError::InvalidVersion.code(), 9);
         assert_eq!(ContractError::InvalidRole.code(), 10);
         assert_eq!(ContractError::InvalidUsername.code(), 11);
+        assert_eq!(ContractError::AttestationExpired.code(), 12);
+        assert_eq!(ContractError::UnattestedWasm.code(), 13);
+        assert_eq!(ContractError::InvalidBatchSize.code(), 14);
     }
 
     #[test]
@@ -1750,11 +1782,17 @@ mod test {
             ContractError::InvalidVersion,
             ContractError::InvalidRole,
             ContractError::InvalidUsername,
+            ContractError::AttestationExpired,
+            ContractError::UnattestedWasm,
+            ContractError::InvalidBatchSize,
         ] {
             assert_eq!(ContractError::from_code(variant.code()), Some(variant));
         }
         assert_eq!(ContractError::from_code(0), None);
-        assert_eq!(ContractError::from_code(12), None);
+        // 15 is one past the highest assigned variant (InvalidBatchSize = 14):
+        // the first code guaranteed not to collide with a real variant as the
+        // enum grows, unlike a fixed gap in the middle of the table.
+        assert_eq!(ContractError::from_code(15), None);
     }
 
     // --- Issue #69: max username length guard ---
@@ -1973,6 +2011,60 @@ mod test {
         assert!(client.has_record(&name));
     }
 
+    // ── Issue #56: unauthorized remove must not disturb registry events ──────
+
+    #[test]
+    fn test_unauthorized_remove_leaves_verified_record_and_events_intact() {
+        let env = Env::default();
+        let (admin, user, other, contract_id) = setup(&env);
+        let client = TrustBridgeContractClient::new(&env, &contract_id);
+        let name = username(&env, "octocat");
+
+        env.mock_all_auths();
+        client.register(&name, &user);
+        env.mock_all_auths();
+        client.verify(&admin, &name);
+
+        // Neither the registrant nor the admin: rejected, and must leave the
+        // registration, its verified flag, and the event log untouched. `all()`
+        // scopes to the last invocation, so an empty result here proves the
+        // failed call published no RemovedEvent (same idiom as
+        // test_removed_event_not_published_on_failed_remove).
+        assert!(client.try_remove(&other, &name).is_err());
+        assert_eq!(
+            env.events().all(),
+            soroban_sdk::vec![&env],
+            "unauthorized remove must not publish a RemovedEvent"
+        );
+        let record = client.get_address(&name).unwrap();
+        assert!(record.verified, "unauthorized remove must not clear verification");
+        assert_eq!(client.get_stats().verified, 1);
+    }
+
+    #[test]
+    fn test_unauthorized_remove_after_revoke_leaves_events_intact() {
+        let env = Env::default();
+        let (admin, user, other, contract_id) = setup(&env);
+        let client = TrustBridgeContractClient::new(&env, &contract_id);
+        let name = username(&env, "octocat");
+
+        env.mock_all_auths();
+        client.register(&name, &user);
+        env.mock_all_auths();
+        client.verify(&admin, &name);
+        env.mock_all_auths();
+        client.revoke_verification(&admin, &name);
+
+        assert!(client.try_remove(&other, &name).is_err());
+        assert_eq!(
+            env.events().all(),
+            soroban_sdk::vec![&env],
+            "unauthorized remove must not publish a RemovedEvent after a prior revoke"
+        );
+        assert!(client.has_record(&name));
+        assert_eq!(client.get_stats().total, 1);
+    }
+
     // ── Pause / unpause workflow ──────────────────────────────────────────────
 
     #[test]
@@ -2126,23 +2218,7 @@ mod test {
         });
     }
 
-    // ── Error codes ───────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_error_codes_match_repr() {
-        assert_eq!(ContractError::AlreadyInitialized.code(), 1);
-        assert_eq!(ContractError::NotInitialized.code(), 2);
-        assert_eq!(ContractError::NotAuthorized.code(), 3);
-        assert_eq!(ContractError::NotRegistered.code(), 4);
-        assert_eq!(ContractError::AlreadyVerified.code(), 5);
-        assert_eq!(ContractError::NotVerified.code(), 6);
-        assert_eq!(ContractError::Paused.code(), 7);
-        assert_eq!(ContractError::CooldownActive.code(), 8);
-        assert_eq!(ContractError::InvalidVersion.code(), 9);
-        assert_eq!(ContractError::InvalidRole.code(), 10);
-    }
-
-    // ── Issue #16: from_code round-trip and completeness ─────────────────────
+    // ── Issue #16 / #53: from_code round-trip and completeness ───────────────
 
     /// Every variant's code() must round-trip through from_code() (Issue #16).
     #[test]
@@ -2158,6 +2234,10 @@ mod test {
             ContractError::CooldownActive,
             ContractError::InvalidVersion,
             ContractError::InvalidRole,
+            ContractError::InvalidUsername,
+            ContractError::AttestationExpired,
+            ContractError::UnattestedWasm,
+            ContractError::InvalidBatchSize,
         ];
         for variant in all {
             assert_eq!(
@@ -2174,7 +2254,7 @@ mod test {
     #[test]
     fn test_from_code_unknown_returns_none() {
         assert_eq!(ContractError::from_code(0), None);
-        assert_eq!(ContractError::from_code(11), None);
+        assert_eq!(ContractError::from_code(15), None);
         assert_eq!(ContractError::from_code(u32::MAX), None);
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -15,41 +15,16 @@ pub const LAST_UPG_KEY: Symbol = symbol_short!("lastupg");
 pub const VER_KEY: Symbol = symbol_short!("ver");
 pub const ROLE_KEY: Symbol = symbol_short!("role");
 pub const CHUNK_KEY: Symbol = symbol_short!("chunk");
-pub const CHUNK_CNT_KEY: Symbol = symbol_short!("chunkcnt");
+pub const CHUNK_CNT_KEY: Symbol = symbol_short!("chkcnt");
 pub const LAST_ACT_KEY: Symbol = symbol_short!("lastact");
-
-/// Entries per index chunk. Keeps a single chunk read well under the ledger
-/// entry size limit while still amortising reads across pages.
-pub const CHUNK_SIZE: u32 = 100;
-
-/// Page size used when a caller passes `limit = 0`.
-pub const DEFAULT_PAGE_LIMIT: u32 = 50;
-/// Upper bound on a single export page, to keep the response under the
-/// transaction result size limit.
-pub const MAX_PAGE_LIMIT: u32 = 200;
-
-/// Persistent entries are bumped when their remaining TTL drops below this.
-pub const TTL_THRESHOLD: u32 = 100_000;
-/// Ledgers of TTL to restore on bump (~60 days at 5s ledgers).
-pub const TTL_BUMP: u32 = 1_000_000;
+/// Key for the WASM provenance record (Wave #24).
+pub const PROV_KEY: Symbol = symbol_short!("prov");
+/// Key for the pending upgrade attestation (Wave #24).
+pub const ATTEST_KEY: Symbol = symbol_short!("attest");
 
 /// Key for the version stored at `storage::get_version` / `set_version`.
 /// Aliased as VERSION_KEY for callers that use that name.
 pub const VERSION_KEY: Symbol = VER_KEY;
-
-/// Key prefix for chunked username index entries.
-pub const CHUNK_KEY: Symbol = symbol_short!("chunk");
-/// Key for the count of chunks in the chunked index.
-pub const CHUNK_CNT_KEY: Symbol = symbol_short!("chkcnt");
-/// Key for the per-user last-action timestamp (cooldown tracking).
-pub const LAST_ACT_KEY: Symbol = symbol_short!("lastact");
-
-// ── TTL constants (ledger-based, ~7 days at 5 s/ledger) ─────────────────────
-
-/// Minimum TTL threshold before a bump is triggered (≈ 3 days).
-pub const TTL_THRESHOLD: u32 = 51840;
-/// Target TTL after a bump (≈ 7 days).
-pub const TTL_BUMP: u32 = 120960;
 
 // ── Pagination constants ─────────────────────────────────────────────────────
 
@@ -190,6 +165,33 @@ pub fn get_admin(env: &Env) -> Result<Address, ContractError> {
         .ok_or(ContractError::NotInitialized)
 }
 
+/// Returns the stored contract version, or `None` on an instance initialized
+/// before version tracking was added.
+pub fn get_version(env: &Env) -> Option<(u32, u32, u32)> {
+    env.storage().instance().get(&VERSION_KEY)
+}
+
+pub fn set_version(env: &Env, version: (u32, u32, u32)) {
+    env.storage().instance().set(&VERSION_KEY, &version);
+}
+
+pub fn is_paused(env: &Env) -> bool {
+    env.storage().instance().get(&PAUSED_KEY).unwrap_or(false)
+}
+
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage().instance().set(&PAUSED_KEY, &paused);
+}
+
+/// Rejects the call while the contract is paused.
+pub fn require_not_paused(env: &Env) -> Result<(), ContractError> {
+    if is_paused(env) {
+        Err(ContractError::Paused)
+    } else {
+        Ok(())
+    }
+}
+
 pub fn get_record(env: &Env, github_username: &String) -> Option<ContributorRecord> {
     let key = (REG_KEY, github_username.clone());
     let record: Option<ContributorRecord> = env.storage().persistent().get(&key);
@@ -264,19 +266,6 @@ pub fn get_index(env: &Env) -> Vec<String> {
 
 pub fn set_index(env: &Env, index: &Vec<String>) {
     env.storage().instance().set(&INDEX_KEY, index);
-}
-
-/// Returns a page of usernames from the flat index starting at `offset`.
-pub fn get_index_page(env: &Env, offset: u32, limit: u32) -> Vec<String> {
-    let index = get_index(env);
-    let mut page = Vec::new(env);
-    let end = (offset.saturating_add(limit)).min(index.len());
-    for i in offset..end {
-        if let Some(u) = index.get(i) {
-            page.push_back(u);
-        }
-    }
-    page
 }
 
 // ── Chunked username index ───────────────────────────────────────────────────
@@ -563,39 +552,6 @@ pub fn remove_role(env: &Env, address: &Address) {
 /// True when `address` is the contract admin.
 pub fn is_admin_caller(env: &Env, address: &Address) -> bool {
     matches!(get_admin(env), Ok(admin) if admin == *address)
-}
-
-/// Timestamp of `github_username`'s last cooldown-tracked action, or 0 if it
-/// has none. Cooldown is tracked per username rather than globally so one
-/// contributor's activity cannot block everyone else's.
-pub fn get_last_action(env: &Env, github_username: &String) -> u64 {
-    env.storage()
-        .persistent()
-        .get(&(LAST_ACT_KEY, github_username.clone()))
-        .unwrap_or(0)
-}
-
-pub fn set_last_action(env: &Env, github_username: &String, timestamp: u64) {
-    let key = (LAST_ACT_KEY, github_username.clone());
-    env.storage().persistent().set(&key, &timestamp);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
-}
-
-/// True when the configured cooldown has not yet elapsed since
-/// `github_username`'s last tracked action. A cooldown of 0 disables the
-/// check entirely.
-pub fn is_in_cooldown(env: &Env, github_username: &String) -> bool {
-    let cooldown = get_cooldown(env);
-    if cooldown == 0 {
-        return false;
-    }
-    let last = get_last_action(env, github_username);
-    if last == 0 {
-        return false;
-    }
-    env.ledger().timestamp() < last.saturating_add(cooldown)
 }
 
 #[allow(dead_code)] // Staged for role-gated entry points; covered by role tests.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,6 +17,7 @@ pub const MAX_USERNAME_LEN: u32 = 39;
 /// Stack buffer size for username copies. Sized above `MAX_USERNAME_LEN`, so
 /// an over-long username is rejected on length before it is ever read.
 const USERNAME_BUF: usize = 64;
+const USERNAME_BUF_LEN: usize = USERNAME_BUF;
 
 /// Copies a username into a fixed stack buffer.
 ///

--- a/src/version.rs
+++ b/src/version.rs
@@ -27,6 +27,24 @@ pub struct Version {
 /// since a contract deployed at 1.0.0 will reject the invocation outright.
 pub const BATCH_VERIFY_MIN_VERSION: Version = Version::new(1, 1, 0);
 
+/// First contract version whose public read functions (`get_address`,
+/// `has_record`, `get_public_paginated`, `get_stats`, `get_verified_count`,
+/// `get_role`, `version`/`is_compatible`, …) are safe for a sibling contract
+/// to call cross-contract (Wave issue #149).
+///
+/// The read surface those functions expose has been stable since the
+/// contract's initial release, so this is 1.0.0 rather than a forward-looking
+/// gate like [`BATCH_VERIFY_MIN_VERSION`] — it exists so a consuming contract
+/// can assert compatibility the same way it does for `batch_verify`, instead
+/// of special-casing "assume reads always work."
+///
+/// Admin-gated exports (`get_all_registered`, `get_registered_page`,
+/// `get_registered_paginated`) are deliberately excluded: they call
+/// `admin.require_auth()`, and a cross-contract invocation cannot supply the
+/// registry admin's signature, so they are not part of this surface at any
+/// version. See `docs/ABI.md` § Cross-Contract Read Interface.
+pub const CROSS_CONTRACT_READ_MIN_VERSION: Version = Version::new(1, 0, 0);
+
 impl Version {
     /// Create a new version.
     pub const fn new(major: u32, minor: u32, patch: u32) -> Self {
@@ -43,6 +61,12 @@ impl Version {
     /// `verify` calls without probing the contract and interpreting a failure.
     pub fn supports_batch_verify(&self) -> bool {
         self.is_compatible_with(BATCH_VERIFY_MIN_VERSION)
+    }
+
+    /// Whether this version's public read functions are safe to call
+    /// cross-contract. See [`CROSS_CONTRACT_READ_MIN_VERSION`].
+    pub fn supports_cross_contract_reads(&self) -> bool {
+        self.is_compatible_with(CROSS_CONTRACT_READ_MIN_VERSION)
     }
 
     /// Parse a version from a tuple (used for storage).

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -864,3 +864,39 @@ fn test_integration_stats_verified_matches_verified_count() {
     });
     check(&env, &contract_id);
 }
+
+// ── Issue #57: verify() on a not-registered username ──────────────────────────
+
+/// `verify` on a username with no registration returns `NotRegistered` and
+/// leaves the registry untouched — the not-registered path must fail closed
+/// rather than silently creating a verified record.
+#[test]
+fn test_integration_verify_not_registered_fails_and_leaves_registry_untouched() {
+    let (env, admin, _user1, _user2, contract_id) = setup_test_env();
+
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        let result = TrustBridgeContract::verify(env.clone(), admin.clone(), s(&env, "ghost"));
+        assert_eq!(result, Err(ContractError::NotRegistered));
+    });
+
+    env.as_contract(&contract_id, || {
+        assert!(TrustBridgeContract::get_address(env.clone(), s(&env, "ghost")).is_none());
+        assert_eq!(TrustBridgeContract::get_verified_count(env.clone()), 0);
+        assert_eq!(TrustBridgeContract::get_stats(env.clone()).total, 0);
+    });
+}
+
+/// The same guard holds for `revoke_verification` on a not-registered
+/// username, so the two verification-mutating entry points stay consistent.
+#[test]
+fn test_integration_revoke_verification_not_registered_fails() {
+    let (env, admin, _user1, _user2, contract_id) = setup_test_env();
+
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        let result =
+            TrustBridgeContract::revoke_verification(env.clone(), admin.clone(), s(&env, "ghost"));
+        assert_eq!(result, Err(ContractError::NotRegistered));
+    });
+}


### PR DESCRIPTION
## Summary

Main was broken before this PR — the last few merges (`bd97989`, `4148ab7`) left `src/storage.rs` with duplicate consts/functions and several symbols referenced from `src/lib.rs` (`PROV_KEY`, `ATTEST_KEY`, `get_version`, `set_version`, `is_paused`, `set_paused`, `require_not_paused`, three `ContractError` variants) that were never defined, plus `verify()` missing its `caller` parameter and a duplicate test function name. `cargo check` failed with 48 errors. Fixing that was a prerequisite for the tests these issues ask for, so it's included here rather than as a separate PR.

With the build repaired, this addresses:

- **Closes #53** — completed and de-duplicated the error-repr alignment tests (`test_error_codes_match_repr`, `test_error_from_code_is_inverse_of_code`, `test_from_code_round_trips_all_variants`, `test_from_code_unknown_returns_none`) so every `ContractError` variant is covered, including the ones restored by the build fix.
- **Closes #56** — added tests proving an unauthorized `remove()` call leaves the Registered/Verified/Revoked event history and registry state untouched: no `RemovedEvent` is published, and the verified flag/stats survive the rejected call.
- **Closes #57** — added a unit + integration test pair for `verify()`/`revoke_verification()` on a not-registered username, and fixed the stale (pre-caller-param) `verify`/`revoke_verification` signatures documented in `docs/ABI.md` and `README.md`.
- **Closes #149** — documented the cross-contract read interface in `docs/ABI.md` and `docs/ARCHITECTURE.md`: which existing public read functions are safe for a sibling contract to call via `env.invoke_contract`, and why the admin-gated exports are excluded (a cross-contract call can't supply the registry admin's signature). Added `Version::supports_cross_contract_reads()` alongside the existing `supports_batch_verify()` pattern in `src/version.rs`.

## Test plan

- [x] `cargo test` — 108 lib tests + 25 integration tests, all passing
- [x] `cargo check` — clean
- [x] `cargo build --target wasm32v1-none --release` — clean

```
test result: ok. 108 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
