### PR TITLE
feat(contract-ops): registry export/import CLI, revoke_verification doc parity, indexer idempotency spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,18 @@ ADMIN       ?= $(shell $(STELLAR) keys address $(SOURCE) 2>/dev/null || echo "")
 CONTRACT_ID ?=
 GITHUB_USER ?=
 STELLAR_ADDR ?=
+CALLER      ?=
 BENCH_OUT   ?= bench-results.txt
 NORM_BENCH_OUT ?= bench-username-normalization.txt
 BINDINGS_DIR ?= bindings/typescript
 PKG_MANAGER  ?= pnpm
+EXPORT_FILE ?= registry-export-$(NETWORK).json
+ADMIN_SOURCE ?=
 
 .PHONY: help build build-legacy test fuzz bench bench-export bench-username fmt lint check ci clean \
         deploy-testnet deploy-mainnet bindings bindings-build invoke-version require-contract-id \
-        invoke-register invoke-lookup invoke-init invoke-stats install-target invoke-extend-ttl
+        invoke-register invoke-lookup invoke-init invoke-stats install-target invoke-extend-ttl \
+        export-registry validate-registry
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
@@ -132,21 +136,21 @@ invoke-stats: require-contract-id ## Read registry statistics (read-only)
 		--network $(NETWORK) \
 		-- get_stats
 
-invoke-verify: ## Mark a contributor as verified (admin-only) (GITHUB_USER, SOURCE=admin, CONTRACT_ID)
+invoke-verify: ## Mark a contributor as verified (admin or Verifier-role) (CALLER, GITHUB_USER, SOURCE, CONTRACT_ID)
 	$(STELLAR) contract invoke \
 		--id $(CONTRACT_ID) \
 		--source-account $(SOURCE) \
 		--network $(NETWORK) \
 		--send=yes \
-		-- verify --github-username $(GITHUB_USER)
+		-- verify --caller $(CALLER) --github-username $(GITHUB_USER)
 
-invoke-revoke-verification: ## Revoke contributor verification (admin-only) (GITHUB_USER, SOURCE=admin, CONTRACT_ID)
+invoke-revoke-verification: ## Revoke contributor verification (admin or Verifier-role) (CALLER, GITHUB_USER, SOURCE, CONTRACT_ID)
 	$(STELLAR) contract invoke \
 		--id $(CONTRACT_ID) \
 		--source-account $(SOURCE) \
 		--network $(NETWORK) \
 		--send=yes \
-		-- revoke_verification --github-username $(GITHUB_USER)
+		-- revoke_verification --caller $(CALLER) --github-username $(GITHUB_USER)
 
 invoke-get-all-registered: ## Export full registry mapping (admin-only) (SOURCE=admin, CONTRACT_ID)
 	$(STELLAR) contract invoke \
@@ -184,3 +188,9 @@ invoke-set-paused: ## Toggle contract pause state (PAUSED, SOURCE=admin, CONTRAC
 		--network $(NETWORK) \
 		--send=yes \
 		-- set_paused --paused $(PAUSED)
+
+export-registry: require-contract-id ## Export full registry to JSON (admin) — see docs/DEPLOYMENT.md#registry-export--import (SOURCE=admin, CONTRACT_ID, EXPORT_FILE)
+	CONTRACT_ID=$(CONTRACT_ID) SOURCE=$(SOURCE) NETWORK=$(NETWORK) OUTPUT_FILE=$(EXPORT_FILE) ./scripts/export_registry.sh
+
+validate-registry: require-contract-id ## Validate a registry export JSON against live state, no writes (CONTRACT_ID, EXPORT_FILE, ADMIN_SOURCE=admin for full diff)
+	CONTRACT_ID=$(CONTRACT_ID) SOURCE=$(SOURCE) ADMIN_SOURCE=$(ADMIN_SOURCE) NETWORK=$(NETWORK) ./scripts/validate_registry.sh $(EXPORT_FILE)

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ This contract provides that mapping **on-chain**:
 - `register` — map GitHub username → Stellar address (requires address auth)
 - `get_address` — read-only lookup
 - `remove` — self-service or admin removal
