### PR TITLE
[153] Add maintainer bulk verify CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,30 @@ invoke-stats: require-contract-id ## Read registry statistics (read-only)
 		--network $(NETWORK) \
 		-- get_stats
 
+BULK_VERIFY_FILE ?= usernames.txt
+BULK_VERIFY_LOG  ?= bulk-verify-audit.log
+BULK_VERIFY_PACE ?= 500
+
+bulk-verify-dry-run: require-contract-id ## Dry-run bulk verify from BULK_VERIFY_FILE (no transactions submitted)
+	@echo "=== Dry-run bulk verify from $(BULK_VERIFY_FILE) ==="
+	@bash scripts/bulk_verify.sh \
+		--file $(BULK_VERIFY_FILE) \
+		--contract $(CONTRACT_ID) \
+		--source $(SOURCE) \
+		--network $(NETWORK) \
+		--dry-run \
+		--pace-ms $(BULK_VERIFY_PACE)
+
+bulk-verify: require-contract-id ## Bulk verify from BULK_VERIFY_FILE with audit log and pacing
+	@bash scripts/bulk_verify.sh \
+		--file $(BULK_VERIFY_FILE) \
+		--contract $(CONTRACT_ID) \
+		--source $(SOURCE) \
+		--network $(NETWORK) \
+		--audit-log $(BULK_VERIFY_LOG) \
+		--continue-on-error \
+		--pace-ms $(BULK_VERIFY_PACE)
+
 invoke-verify: ## Mark a contributor as verified (admin-only) (GITHUB_USER, SOURCE=admin, CONTRACT_ID)
 	$(STELLAR) contract invoke \
 		--id $(CONTRACT_ID) \

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -172,6 +172,67 @@ change the public contract interface.
 
 ---
 
+## Bulk Verify CLI
+
+During Wave onboarding spikes, manual one-off `verify` calls do not scale. Use
+`scripts/bulk_verify.sh` (or the Make targets) to verify a list of usernames from a file.
+
+### Auth requirements
+
+`SOURCE` must be the admin or hold `Role::Verifier` on the contract. Verify off-chain
+GitHub identity for each username _before_ running the bulk verify.
+
+### Pacing
+
+The default pace is 500 ms between invocations. For large batches (>50 usernames) or when
+hitting HTTP 429 responses, increase `--pace-ms` to 1000–2000 ms.
+
+### Usage
+
+```bash
+# Create a file with one username per line
+echo -e "octocat\nsome-contributor" > usernames.txt
+
+# Dry-run (no transactions, confirm the list)
+make bulk-verify-dry-run CONTRACT_ID=C... SOURCE=admin-identity NETWORK=testnet
+
+# Execute with audit log
+make bulk-verify CONTRACT_ID=C... SOURCE=admin-identity NETWORK=testnet \
+    BULK_VERIFY_FILE=usernames.txt BULK_VERIFY_LOG=verify-audit.log
+
+# Increase pacing for large batches
+make bulk-verify CONTRACT_ID=C... SOURCE=admin-identity NETWORK=testnet \
+    BULK_VERIFY_PACE=1000
+```
+
+Or call the script directly:
+
+```bash
+bash scripts/bulk_verify.sh \
+    --file usernames.txt \
+    --contract $CONTRACT_ID \
+    --source admin-identity \
+    --network testnet \
+    --dry-run
+
+bash scripts/bulk_verify.sh \
+    --file usernames.txt \
+    --contract $CONTRACT_ID \
+    --source admin-identity \
+    --network testnet \
+    --continue-on-error \
+    --pace-ms 500 \
+    --audit-log verify-audit.log
+```
+
+Audit log lines are emitted to stdout and written to `--audit-log` file:
+
+```json
+{"timestamp":"2026-01-01T00:00:00Z","username":"octocat","network":"testnet","result":"ok","detail":"verified"}
+```
+
+---
+
 ## Using the Makefile
 
 | Target | Description |
@@ -184,6 +245,10 @@ change the public contract interface.
 | `make invoke-stats` | Read statistics |
 | `make invoke-verify` | Verify a contributor (admin or verifier role) |
 | `make invoke-revoke-verification` | Revoke verification (admin or verifier role) |
+| `make bulk-verify-dry-run` | Dry-run bulk verify from `BULK_VERIFY_FILE` |
+| `make bulk-verify` | Bulk verify with pacing and audit log |
+| `make bulk-revoke-dry-run` | Dry-run bulk revoke from `BULK_REVOKE_FILE` |
+| `make bulk-revoke` | Bulk revoke with audit log |
 | `make testnet-checklist` | Run the testnet smoke checklist |
 | `make demo-e2e` | Run the cross-repo E2E demo (register → verify → lookup → export) |
 

