### PR TITLE
[154] Harden maintainer bulk revoke CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,28 @@ invoke-verify: ## Mark a contributor as verified (admin-only) (GITHUB_USER, SOUR
 		--send=yes \
 		-- verify --github-username $(GITHUB_USER)
 
+BULK_REVOKE_FILE ?= usernames.txt
+BULK_REVOKE_LOG  ?= bulk-revoke-audit.log
+
+bulk-revoke-dry-run: require-contract-id ## Dry-run bulk revoke from BULK_REVOKE_FILE (no transactions submitted)
+	@echo "=== Dry-run bulk revoke from $(BULK_REVOKE_FILE) ==="
+	@bash scripts/bulk_revoke.sh \
+		--file $(BULK_REVOKE_FILE) \
+		--contract $(CONTRACT_ID) \
+		--source $(SOURCE) \
+		--network $(NETWORK) \
+		--dry-run
+
+bulk-revoke: require-contract-id ## Bulk revoke from BULK_REVOKE_FILE with audit log (--yes skips confirm, add CONFIRM=yes for mainnet)
+	@bash scripts/bulk_revoke.sh \
+		--file $(BULK_REVOKE_FILE) \
+		--contract $(CONTRACT_ID) \
+		--source $(SOURCE) \
+		--network $(NETWORK) \
+		--audit-log $(BULK_REVOKE_LOG) \
+		--continue-on-error \
+		$(if $(filter yes,$(CONFIRM)),--yes,)
+
 invoke-revoke-verification: ## Revoke contributor verification (admin-only) (GITHUB_USER, SOURCE=admin, CONTRACT_ID)
 	$(STELLAR) contract invoke \
 		--id $(CONTRACT_ID) \

--- a/docs/ADMIN_RUNBOOK.md
+++ b/docs/ADMIN_RUNBOOK.md
@@ -365,6 +365,85 @@ stellar contract invoke \
 Store the packet in your compliance archive. On-chain events remain the
 append-only source of truth; this export is the operator-facing bundle.
 