-- `verify` — admin marks contributor as GitHub-verified
-- `revoke_verification` — admin revokes verified status
+- `verify` — admin or `Verifier`-role holder marks contributor as GitHub-verified
+- `revoke_verification` — admin or `Verifier`-role holder revokes verified status
 - `get_all_registered` — admin-only full export for dashboard sync
+- `scripts/export_registry.sh` / `scripts/validate_registry.sh` — CLI export to JSON and validate-only diff against live state (see [Registry Export & Import](docs/DEPLOYMENT.md#registry-export--import))
 - `get_stats` — total and verified registration counts
 - `pause` / `unpause` / `is_paused` — emergency circuit breaker to pause mutating contract state
 - `set_role` / `remove_role` / `get_role` — Role-Based Access Control (`Admin`, `Upgrader`, `Verifier`)
@@ -251,8 +252,8 @@ More examples (verify, remove, admin export): [docs/ABI.md](docs/ABI.md)
 | `get_address(github_username)` | None | ❌ | Lookup by username |
 | `remove(caller, github_username)` | `caller` (registrant or admin) | ✅ | Remove a registration |
 | `get_all_registered()` | Admin | ❌ | Export full registry |
-| `verify(github_username)` | Admin | ✅ | Mark as GitHub-verified |
-| `revoke_verification(github_username)` | Admin | ✅ | Clear a verification |
+| `verify(caller, github_username)` | Admin **or** `Verifier`-role | ✅ | Mark as GitHub-verified |
+| `revoke_verification(caller, github_username)` | Admin **or** `Verifier`-role | ✅ | Clear a verification |
 | `get_verified_count()` | None | ❌ | Verified registration count |
 | `get_stats()` | None | ❌ | `{ total, verified }` |
 | `version()` | None | ❌ | Deployed version as `(major, minor, patch)` |

--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -266,9 +266,13 @@ stellar contract invoke --id $ID --source admin --network testnet \
   -- get_all_registered
 ```
 
+For a repeatable JSON export (backups, dashboard migrations, audit
+snapshots) that pages through `get_registered_paginated` instead of this
+single-call export, see [Registry Export & Import](DEPLOYMENT.md#registry-export--import).
+
 ---
 
-### `verify(github_username: String) -> Result<(), ContractError>`
+### `verify(caller: Address, github_username: String) -> Result<(), ContractError>`
 
 Mark a contributor as verified after off-chain GitHub identity confirmation.
 
@@ -339,7 +343,7 @@ stellar contract invoke --id $ID --source admin --network testnet --send=yes \
 
 ---
 
-### `revoke_verification(github_username: String) -> Result<(), ContractError>`
+### `revoke_verification(caller: Address, github_username: String) -> Result<(), ContractError>`
 
 Revoke verification for a registered contributor.
 
@@ -553,6 +557,11 @@ Updates the contract schema version following a WASM upgrade. Target version mus
 ## Events
 
 All events are defined with `#[contractevent]` and include a topic field for filtering.
+
+For idempotent handling of these events by indexers — replays, gaps, and
+duplicate deliveries of `RegisteredEvent` / `VerifiedEvent` /
+`VerificationRevokedEvent` / `RemovedEvent` — see
+[DASHBOARD_SYNC.md — Event Idempotency & Replay Handling](DASHBOARD_SYNC.md#event-idempotency--replay-handling).
 
 ### RegisteredEvent
 

--- a/docs/DASHBOARD_SYNC.md
+++ b/docs/DASHBOARD_SYNC.md
@@ -35,3 +35,98 @@ instead when syncing incrementally — it walks the same admin-gated index but
 in bounded chunks, so a dashboard/indexer sync job can page through without
 risking a resource-limit failure on a large registry. See
 `test_get_registered_page_paginates_and_gates_on_admin` in `src/lib.rs`.
+
+## Event Idempotency & Replay Handling
+
+Issue #135: Horizon/RPC replays and worker retries are normal operating conditions, not
+failure modes. An indexer that treats every delivery as new will double-count
+registrations or resurrect a contributor after they were removed. This
+section is the spec for handling replays, gaps, and duplicate deliveries of
+`RegisteredEvent`, `VerifiedEvent`, `VerificationRevokedEvent`, and
+`RemovedEvent` without corrupting off-chain state.
+
+### Idempotency key
+
+None of the contract's events carry a sequence number in their payload — see
+`src/events.rs`. The payload alone (`github_username`, `stellar_address`,
+`timestamp`) is not unique: the same contributor can be registered, removed,
+and re-registered, producing multiple `RegisteredEvent`s with the same topic.
+
+The uniqueness comes from the delivery envelope Horizon/RPC attaches to every
+event, not from the contract payload. Key every stored event on:
+
+```
+(github_username, event_type, ledger_sequence, tx_hash)
+```
+
+- `event_type` — the event's topic symbol (`registered_event`,
+  `verified_event`, `verification_revoked_event`, `removed_event`, …)
+- `ledger_sequence` — the ledger the event was emitted in; also the ordering
+  key (see "Out-of-order handling" below)
+- `tx_hash` — the transaction hash that emitted it; distinguishes two events
+  of the same type for the same username emitted in different transactions
+  within the same ledger
+
+`(ledger_sequence, tx_hash)` alone is sufficient to deduplicate a single
+delivery; `github_username` and `event_type` are included so a lookup by
+contributor doesn't require a join back to raw envelope data.
+
+### Event → action → duplicate handling
+
+| Event | Expected indexer action | Duplicate delivery |
+|-------|--------------------------|---------------------|
+| `RegisteredEvent` | Upsert `(github_username → stellar_address)`; reset local `verified` to `false` unless a `VerifiedEvent` for the same `(ledger_sequence, tx_hash)` ordering is already applied | No-op — same key already applied, re-applying the same payload is a harmless overwrite |
+| `VerifiedEvent` | Set local `verified = true` for `github_username` | No-op if the key was already applied; if `verified` is already `true`, applying it again is still a safe overwrite |
+| `VerificationRevokedEvent` | Set local `verified = false` for `github_username` | Same as above — idempotent overwrite |
+| `RemovedEvent` | Delete (or tombstone) the local record for `github_username` | No-op if already deleted/tombstoned |
+
+Applying the same event twice is always safe **provided duplicates are
+detected by key first** — every action above is a last-write-wins overwrite
+on a single field or record, not an increment or counter update. Never
+implement indexer-side counters (e.g. "times verified") by counting event
+occurrences; use `get_stats()` / `get_public_paginated` reads against the
+contract as the source of truth for aggregate counts instead.
+
+### Out-of-order handling
+
+Horizon delivery order is not guaranteed to match ledger order under replay
+or catch-up conditions. Two rules keep out-of-order delivery from producing
+the wrong final state:
+
+1. **Order by `(ledger_sequence, tx_hash-relative-order)` before applying,
+   not by delivery order.** If a `RemovedEvent` and a later `RegisteredEvent`
+   for the same username arrive out of order, applying them in delivery order
+   instead of ledger order can leave the record deleted when it should exist
+   (or vice versa).
+2. **Track the last-applied `ledger_sequence` per `github_username`.** Before
+   applying an event, compare its `ledger_sequence` to the last one recorded
+   for that username. If the incoming event is older, it is a gap-fill or a
+   late replay of something already superseded — record it for audit purposes
+   but do not let it overwrite newer state.
+
+For gaps (a missing ledger range in the delivery stream), reconcile against
+on-chain state directly rather than waiting for the missing event: call
+`get_public_paginated` (or `get_address` for a single username) and treat its
+result as authoritative. The event stream is a change-notification
+optimization; the contract's own storage is always the ground truth.
+
+### Example: duplicate delivery fixture
+
+```json
+{
+  "event_type": "verified_event",
+  "github_username": "octocat",
+  "stellar_address": "GABCDEF...",
+  "timestamp": 1732800000,
+  "ledger_sequence": 1000042,
+  "tx_hash": "a1b2c3..."
+}
+```
+
+A replay test in the sibling indexer repo applies this record twice and
+asserts the local `verified` flag is `true` exactly once — i.e. the second
+apply is detected as a duplicate by `(ledger_sequence, tx_hash)` and produces
+no state change, no duplicate row, and no double count in any aggregate.
+
+See [ABI.md — Events](ABI.md#events) for the full topic/payload reference per
+event type.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -117,6 +117,8 @@ make deploy-mainnet
 | `make invoke-register` | Register a username |
 | `make invoke-lookup` | Read-only lookup |
 | `make invoke-stats` | Read statistics |
+| `make export-registry` | Export the full registry to JSON (see [Registry Export & Import](#registry-export--import)) |
+| `make validate-registry` | Validate an export file against live state, no writes |
 
 Example registration:
 
@@ -145,6 +147,95 @@ INIT=true \
 | `SOURCE` | `default` | Signing identity |
 | `ALIAS` | `trustbridge` | CLI alias for contract ID |
 | `INIT` | `true` | Call `initialize` after deploy |
+
+---
+
+## Registry Export & Import
+
+Two operator scripts cover backups, dashboard migrations, and audit snapshots
+of the registry, without giving up the on-chain data as the source of truth.
+
+### Export (Issue #132)
+
+`scripts/export_registry.sh` pages through the admin-only
+`get_registered_paginated` and writes a single JSON file with a stable schema.
+
+| Variable | Required | Description |
+|----------|----------|--------------|
+| `CONTRACT_ID` | **Yes** | Deployed contract ID |
+| `SOURCE` | **Yes** | Stellar CLI identity of the contract admin — `get_registered_paginated` is admin-gated |
+| `NETWORK` | No | `testnet` (default), `mainnet`, or `futurenet` |
+| `OUTPUT_FILE` | No | Output path (default: `registry-export-<network>.json`) |
+| `PAGE_LIMIT` | No | Records per page (default: `100`, the contract's `MAX_PAGE_LIMIT`) |
+
+```bash
+CONTRACT_ID=$CONTRACT_ID SOURCE=admin NETWORK=testnet ./scripts/export_registry.sh
+# or:
+make export-registry CONTRACT_ID=$CONTRACT_ID SOURCE=admin
+```
+
+The script fails with a clear error and a non-zero exit code if `CONTRACT_ID`,
+`SOURCE`, the Stellar CLI, or `jq` are missing.
+
+**Output schema** (stable field names for dashboard/indexer consumers):
+
+```json
+{
+  "schema_version": 1,
+  "contract_id": "C...",
+  "network": "testnet",
+  "exported_at": "2026-01-01T00:00:00Z",
+  "count": 2,
+  "records": [
+    {
+      "github_username": "octocat",
+      "stellar_address": "G...",
+      "verified": true,
+      "registered_at": 1732800000
+    }
+  ]
+}
+```
+
+### Import / validate (Issue #133)
+
+Import does not bypass on-chain auth. `scripts/validate_registry.sh` never
+writes to the contract — it validates an export file against live state,
+which covers staging restores and migration dry-runs.
+
+| Variable | Required | Description |
+|----------|----------|--------------|
+| `CONTRACT_ID` | **Yes** | Deployed contract ID |
+| `NETWORK` | No | `testnet` (default), `mainnet`, or `futurenet` |
+| `SOURCE` | No | Identity for per-record reads (default: `default`); `get_address` needs no auth, so any funded identity works |
+| `ADMIN_SOURCE` | No | Admin identity; when set, also detects on-chain registrations **missing from** the export via admin-gated `get_registered_paginated` |
+| `PAGE_LIMIT` | No | Records per page for the admin-side check (default: `100`) |
+
+```bash
+CONTRACT_ID=$CONTRACT_ID NETWORK=testnet ./scripts/validate_registry.sh registry-export-testnet.json
+# or, for the full two-way diff:
+make validate-registry CONTRACT_ID=$CONTRACT_ID ADMIN_SOURCE=admin EXPORT_FILE=registry-export-testnet.json
+```
+
+The script reports every mismatch it finds and exits `1` if any are present,
+`0` if the export matches live state exactly, `2` on a usage or config error
+(missing file, malformed JSON, missing `CONTRACT_ID`, etc.):
+
+| Diff type | Meaning |
+|-----------|---------|
+| `MISSING_ONCHAIN` | Export has the username; the contract does not |
+| `ADDRESS_MISMATCH` | `stellar_address` differs between export and chain |
+| `VERIFIED_MISMATCH` | `verified` flag differs between export and chain |
+| `MISSING_FROM_EXPORT` | Contract has the username; the export file does not (`ADMIN_SOURCE` only) |
+
+**Safety warning:** this tool is validate-only by design. It does not replay
+writes. Never use an export file to blindly overwrite mainnet state —
+`register`/`verify`/`revoke_verification` all require the appropriate signer
+to authorize each call individually, so a "replay" is a reviewed, one-by-one
+series of ordinary invocations (e.g. `make invoke-register`), not a bulk
+import. Treat `scripts/validate_registry.sh` output as the checklist for that
+review, run it against testnet first, and never against mainnet without a
+human reading every reported diff.
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -14,7 +14,8 @@ Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [DEPL
 |--------|------------|
 | Impersonation (registering someone else's GitHub username) | `stellar_address.require_auth()` — only the address owner can register |
 | Unauthorized removal | `caller` must auth as registrant or admin |
-| Unauthorized admin actions | `admin.require_auth()` on `verify` and `get_all_registered` |
+| Unauthorized admin-only actions | `admin.require_auth()` on `get_all_registered`, `get_registered_paginated`, `set_role`, `pause`/`unpause` |
+| Unauthorized verification actions | `caller.require_auth()` on `verify` / `revoke_verification`; `caller` must be the admin or hold `Role::Verifier` (checked via `has_role_or_admin`) — any other caller gets `NotAuthorized` |
 | Double initialization | `AlreadyInitialized` error |
 | Malformed or oversized username input | `InvalidUsername` error, checked before auth and before any write |
 | Counter drift from rejected calls | Invariant property fuzzing, see [REGISTRY_INVARIANTS](REGISTRY_INVARIANTS.md) |

--- a/scripts/export_registry.sh
+++ b/scripts/export_registry.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Export the full contributor registry to a JSON file for backups, dashboard
+# migrations, and audit snapshots (Issue #132).
+#
+# Usage:
+#   CONTRACT_ID=C... SOURCE=admin NETWORK=testnet ./scripts/export_registry.sh
+#   CONTRACT_ID=C... SOURCE=admin NETWORK=testnet OUTPUT_FILE=out.json ./scripts/export_registry.sh
+#
+# Environment variables:
+#   CONTRACT_ID  — deployed contract ID (required)
+#   SOURCE       — Stellar CLI identity of the contract admin (required).
+#                  get_registered_paginated is admin-gated, so SOURCE must
+#                  sign as the address that called `initialize`.
+#   NETWORK      — testnet | mainnet | futurenet (default: testnet)
+#   OUTPUT_FILE  — path to write the export JSON (default: registry-export-<network>.json)
+#   PAGE_LIMIT   — records requested per page (default: 100, the contract's MAX_PAGE_LIMIT)
+#
+# Output schema (see docs/DEPLOYMENT.md#registry-export--import):
+#   {
+#     "schema_version": 1,
+#     "contract_id": "C...",
+#     "network": "testnet",
+#     "exported_at": "2026-01-01T00:00:00Z",
+#     "count": 2,
+#     "records": [
+#       { "github_username": "octocat", "stellar_address": "G...",
+#         "verified": true, "registered_at": 1732800000 }
+#     ]
+#   }
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+NETWORK="${NETWORK:-testnet}"
+SOURCE="${SOURCE:-}"
+CONTRACT_ID="${CONTRACT_ID:-}"
+OUTPUT_FILE="${OUTPUT_FILE:-registry-export-${NETWORK}.json}"
+PAGE_LIMIT="${PAGE_LIMIT:-100}"
+STELLAR="${STELLAR:-stellar}"
+
+if [[ -z "$CONTRACT_ID" ]]; then
+  echo "ERROR: CONTRACT_ID must be set to the deployed contract ID (C...)." >&2
+  echo "Example: CONTRACT_ID=C... SOURCE=admin NETWORK=testnet ./scripts/export_registry.sh" >&2
+  exit 1
+fi
+
+if [[ -z "$SOURCE" ]]; then
+  echo "ERROR: SOURCE must be set to the Stellar CLI identity of the contract admin." >&2
+  echo "get_registered_paginated is admin-gated; SOURCE must sign as the registered admin address." >&2
+  exit 1
+fi
+
+if ! command -v "$STELLAR" >/dev/null 2>&1; then
+  echo "ERROR: Stellar CLI ('$STELLAR') not found on PATH." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required to assemble the export JSON." >&2
+  exit 1
+fi
+
+echo "==> Exporting registry from ${CONTRACT_ID} (${NETWORK})" >&2
+
+tmp_records="$(mktemp)"
+trap 'rm -f "$tmp_records"' EXIT
+
+cursor=0
+# Bounds the loop against a stalled cursor (e.g. an RPC hiccup echoing the same
+# page) instead of spinning forever on untrusted network responses.
+max_iterations=100000
+iteration=0
+
+while :; do
+  iteration=$((iteration + 1))
+  if [[ "$iteration" -gt "$max_iterations" ]]; then
+    echo "ERROR: exceeded ${max_iterations} pages without exhausting the index; aborting." >&2
+    exit 1
+  fi
+
+  page="$("$STELLAR" contract invoke \
+    --id "$CONTRACT_ID" \
+    --source-account "$SOURCE" \
+    --network "$NETWORK" \
+    -- get_registered_paginated --cursor "$cursor" --limit "$PAGE_LIMIT")"
+
+  # get_registered_paginated returns:
+  #   { "records": [[username, {stellar_address, registered_at, verified}], ...],
+  #     "next_cursor": <u32> | null, "total": <u32>, "has_more": bool }
+  jq -c '.records[] | {
+      github_username: .[0],
+      stellar_address: .[1].stellar_address,
+      verified: .[1].verified,
+      registered_at: .[1].registered_at
+    }' <<<"$page" >> "$tmp_records"
+
+  has_more="$(jq -r '.has_more' <<<"$page")"
+  next_cursor="$(jq -r '.next_cursor' <<<"$page")"
+
+  if [[ "$has_more" != "true" || "$next_cursor" == "null" ]]; then
+    break
+  fi
+  cursor="$next_cursor"
+done
+
+jq -s \
+  --arg contract_id "$CONTRACT_ID" \
+  --arg network "$NETWORK" \
+  --arg exported_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  '{
+    schema_version: 1,
+    contract_id: $contract_id,
+    network: $network,
+    exported_at: $exported_at,
+    count: length,
+    records: .
+  }' "$tmp_records" > "$OUTPUT_FILE"
+
+echo "==> Wrote $(jq '.count' "$OUTPUT_FILE") record(s) to ${OUTPUT_FILE}" >&2

--- a/scripts/validate_registry.sh
+++ b/scripts/validate_registry.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Validate a registry export JSON file (see scripts/export_registry.sh) against
+# the live on-chain registry (Issue #133).
+#
+# This is a validate-only tool: it never writes to the contract. It is meant
+# for staging restores, migration dry-runs, and catching a stale export before
+# anyone acts on it. Do not use its output to blindly replay writes to
+# mainnet — review every reported mismatch first.
+#
+# Usage:
+#   CONTRACT_ID=C... NETWORK=testnet ./scripts/validate_registry.sh registry-export-testnet.json
+#
+#   # Also check for on-chain registrations missing from the export file
+#   # (requires the admin identity, since that read is admin-gated):
+#   CONTRACT_ID=C... SOURCE=admin NETWORK=testnet ./scripts/validate_registry.sh export.json
+#
+# Environment variables:
+#   CONTRACT_ID  — deployed contract ID (required)
+#   NETWORK      — testnet | mainnet | futurenet (default: testnet)
+#   SOURCE       — Stellar CLI identity used for the per-record checks (default: default).
+#                  Those checks call get_address, which requires no auth, so
+#                  any funded identity works here.
+#   ADMIN_SOURCE — Stellar CLI identity of the contract admin (unset by default).
+#                  When set, additionally detects on-chain records missing from
+#                  the export via the admin-gated get_registered_paginated.
+#                  Kept separate from SOURCE so a plain `make validate-registry`
+#                  never attempts an admin-gated call with a non-admin identity.
+#   PAGE_LIMIT   — records requested per page for the admin-side check (default: 100)
+#
+# Exit status: 0 if the export matches live state, 1 if any mismatch was
+# found, 2 on usage/configuration errors.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+NETWORK="${NETWORK:-testnet}"
+CONTRACT_ID="${CONTRACT_ID:-}"
+SOURCE="${SOURCE:-default}"
+ADMIN_SOURCE="${ADMIN_SOURCE:-}"
+STELLAR="${STELLAR:-stellar}"
+PAGE_LIMIT="${PAGE_LIMIT:-100}"
+
+EXPORT_FILE="${1:-}"
+
+if [[ -z "$EXPORT_FILE" ]]; then
+  echo "Usage: CONTRACT_ID=C... NETWORK=testnet $0 <export.json>" >&2
+  exit 2
+fi
+
+if [[ -z "$CONTRACT_ID" ]]; then
+  echo "ERROR: CONTRACT_ID must be set to the deployed contract ID (C...)." >&2
+  exit 2
+fi
+
+if [[ ! -f "$EXPORT_FILE" ]]; then
+  echo "ERROR: export file not found: $EXPORT_FILE" >&2
+  exit 2
+fi
+
+if ! command -v "$STELLAR" >/dev/null 2>&1; then
+  echo "ERROR: Stellar CLI ('$STELLAR') not found on PATH." >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required to read the export JSON." >&2
+  exit 2
+fi
+
+if ! jq empty "$EXPORT_FILE" >/dev/null 2>&1; then
+  echo "ERROR: $EXPORT_FILE is not valid JSON." >&2
+  exit 2
+fi
+
+if ! jq -e 'has("records") and (.records | type == "array")' "$EXPORT_FILE" >/dev/null 2>&1; then
+  echo "ERROR: $EXPORT_FILE does not match the export schema (expected a top-level \"records\" array)." >&2
+  echo "See docs/DEPLOYMENT.md#registry-export--import for the schema." >&2
+  exit 2
+fi
+
+echo "==> Validating $EXPORT_FILE against ${CONTRACT_ID} (${NETWORK})" >&2
+
+mismatches=0
+record_count="$(jq '.records | length' "$EXPORT_FILE")"
+
+for i in $(seq 0 $((record_count - 1))); do
+  username="$(jq -r ".records[$i].github_username" "$EXPORT_FILE")"
+  exp_address="$(jq -r ".records[$i].stellar_address" "$EXPORT_FILE")"
+  exp_verified="$(jq -r ".records[$i].verified" "$EXPORT_FILE")"
+
+  onchain="$("$STELLAR" contract invoke \
+    --id "$CONTRACT_ID" \
+    --source-account "$SOURCE" \
+    --network "$NETWORK" \
+    -- get_address --github-username "$username" 2>/dev/null || echo null)"
+
+  if [[ "$onchain" == "null" ]]; then
+    echo "MISSING_ONCHAIN    ${username}  (export has ${exp_address}, verified=${exp_verified})"
+    mismatches=$((mismatches + 1))
+    continue
+  fi
+
+  onchain_address="$(jq -r '.stellar_address' <<<"$onchain")"
+  onchain_verified="$(jq -r '.verified' <<<"$onchain")"
+
+  if [[ "$onchain_address" != "$exp_address" ]]; then
+    echo "ADDRESS_MISMATCH   ${username}  export=${exp_address} onchain=${onchain_address}"
+    mismatches=$((mismatches + 1))
+  elif [[ "$onchain_verified" != "$exp_verified" ]]; then
+    echo "VERIFIED_MISMATCH  ${username}  export=${exp_verified} onchain=${onchain_verified}"
+    mismatches=$((mismatches + 1))
+  fi
+done
+
+if [[ -n "$ADMIN_SOURCE" ]]; then
+  echo "==> Checking for on-chain registrations missing from the export (admin read)..." >&2
+
+  onchain_usernames="$(mktemp)"
+  trap 'rm -f "$onchain_usernames"' EXIT
+
+  cursor=0
+  while :; do
+    page="$("$STELLAR" contract invoke \
+      --id "$CONTRACT_ID" \
+      --source-account "$ADMIN_SOURCE" \
+      --network "$NETWORK" \
+      -- get_registered_paginated --cursor "$cursor" --limit "$PAGE_LIMIT")"
+
+    jq -r '.records[][0]' <<<"$page" >> "$onchain_usernames"
+
+    has_more="$(jq -r '.has_more' <<<"$page")"
+    next_cursor="$(jq -r '.next_cursor' <<<"$page")"
+    [[ "$has_more" == "true" && "$next_cursor" != "null" ]] || break
+    cursor="$next_cursor"
+  done
+
+  while IFS= read -r uname; do
+    [[ -z "$uname" ]] && continue
+    if ! jq -e --arg u "$uname" '.records[] | select(.github_username == $u)' "$EXPORT_FILE" >/dev/null; then
+      echo "MISSING_FROM_EXPORT ${uname}"
+      mismatches=$((mismatches + 1))
+    fi
+  done < "$onchain_usernames"
+else
+  echo "==> ADMIN_SOURCE not set — skipping the on-chain-only diff." >&2
+  echo "    Set ADMIN_SOURCE=<admin identity> to also detect registrations missing from the export." >&2
+fi
+
+echo "" >&2
+if [[ "$mismatches" -eq 0 ]]; then
+  echo "OK: export matches live registry (${record_count} record(s) checked)." >&2
+  exit 0
+else
+  echo "FOUND ${mismatches} mismatch(es). Review before using this export for a restore." >&2
+  exit 1
+fi


### PR DESCRIPTION
Solves four ops/documentation issues for `trustbridge-contract`. No contract behavior changed — docs, scripts, and Makefile only.

## #132 — Export registry JSON CLI
- `scripts/export_registry.sh` pages through the admin-gated `get_registered_paginated` and writes a stable-schema JSON export (`github_username`, `stellar_address`, `verified`, `registered_at`).
- `make export-registry CONTRACT_ID=... SOURCE=admin` wraps it.
- Schema, required env vars, and failure behavior documented in `docs/DEPLOYMENT.md#registry-export--import`.

## #133 — Import/validate registry JSON CLI
- `scripts/validate_registry.sh` is validate-only — it never writes to the contract. It diffs an export file against live state per record (`get_address`, no auth needed), and optionally (via `ADMIN_SOURCE`) also detects on-chain records missing from the export (admin-gated `get_registered_paginated`).
- `make validate-registry` wraps it. Exit codes: `0` match, `1` mismatches found, `2` usage/config error.
- Safety warnings (never blind-import to mainnet) documented alongside the schema.

## #134 — README/ABI/SECURITY revoke_verification parity
- `verify`/`revoke_verification` signatures in README and ABI.md were missing the required `caller` argument, and auth was documented as "Admin" only when the code allows admin **or** a `Verifier`-role holder. Fixed in `README.md` and `docs/ABI.md` to match `src/lib.rs`.
- `docs/SECURITY.md`'s threat-model table only mentioned `verify`/`get_all_registered`; added a row for `revoke_verification`'s role-gated auth.
- Found in the same pass: `make invoke-verify` / `make invoke-revoke-verification` were missing `--caller`, which the contract requires — these would have failed if run as documented. Fixed.

## #135 — Indexer event idempotency
- New "Event Idempotency & Replay Handling" section in `docs/DASHBOARD_SYNC.md`: dedupe key (`github_username`, `event_type`, `ledger_sequence`, `tx_hash` — the events themselves carry no sequence number, so this comes from the delivery envelope), an event → action → duplicate-handling table, and out-of-order/gap guidance.
- Linked from `docs/ABI.md`'s Events section.

Closes #132 
Closes #133 
Closes #134
Closes #135


## Verification
- Both new scripts smoke-tested end-to-end against a stubbed `stellar` CLI (pagination, JSON schema, all four diff types: match / address mismatch / missing on-chain / missing from export). `bash -n` clean on both.
- `git diff --stat -- src/ tests/` is empty — no Rust source touched by this PR.

**Note:** `cargo test` / `cargo build` currently fail on `main` independent of this PR (pre-existing duplicate-definition/merge issue in `src/storage.rs` and missing symbols in `src/lib.rs`, unrelated to any of these four issues). Flagging separately; this PR doesn't touch those files.