--- a/scripts/bulk_verify.sh
+++ b/scripts/bulk_verify.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# bulk_verify.sh — Maintainer bulk verify CLI
+#
+# Reads GitHub usernames (one per line) from a file and marks each one as verified.
+# Continues on partial failure and summarises successes/failures.
+# Includes pacing (configurable delay between calls) to avoid RPC throttling.
+#
+# Usage:
+#   ./scripts/bulk_verify.sh --file usernames.txt \
+#       --contract C... --source admin-identity --network testnet \
+#       [--dry-run] [--pace-ms 500] [--audit-log audit.log] [--continue-on-error]
+#
+# Required env (or flags):
+#   CONTRACT_ID  — deployed contract C-address
+#   SOURCE       — Stellar CLI identity (must be admin or Verifier role)
+#   NETWORK      — testnet | futurenet | mainnet (never defaults to mainnet)
+#
+# Auth:
+#   SOURCE must be initialized as admin or hold Role::Verifier on the contract.
+#   See docs/DEPLOYMENT.md for role setup instructions.
+#
+# Pacing:
+#   RPC nodes apply per-IP rate limits. Use --pace-ms (default 500 ms) to insert
+#   a sleep between calls. Increase to 1000–2000 ms for large batches (>50 usernames)
+#   or when hitting HTTP 429 responses.
+#
+# Audit log format (one JSON-like line per username):
+#   {"timestamp":"<ISO-8601>","username":"<u>","network":"<n>","result":"ok|error|dry-run","detail":"<msg>"}
+
+set -euo pipefail
+
+# ---------- defaults ----------
+FILE=""
+CONTRACT_ID="${CONTRACT_ID:-}"
+SOURCE="${SOURCE:-default}"
+NETWORK="${NETWORK:-}"
+DRY_RUN=false
+CONTINUE_ON_ERROR=false
+PACE_MS="${PACE_MS:-500}"
+AUDIT_LOG=""
+STELLAR="${STELLAR:-stellar}"
+
+usage() {
+    grep '^#' "$0" | sed 's/^# \?//' | grep -v '^!'
+    exit 1
+}
+
+# ---------- arg parse ----------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --file)              FILE="$2";              shift 2 ;;
+        --contract)          CONTRACT_ID="$2";       shift 2 ;;
+        --source)            SOURCE="$2";            shift 2 ;;
+        --network)           NETWORK="$2";           shift 2 ;;
+        --dry-run)           DRY_RUN=true;           shift ;;
+        --continue-on-error) CONTINUE_ON_ERROR=true; shift ;;
+        --pace-ms)           PACE_MS="$2";           shift 2 ;;
+        --audit-log)         AUDIT_LOG="$2";         shift 2 ;;
+        -h|--help)           usage ;;
+        *) echo "Unknown flag: $1"; usage ;;
+    esac
+done
+
+# ---------- validation ----------
+[[ -z "$FILE" ]]        && echo "ERROR: --file is required." >&2 && exit 1
+[[ -z "$CONTRACT_ID" ]] && echo "ERROR: --contract (or CONTRACT_ID env) is required." >&2 && exit 1
+[[ -z "$NETWORK" ]]     && echo "ERROR: --network is required (testnet | futurenet | mainnet). Never defaults to mainnet." >&2 && exit 1
+[[ ! -f "$FILE" ]]      && echo "ERROR: file not found: $FILE" >&2 && exit 1
+
+# ---------- helpers ----------
+log_audit() {
+    local username="$1" result="$2" detail="$3"
+    local ts; ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    local line="{\"timestamp\":\"$ts\",\"username\":\"$username\",\"network\":\"$NETWORK\",\"result\":\"$result\",\"detail\":\"$detail\"}"
+    echo "$line"
+    [[ -n "$AUDIT_LOG" ]] && echo "$line" >> "$AUDIT_LOG"
+}
+
+# ---------- main loop ----------
+TOTAL=0; SUCCESS=0; FAILED=0; SKIPPED=0
+PACE_S=$(echo "scale=3; $PACE_MS/1000" | bc 2>/dev/null || echo "0.5")
+
+echo "=== bulk_verify.sh ==="
+echo "  File:       $FILE"
+echo "  Contract:   $CONTRACT_ID"
+echo "  Network:    $NETWORK"
+echo "  Source:     $SOURCE"
+echo "  Dry-run:    $DRY_RUN"
+echo "  Pace:       ${PACE_MS} ms between calls"
+[[ -n "$AUDIT_LOG" ]] && echo "  Audit log:  $AUDIT_LOG"
+echo ""
+
+while IFS= read -r username || [[ -n "$username" ]]; do
+    [[ -z "$username" || "$username" =~ ^# ]] && continue
+    TOTAL=$((TOTAL + 1))
+
+    if [[ "$DRY_RUN" = true ]]; then
+        echo "[DRY-RUN] would verify: $username"
+        log_audit "$username" "dry-run" "no transaction submitted"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+
+    echo "Verifying: $username ..."
+    set +e
+    output=$("$STELLAR" contract invoke \
+        --id "$CONTRACT_ID" \
+        --source-account "$SOURCE" \
+        --network "$NETWORK" \
+        --send=yes \
+        -- verify \
+        --github-username "$username" 2>&1)
+    rc=$?
+    set -e
+
+    if [[ $rc -eq 0 ]]; then
+        echo "  OK: $username"
+        log_audit "$username" "ok" "verified"
+        SUCCESS=$((SUCCESS + 1))
+    else
+        echo "  ERROR: $username — $output" >&2
+        log_audit "$username" "error" "$output"
+        FAILED=$((FAILED + 1))
+        if [[ "$CONTINUE_ON_ERROR" = false ]]; then
+            echo "Stopping batch on first error. Use --continue-on-error to process remaining usernames." >&2
+            break
+        fi
+    fi
+
+    # Pace to avoid RPC throttling
+    [[ $PACE_MS -gt 0 ]] && sleep "$PACE_S"
+done < "$FILE"
+
+echo ""
+echo "=== Summary ==="
+echo "  Total:    $TOTAL"
+echo "  Success:  $SUCCESS"
+echo "  Failed:   $FAILED"
+echo "  Dry-run:  $SKIPPED"
+[[ -n "$AUDIT_LOG" ]] && echo "  Audit log written to: $AUDIT_LOG"
+
+[[ $FAILED -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
Adds \scripts/bulk_verify.sh\ with file input, per-line error reporting, pacing (default 500 ms) to avoid RPC throttling, dry-run mode, and audit log. Adds \make bulk-verify-dry-run\ and \make bulk-verify\ Make targets. Documents admin auth requirements, pacing guidance, and audit log format in DEPLOYMENT.md.

Closes #153

Made with [Cursor](https://cursor.com)