+---
+
+## Bulk revoke (incident response)
+
+During a Wave incident requiring multiple revocations, use the bulk revoke CLI instead of
+manual one-by-one invocations. The script adds dry-run mode, confirmation prompts, and an
+audit log so every action is traceable.
+
+### Safety rules
+
+- **NETWORK never defaults to mainnet.** You must pass `--network mainnet` explicitly.
+- **Always dry-run first** to confirm the username list before sending transactions.
+- Failures do not abort the batch when `--continue-on-error` is set; the summary reports
+  per-line results. Without that flag, the script stops on the first error.
+- Audit log lines are emitted to stdout and optionally to a file; retain them for the
+  post-incident audit packet.
+
+### Audit log format
+
+One JSON line per username:
+
+```json
+{"timestamp":"2026-01-01T00:00:00Z","username":"octocat","network":"mainnet","result":"ok","detail":"revoked"}
+```
+
+`result` is one of: `ok`, `error`, `dry-run`.
+
+### Usage
+
+```bash
+# 1. Create a file with one GitHub username per line (blank lines and # comments ignored)
+cat > revoke-list.txt <<'EOF'
+octocat
+some-contributor
+EOF
+
+# 2. Dry-run first (no transactions, no fees)
+make bulk-revoke-dry-run \
+    CONTRACT_ID=C... SOURCE=admin-identity NETWORK=testnet \
+    BULK_REVOKE_FILE=revoke-list.txt
+
+# 3. Execute with audit log
+make bulk-revoke \
+    CONTRACT_ID=C... SOURCE=admin-identity NETWORK=testnet \
+    BULK_REVOKE_FILE=revoke-list.txt BULK_REVOKE_LOG=audit.log
+
+# 4. Mainnet (requires CONFIRM=yes)
+make bulk-revoke \
+    CONTRACT_ID=C... SOURCE=admin-identity NETWORK=mainnet \
+    BULK_REVOKE_FILE=revoke-list.txt BULK_REVOKE_LOG=audit-mainnet.log \
+    CONFIRM=yes
+```
+
+Or call the script directly for full flag control:
+
+```bash
+bash scripts/bulk_revoke.sh \
+    --file revoke-list.txt \
+    --contract $CONTRACT_ID \
+    --source admin-identity \
+    --network mainnet \
+    --dry-run
+
+bash scripts/bulk_revoke.sh \
+    --file revoke-list.txt \
+    --contract $CONTRACT_ID \
+    --source admin-identity \
+    --network mainnet \
+    --yes \
+    --continue-on-error \
+    --audit-log audit-mainnet.log
+```
+
+### Post-bulk-revoke audit
+
+Include `bulk-revoke-audit.log` in the post-incident audit packet alongside the individual
+`get_address` and `get_stats` snapshots described in
+[Post-incident audit export checklist](#post-incident-audit-export-checklist).
+
 ### Tabletop walkthrough (15 minutes)
 
 1. Pick a testnet/futurenet verified username (never rehearse first on mainnet).

--- a/scripts/bulk_revoke.sh
+++ b/scripts/bulk_revoke.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# bulk_revoke.sh — Maintainer bulk revoke_verification CLI
+#
+# Reads GitHub usernames (one per line) from a file and revokes each one.
+# Supports dry-run mode, confirmation prompts, and per-line audit logging.
+#
+# Usage:
+#   ./scripts/bulk_revoke.sh --file usernames.txt \
+#       --contract C... --source admin-identity --network testnet \
+#       [--dry-run] [--yes] [--audit-log audit.log] [--continue-on-error]
+#
+# Required env (or flags):
+#   CONTRACT_ID  — deployed contract C-address
+#   SOURCE       — Stellar CLI identity (must be admin or Verifier)
+#   NETWORK      — testnet | mainnet | futurenet (never defaults to mainnet)
+#
+# Safety rules:
+#   - NETWORK never defaults to mainnet; explicit --network mainnet required.
+#   - Dry-run prints what would run without submitting any transaction.
+#   - Without --yes, prompts for confirmation before sending to mainnet.
+#   - Failures do not abort the batch unless --continue-on-error is omitted.
+#
+# Audit log format (one JSON-like line per username):
+#   {"timestamp":"<ISO-8601>","username":"<u>","network":"<n>","result":"ok|error|dry-run","detail":"<msg>"}
+
+set -euo pipefail
+
+# ---------- defaults ----------
+FILE=""
+CONTRACT_ID="${CONTRACT_ID:-}"
+SOURCE="${SOURCE:-default}"
+NETWORK="${NETWORK:-}"
+DRY_RUN=false
+CONFIRM=false
+CONTINUE_ON_ERROR=false
+AUDIT_LOG=""
+STELLAR="${STELLAR:-stellar}"
+
+usage() {
+    grep '^#' "$0" | sed 's/^# \?//' | grep -v '^!'
+    exit 1
+}
+
+# ---------- arg parse ----------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --file)          FILE="$2";          shift 2 ;;
+        --contract)      CONTRACT_ID="$2";   shift 2 ;;
+        --source)        SOURCE="$2";        shift 2 ;;
+        --network)       NETWORK="$2";       shift 2 ;;
+        --dry-run)       DRY_RUN=true;       shift ;;
+        --yes)           CONFIRM=true;       shift ;;
+        --continue-on-error) CONTINUE_ON_ERROR=true; shift ;;
+        --audit-log)     AUDIT_LOG="$2";     shift 2 ;;
+        -h|--help)       usage ;;
+        *) echo "Unknown flag: $1"; usage ;;
+    esac
+done
+
+# ---------- validation ----------
+[[ -z "$FILE" ]]        && echo "ERROR: --file is required." >&2 && exit 1
+[[ -z "$CONTRACT_ID" ]] && echo "ERROR: --contract (or CONTRACT_ID env) is required." >&2 && exit 1
+[[ -z "$NETWORK" ]]     && echo "ERROR: --network is required (testnet | futurenet | mainnet). Never defaults to mainnet." >&2 && exit 1
+[[ ! -f "$FILE" ]]      && echo "ERROR: file not found: $FILE" >&2 && exit 1
+
+# Explicit mainnet guard: require --yes confirmation
+if [[ "$NETWORK" = "mainnet" && "$DRY_RUN" = false && "$CONFIRM" = false ]]; then
+    echo "WARNING: You are about to bulk-revoke on MAINNET."
+    read -r -p "Type 'yes' to confirm mainnet bulk revoke: " ans
+    [[ "$ans" != "yes" ]] && echo "Aborted." && exit 1
+fi
+
+CALLER=$("$STELLAR" keys address "$SOURCE" 2>/dev/null || echo "")
+[[ -z "$CALLER" ]] && echo "ERROR: could not resolve address for identity '$SOURCE'." >&2 && exit 1
+
+# ---------- helpers ----------
+log_audit() {
+    local username="$1" result="$2" detail="$3"
+    local ts; ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    local line="{\"timestamp\":\"$ts\",\"username\":\"$username\",\"network\":\"$NETWORK\",\"result\":\"$result\",\"detail\":\"$detail\"}"
+    echo "$line"
+    [[ -n "$AUDIT_LOG" ]] && echo "$line" >> "$AUDIT_LOG"
+}
+
+# ---------- main loop ----------
+TOTAL=0; SUCCESS=0; FAILED=0; SKIPPED=0
+
+echo "=== bulk_revoke.sh ==="
+echo "  File:       $FILE"
+echo "  Contract:   $CONTRACT_ID"
+echo "  Network:    $NETWORK"
+echo "  Source:     $SOURCE ($CALLER)"
+echo "  Dry-run:    $DRY_RUN"
+[[ -n "$AUDIT_LOG" ]] && echo "  Audit log:  $AUDIT_LOG"
+echo ""
+
+while IFS= read -r username || [[ -n "$username" ]]; do
+    # skip blank lines and comments
+    [[ -z "$username" || "$username" =~ ^# ]] && continue
+    TOTAL=$((TOTAL + 1))
+
+    if [[ "$DRY_RUN" = true ]]; then
+        echo "[DRY-RUN] would revoke: $username"
+        log_audit "$username" "dry-run" "no transaction submitted"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+
+    echo "Revoking: $username ..."
+    set +e
+    output=$("$STELLAR" contract invoke \
+        --id "$CONTRACT_ID" \
+        --source-account "$SOURCE" \
+        --network "$NETWORK" \
+        --send=yes \
+        -- revoke_verification \
+        --caller "$CALLER" \
+        --github-username "$username" 2>&1)
+    rc=$?
+    set -e
+
+    if [[ $rc -eq 0 ]]; then
+        echo "  OK: $username"
+        log_audit "$username" "ok" "revoked"
+        SUCCESS=$((SUCCESS + 1))
+    else
+        echo "  ERROR: $username — $output" >&2
+        log_audit "$username" "error" "$output"
+        FAILED=$((FAILED + 1))
+        if [[ "$CONTINUE_ON_ERROR" = false ]]; then
+            echo "Stopping batch on first error. Use --continue-on-error to process remaining usernames." >&2
+            break
+        fi
+    fi
+done < "$FILE"
+
+echo ""
+echo "=== Summary ==="
+echo "  Total:    $TOTAL"
+echo "  Success:  $SUCCESS"
+echo "  Failed:   $FAILED"
+echo "  Dry-run:  $SKIPPED"
+[[ -n "$AUDIT_LOG" ]] && echo "  Audit log written to: $AUDIT_LOG"
+
+[[ $FAILED -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
Adds \scripts/bulk_revoke.sh\ with dry-run mode, mainnet confirmation prompt, per-line audit log, and \--continue-on-error\ flag. Adds \make bulk-revoke-dry-run\ and \make bulk-revoke\ Make targets. Documents bulk revoke incident procedure in ADMIN_RUNBOOK.md incident section.

Closes #154

Made with [Cursor](https://cursor.com)