### PR TITLE
feat: implement issues #195, #198, #205, #208

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -83,7 +83,12 @@ enum Role {
 | 12 | `AttestationExpired` | Upgrade attestation's `expires_at` has passed |
 | 13 | `UnattestedWasm` | `upgrade` hash does not match the live attestation |
 | 14 | `InvalidBatchSize` | Batch call supplied zero items or more than the configured max |
-| 15 | `ZeroAddress` | Supplied Stellar address is the well-known zero/burn address |
+| 15 | `InvalidReasonCode` | `revoke_verification` was called with an unrecognized reason code |
+| 16 | `ZeroAddress` | Supplied Stellar address is the well-known zero/burn address |
+| 17 | `AdminTransferPending` | A second propose while one was already pending (reserved) |
+| 18 | `AdminTransferDelayActive` | `execute_admin_transfer` called before the delay elapsed |
+| 19 | `NoPendingAdminTransfer` | `execute_admin_transfer` called with no pending proposal |
+| 20 | `AttestationRequired` | `upgrade` called without attestation when required mode is on |
 
 `ContractError::from_code(u32)` maps every code in this table back to the typed
 variant and returns `None` for any unrecognized code. Every code round-trips
@@ -104,12 +109,10 @@ One-time setup. Stores the admin address and zeroes counters.
 | **Mutates** | Yes |
 | **Errors** | `AlreadyInitialized` |
 
-**Admin immutability (Issue #97).** The admin address set here cannot be
-overwritten or silently replaced afterward: `initialize` is the only entry
-point that writes it, and a second call always fails with
-`AlreadyInitialized`, regardless of which admin address it names. No other
-function in this ABI mutates the admin. There is no on-chain admin-transfer
-API — rotating the admin means deploying a new contract instance. See
+**Admin immutability (Issue #97) and rotation (Issue #195).** The admin address
+set here cannot be overwritten by `initialize` again (a second call always fails
+with `AlreadyInitialized`). Admin rotation is now supported via the two-step
+`propose_admin_transfer` → `execute_admin_transfer` flow — see
 [SECURITY.md § Admin Key Management](SECURITY.md#admin-key-management).
 
 ```bash
@@ -963,6 +966,38 @@ the previous role must track it from the corresponding `RoleGrantedEvent`.
 
 ---
 
+### AdminTransferProposedEvent (Issue #195)
+
+```
+topics: ["admin_transfer_proposed_event", new_admin]
+data:   { proposed_by, executable_at, timestamp }
+```
+
+Emitted when `propose_admin_transfer` is called. `new_admin` is indexed as a
+topic for efficient filtering. `executable_at` is the earliest timestamp at
+which `execute_admin_transfer` may succeed.
+
+### AdminTransferCancelledEvent (Issue #195)
+
+```
+topics: ["admin_transfer_cancelled_event", cancelled_by]
+data:   { timestamp }
+```
+
+Emitted when the current admin cancels a pending transfer proposal.
+
+### AdminTransferExecutedEvent (Issue #195)
+
+```
+topics: ["admin_transfer_executed_event", new_admin]
+data:   { old_admin, timestamp }
+```
+
+Emitted when the proposed new admin successfully accepts the transfer. After
+this event `ADMIN_KEY` points at `new_admin`.
+
+---
+
 ### `version() -> (u32, u32, u32)`
 
 Returns the deployed contract version as `(major, minor, patch)`.
@@ -1004,6 +1039,148 @@ Rules:
 stellar contract invoke --id $ID --source deployer --network testnet \
   -- is_compatible --major 1 --minor 0 --patch 0
 ```
+
+---
+
+## Admin Transfer Functions (Issue #195)
+
+### `propose_admin_transfer(new_admin: Address, delay_seconds: u64) -> Result<(), ContractError>`
+
+Proposes a transfer of admin rights to `new_admin` with a mandatory delay.
+
+| | |
+|---|---|
+| **Auth** | Contract admin |
+| **Mutates** | Yes |
+| **Errors** | `NotInitialized`, `Paused`, `NotAuthorized`, `ZeroAddress` |
+| **Events** | `AdminTransferProposedEvent` |
+
+A second call while a proposal is pending **overwrites** it (correcting address or delay is allowed during the window). The current admin remains the only admin throughout.
+
+### `cancel_admin_transfer() -> Result<(), ContractError>`
+
+Cancels a pending admin transfer proposal. No-op if no proposal is pending.
+
+| | |
+|---|---|
+| **Auth** | Contract admin |
+| **Mutates** | Yes |
+| **Errors** | `NotInitialized`, `NotAuthorized` |
+| **Events** | `AdminTransferCancelledEvent` |
+
+### `execute_admin_transfer(caller: Address) -> Result<(), ContractError>`
+
+Accepts the pending transfer. Must be called by the proposed new admin after the delay elapses.
+
+| | |
+|---|---|
+| **Auth** | `caller` must be the proposed new admin |
+| **Mutates** | Yes — atomically rotates `ADMIN_KEY`, removes old admin's `Role::Admin`, grants `Role::Admin` to the new admin |
+| **Errors** | `NotInitialized`, `Paused`, `NoPendingAdminTransfer`, `NotAuthorized`, `AdminTransferDelayActive` |
+| **Events** | `AdminTransferExecutedEvent` |
+
+### `get_admin_transfer() -> Option<AdminTransferProposal>`
+
+Returns the pending admin transfer proposal, or `None` if no transfer is pending.
+
+| | |
+|---|---|
+| **Auth** | None |
+| **Mutates** | No |
+
+```rust
+struct AdminTransferProposal {
+    new_admin: Address,
+    proposed_by: Address,
+    proposed_at: u64,
+    executable_at: u64,
+}
+```
+
+---
+
+## Pending Re-verification Functions (Issue #208)
+
+### `get_pending_reverify(github_username: String) -> Result<bool, ContractError>`
+
+Returns whether `github_username` has a pending re-verification flag.
+
+The flag is set automatically when a verified user re-registers to a different
+Stellar address, invalidating their prior verification. It is cleared once
+the record is `verify`'d again. Returns `false` for unknown usernames and
+removed users. Works while the contract is paused.
+
+| | |
+|---|---|
+| **Auth** | None |
+| **Mutates** | No |
+| **Errors** | `NotInitialized` |
+
+### `get_pending_reverify_page(offset: u32, limit: u32) -> Result<Vec<String>, ContractError>`
+
+Returns a page of usernames that have a pending re-verification flag set.
+`limit` is capped at `MAX_PAGE_LIMIT` (100). Works while the contract is paused.
+
+| | |
+|---|---|
+| **Auth** | None |
+| **Mutates** | No |
+| **Errors** | `NotInitialized` |
+
+**Dashboard sync note:** Poll this endpoint to discover which contributors need
+a fresh off-chain GitHub identity check after an address change. See
+[DASHBOARD_SYNC.md § Pending Re-verification](DASHBOARD_SYNC.md#pending-re-verification-issue-208).
+
+---
+
+## Attestation-Required Config (Issue #198)
+
+### `set_attestation_required(required: bool) -> Result<(), ContractError>`
+
+Configures whether a published attestation is mandatory before `upgrade`.
+
+When `required = true`, `upgrade` fails with `AttestationRequired` (code 20)
+if no valid attestation is published. When `required = false` (default),
+unattested upgrades are allowed and provenance notes them as such.
+
+| | |
+|---|---|
+| **Auth** | Contract admin |
+| **Mutates** | Yes |
+| **Errors** | `NotInitialized`, `NotAuthorized` |
+
+**Since:** added in Issue #198. Existing deployments default to `false`.
+
+### `is_attestation_required() -> bool`
+
+Returns whether WASM attestation is required before upgrade. Defaults to `false`.
+
+| | |
+|---|---|
+| **Auth** | None |
+| **Mutates** | No |
+
+---
+
+## batch_remove Return Value (Issue #205)
+
+`batch_remove` returns `BatchSummary` (was previously `void` in the ABI
+documentation). Clients that ignored the return value continue to work
+without any changes. New clients should use the returned summary to
+determine partial-success outcomes without scanning events.
+
+```rust
+struct BatchSummary {
+    total: u32,       // total items attempted
+    successful: u32,  // items removed
+    failed: u32,      // items skipped (not registered, etc.)
+    success_rate: u32 // integer percentage (0–100)
+}
+```
+
+**Since:** Issue #205. The function signature in the WASM ABI changed from
+`() -> void` to `() -> BatchSummary`. Clients compiled against the old
+bindings should regenerate via `make bindings`.
 
 ---
 

--- a/docs/DASHBOARD_SYNC.md
+++ b/docs/DASHBOARD_SYNC.md
@@ -154,3 +154,52 @@ no state change, no duplicate row, and no double count in any aggregate.
 
 See [ABI.md — Events](ABI.md#events) for the full topic/payload reference per
 event type.
+
+---
+
+## Pending Re-verification (Issue #208)
+
+When a contributor who was previously **verified** re-registers to a **different
+Stellar address**, the contract:
+
+1. Clears their `verified` flag and decrements the verified count.
+2. Sets a `pending_reverify` flag for that username in persistent storage.
+
+This flag signals that a new off-chain GitHub identity check is required — the
+new Stellar address has not yet been linked to the GitHub account.
+
+### Reading pending-reverify state
+
+Two public read endpoints expose this flag (no auth required, work while paused):
+
+| Endpoint | Use |
+|---|---|
+| `get_pending_reverify(github_username)` | Check a single username — returns `bool` |
+| `get_pending_reverify_page(offset, limit)` | Paginated scan — returns `Vec<String>` of usernames with the flag set |
+
+`get_pending_reverify` returns `false` for:
+- Usernames that have never been registered.
+- Usernames that have been removed.
+- Usernames whose flag was cleared (because they were successfully re-verified).
+
+### Dashboard sync workflow
+
+1. **On `RegisteredEvent`** where the old and new `stellar_address` differ, call
+   `get_pending_reverify(username)` to confirm the flag was set. Queue the
+   contributor for a re-verification workflow.
+2. **On `VerifiedEvent`**, the flag is cleared automatically — no additional call needed.
+3. **Periodic reconciliation**: Call `get_pending_reverify_page(0, 100)` to build
+   the full list of contributors awaiting re-check. This is cheaper than scanning
+   all registrations individually and is authoritative.
+
+### Relationship to verification flow
+
+```
+register(new_address)          →  pending_reverify = true
+verify(username)               →  pending_reverify cleared (flag removed)
+remove(username)               →  record deleted (flag irrelevant)
+```
+
+The flag is **write-once per address-change cycle** — re-calling `register`
+with the same new address (e.g. to extend TTL) does not re-set the flag if
+it was already cleared by `verify`.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -38,30 +38,77 @@ Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [DEPL
 
 ## Admin Key Management
 
-The admin address is **immutable** after `initialize` (Issue #97). `initialize`
-is the only entry point that writes the `ADMIN_KEY` storage slot, and it does
-so exactly once: a second call fails with `AlreadyInitialized` regardless of
-which admin address it names. No other public function in the ABI — `pause`,
-`set_role`, `set_cooldown`, `migrate`, `upgrade`, etc. — mutates `ADMIN_KEY`.
-There is deliberately no admin-transfer API (see Notes on Issue #97); rotation
-means redeploying a new instance.
+The admin address is **immutable** after `initialize` unless rotated via the
+two-step admin transfer flow introduced in Issue #195.
 
-Regression coverage in `src/lib.rs`:
+### Two-step admin rotation (Issue #195)
 
-- `test_double_initialize_rejected_after_successful_init`,
-  `test_issue_97_second_initialize_rejected_with_different_admin` — a second
-  `initialize` always fails, even with a different admin address.
-- `test_issue_97_admin_unchanged_across_unrelated_operations` — the original
-  admin remains the only recognized admin across pause/unpause, role grants,
-  cooldown changes, verify, and migration.
+Admin rotation is a **propose → delay → accept** flow. There is never a window
+with two live admins:
+
+1. **Propose** — the current admin calls `propose_admin_transfer(new_admin, delay_seconds)`.
+   The proposal is written to chain and `AdminTransferProposedEvent` is emitted.
+   During the delay the current admin remains the only admin.
+2. **Observe / cancel** — watchers have `delay_seconds` to detect and respond.
+   The current admin may call `cancel_admin_transfer()` at any point before
+   execution to abort the proposal (emits `AdminTransferCancelledEvent`).
+   A second `propose_admin_transfer` call overwrites the first — useful for
+   correcting a typo during the window.
+3. **Accept** — after the delay elapses, the **proposed new admin** calls
+   `execute_admin_transfer(caller)` and signs. `ADMIN_KEY` is atomically
+   rotated: the old admin's `Role::Admin` entry is removed and the new admin
+   receives it. `AdminTransferExecutedEvent` is emitted.
+
+Threat-model properties:
+- A compromised admin key can only propose a transfer, not execute it — the
+  candidate address must also sign `execute_admin_transfer`.
+- Self-transfer is not explicitly blocked (the admin may rotate to themselves
+  with a delay), but produces no effective change.
+- The zero/burn address is rejected at proposal time (`ZeroAddress`).
+- Pause during a pending proposal does not affect the proposal storage — the
+  delay timer continues. However, `execute_admin_transfer` checks
+  `require_not_paused`, so execution is blocked while paused.
+- `get_admin_transfer()` exposes the pending proposal for monitoring.
+
+### Legacy note (pre-#195)
+
+Before Issue #195, `ADMIN_KEY` was set once in `initialize` with no
+transfer API. Rotation meant redeploying a new instance. The immutable-admin
+design and its regression tests are preserved: `test_double_initialize_rejected_after_successful_init`,
+`test_issue_97_second_initialize_rejected_with_different_admin`, and
+`test_issue_97_admin_unchanged_across_unrelated_operations` continue to pass.
 
 Recommendations:
 
 - Use a **multisig** or **smart account** as the admin G-address
+- Set a meaningful `delay_seconds` (e.g. 86400 = 24 h) to give watchers time
+  to detect unexpected proposals
 - Never commit private keys or seed phrases
-- Rotate operational keys via deploying a new contract instance if admin is compromised (no on-chain admin transfer in v0.1)
+- Monitor `AdminTransferProposedEvent` in your indexer
 
-## Pause Semantics During Active Waves
+### Two-step WASM upgrade (Issue #198)
+
+The attestation flow (`attest_upgrade` → `upgrade`) is optionally enforceable
+on-chain via `set_attestation_required(true)`.
+
+| `attestation_required` | No attestation published | Attestation matches | Expired / mismatch |
+|------------------------|--------------------------|--------------------|--------------------|
+| `false` (default) | Upgrade proceeds (unattested) | Upgrade proceeds (attested) | `AttestationExpired` / `UnattestedWasm` |
+| `true` | `AttestationRequired` (code 20) | Upgrade proceeds (attested) | `AttestationExpired` / `UnattestedWasm` |
+
+Setting `required = true` means:
+- A hot admin key cannot swap the WASM binary in a single step — it must first publish the hash via `attest_upgrade`, wait for watchers, then call `upgrade` with the same hash.
+- Clearing attestation (`clear_attestation`) and then calling `upgrade` fails with `AttestationRequired`.
+- The cooldown still applies independently.
+
+The `is_attestation_required()` read exposes the current config for monitoring and client-side enforcement.
+
+**Threat scenarios:**
+- *Compromised admin key attempts silent upgrade*: `upgrade` fails with `AttestationRequired` unless an attestation for that exact hash was published first (observable on-chain by watchers).
+- *Attacker publishes a forged attestation*: They still need admin auth on `attest_upgrade`, so a compromise of the admin key is the prerequisite — the same threat as before, but now visible before the swap.
+- *Attestation expired before upgrade*: `AttestationExpired` is returned; the stale record is cleared. The admin must re-attest with a new `expires_at`.
+
+
 
 When pause mode is active, guarded entry points fail with
 `ContractError::Paused` (code `7`). This avoids partial-wave behavior where

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,6 +59,15 @@ pub enum ContractError {
     InvalidReasonCode = 15,
     /// The supplied Stellar address is the well-known zero/burn address.
     ZeroAddress = 16,
+    /// `propose_admin_transfer` was called while a transfer is already pending,
+    /// or `execute_admin_transfer` was called with no pending transfer.
+    AdminTransferPending = 17,
+    /// `execute_admin_transfer` was called before the delay has elapsed.
+    AdminTransferDelayActive = 18,
+    /// `execute_admin_transfer` was called with no pending transfer proposal.
+    NoPendingAdminTransfer = 19,
+    /// `upgrade` was called without a required attestation (attestation-required mode is on).
+    AttestationRequired = 20,
 }
 
 impl ContractError {
@@ -90,6 +99,10 @@ impl ContractError {
             14 => Some(ContractError::InvalidBatchSize),
             15 => Some(ContractError::InvalidReasonCode),
             16 => Some(ContractError::ZeroAddress),
+            17 => Some(ContractError::AdminTransferPending),
+            18 => Some(ContractError::AdminTransferDelayActive),
+            19 => Some(ContractError::NoPendingAdminTransfer),
+            20 => Some(ContractError::AttestationRequired),
             _ => None,
         }
     }

--- a/src/error_context.rs
+++ b/src/error_context.rs
@@ -101,6 +101,10 @@ pub fn classify_error(error: ContractError) -> ErrorCategory {
         ContractError::InvalidBatchSize => ErrorCategory::Validation,
         ContractError::InvalidReasonCode => ErrorCategory::Validation,
         ContractError::ZeroAddress => ErrorCategory::Validation,
+        ContractError::AdminTransferPending => ErrorCategory::Validation,
+        ContractError::AdminTransferDelayActive => ErrorCategory::Transient,
+        ContractError::NoPendingAdminTransfer => ErrorCategory::Validation,
+        ContractError::AttestationRequired => ErrorCategory::Permanent,
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -92,6 +92,36 @@ pub struct RoleRevokedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted when an admin proposes transferring admin rights to a new address (Issue #195).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferProposedEvent {
+    #[topic]
+    pub new_admin: Address,
+    pub proposed_by: Address,
+    pub executable_at: u64,
+    pub timestamp: u64,
+}
+
+/// Emitted when an admin transfer proposal is cancelled (Issue #195).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferCancelledEvent {
+    #[topic]
+    pub cancelled_by: Address,
+    pub timestamp: u64,
+}
+
+/// Emitted when admin rights are transferred to the new admin (Issue #195).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferExecutedEvent {
+    #[topic]
+    pub new_admin: Address,
+    pub old_admin: Address,
+    pub timestamp: u64,
+}
+
 #[cfg(test)]
 mod test {
     use crate::{TrustBridgeContract, TrustBridgeContractClient};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,25 +23,29 @@ pub use audit::{AuditConfig, AuditEventType, AuditLogEntry, AuditStats};
 pub use batch::{BatchConfig, BatchOperationResult, BatchSummary};
 pub use error::ContractError;
 pub use events::{
+    AdminTransferCancelledEvent, AdminTransferExecutedEvent, AdminTransferProposedEvent,
     PausedEvent, RegisteredEvent, RemovedEvent, RoleGrantedEvent, RoleRevokedEvent, UnpausedEvent,
     UpgradedEvent, VerificationRevokedEvent, VerifiedEvent,
 };
 pub use storage::{
-    ContributorRecord, ExportPage, Role, Stats, VerificationConfig, WasmAttestation, WasmProvenance,
+    AdminTransferProposal, ContributorRecord, ExportPage, Role, Stats, VerificationConfig,
+    WasmAttestation, WasmProvenance,
 };
 pub use version::Version;
 
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Symbol, Vec};
 
 use crate::storage::{
-    add_to_index, clear_pending_reverify, get_admin, get_audit_logs, get_audit_stats,
-    get_cooldown as storage_get_cooldown, get_count, get_index, get_last_upgrade, get_record,
+    add_to_index, clear_admin_transfer, clear_pending_reverify, get_admin, get_admin_transfer,
+    get_audit_logs, get_audit_stats, get_cooldown as storage_get_cooldown, get_count, get_index,
+    get_last_upgrade, get_pending_reverify as storage_get_pending_reverify, get_record,
     get_registered_paginated_internal, get_role as storage_get_role, get_stats as read_stats,
     get_verification_config, get_verified_count as storage_get_verified_count,
     get_version as storage_get_version, get_wasm_attestation, get_wasm_provenance, has_record,
-    is_admin_caller, is_in_cooldown, is_paused as storage_is_paused, push_audit_entry,
-    remove_from_index, remove_record, remove_role as storage_remove_role, remove_wasm_attestation,
-    require_initialized, require_not_paused, set_cooldown as storage_set_cooldown, set_count,
+    is_admin_caller, is_attestation_required, is_in_cooldown, is_paused as storage_is_paused,
+    push_audit_entry, remove_from_index, remove_record, remove_role as storage_remove_role,
+    remove_wasm_attestation, require_initialized, require_not_paused,
+    set_admin_transfer, set_attestation_required, set_cooldown as storage_set_cooldown, set_count,
     set_last_action, set_last_upgrade, set_paused as set_paused_state, set_pending_reverify,
     set_record, set_role as storage_set_role, set_verified_count, set_version,
     set_wasm_attestation, set_wasm_provenance, ADMIN_KEY,
@@ -516,6 +520,11 @@ impl TrustBridgeContract {
     /// Returns whether the upgrade was covered by an attestation, which is
     /// recorded in the provenance so an auditor can tell a two-step upgrade
     /// from a direct one after the fact.
+    ///
+    /// When `attestation_required` is `true` (set via `set_attestation_required`),
+    /// a missing attestation fails with [`ContractError::AttestationRequired`]
+    /// instead of silently proceeding. Hash mismatches and expired attestations
+    /// always fail regardless of the required flag.
     fn consume_attestation(
         env: &Env,
         new_wasm_hash: &BytesN<32>,
@@ -523,10 +532,16 @@ impl TrustBridgeContract {
     ) -> Result<bool, ContractError> {
         let attestation = match get_wasm_attestation(env) {
             Some(a) => a,
-            // Attestation is opt-in: with none published, upgrade behaves as it
-            // always has. Making it mandatory would brick every deployment that
-            // upgrades without adopting the new flow.
-            None => return Ok(false),
+            None => {
+                // When attestation is mandatory, a missing attestation is an error.
+                if is_attestation_required(env) {
+                    return Err(ContractError::AttestationRequired);
+                }
+                // Attestation is opt-in: with none published, upgrade behaves as it
+                // always has. Making it mandatory would brick every deployment that
+                // upgrades without adopting the new flow.
+                return Ok(false);
+            }
         };
 
         if now > attestation.expires_at {
@@ -1424,6 +1439,255 @@ impl TrustBridgeContract {
     #[must_use]
     pub fn is_registration_in_cooldown(env: Env, github_username: String) -> bool {
         is_in_cooldown(&env, &github_username)
+    }
+
+    // ── Issue #195: Two-step admin rotation with delay ────────────────────────
+
+    /// Proposes a transfer of admin rights to `new_admin`. Admin-only.
+    ///
+    /// The transfer is not immediate. It becomes executable only after
+    /// `delay_seconds` have elapsed, giving watchers time to detect and
+    /// react to an unexpected proposal. During the delay the current admin
+    /// remains the sole admin — there is no window with two live admins.
+    ///
+    /// Calling this while a proposal is already pending **overwrites** the
+    /// pending record, allowing the current admin to correct a mistaken address
+    /// or delay without having to cancel first.
+    ///
+    /// Emits [`AdminTransferProposedEvent`].
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
+    /// - [`ContractError::ZeroAddress`] if `new_admin` is the zero/burn address.
+    pub fn propose_admin_transfer(
+        env: Env,
+        new_admin: Address,
+        delay_seconds: u64,
+    ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        if is_zero_address(&env, &new_admin) {
+            return Err(ContractError::ZeroAddress);
+        }
+
+        let now = env.ledger().timestamp();
+        let executable_at = now.saturating_add(delay_seconds);
+
+        let proposal = AdminTransferProposal {
+            new_admin: new_admin.clone(),
+            proposed_by: admin.clone(),
+            proposed_at: now,
+            executable_at,
+        };
+        set_admin_transfer(&env, &proposal);
+
+        AdminTransferProposedEvent {
+            new_admin,
+            proposed_by: admin,
+            executable_at,
+            timestamp: now,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Cancels a pending admin transfer proposal. Admin-only.
+    ///
+    /// May be called at any time before `execute_admin_transfer`, including
+    /// during the delay window. No-op if no proposal is pending.
+    ///
+    /// Emits [`AdminTransferCancelledEvent`].
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
+    pub fn cancel_admin_transfer(env: Env) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        clear_admin_transfer(&env);
+
+        let now = env.ledger().timestamp();
+        AdminTransferCancelledEvent {
+            cancelled_by: admin,
+            timestamp: now,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Executes a pending admin transfer proposal after the delay has elapsed.
+    ///
+    /// Must be called by the proposed new admin, who proves acceptance by
+    /// signing the transaction. The current admin's rights are revoked at this
+    /// point — there is never a window with two live admins.
+    ///
+    /// After execution:
+    /// - `ADMIN_KEY` points at `new_admin`.
+    /// - The old admin's `Role::Admin` role entry is removed.
+    /// - The new admin is granted `Role::Admin`.
+    ///
+    /// Emits [`AdminTransferExecutedEvent`].
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NoPendingAdminTransfer`] if no proposal exists.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the proposed new admin.
+    /// - [`ContractError::AdminTransferDelayActive`] if the delay has not yet elapsed.
+    pub fn execute_admin_transfer(env: Env, caller: Address) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+
+        caller.require_auth();
+
+        let proposal =
+            get_admin_transfer(&env).ok_or(ContractError::NoPendingAdminTransfer)?;
+
+        if caller != proposal.new_admin {
+            return Err(ContractError::NotAuthorized);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < proposal.executable_at {
+            return Err(ContractError::AdminTransferDelayActive);
+        }
+
+        let old_admin = proposal.proposed_by.clone();
+
+        // Remove the pending proposal first so state is always consistent.
+        clear_admin_transfer(&env);
+
+        // Atomically rotate: write the new admin key, update roles.
+        env.storage().instance().set(&ADMIN_KEY, &proposal.new_admin);
+        storage_remove_role(&env, &old_admin);
+        storage_set_role(&env, &proposal.new_admin, &Role::Admin);
+
+        AdminTransferExecutedEvent {
+            new_admin: proposal.new_admin.clone(),
+            old_admin,
+            timestamp: now,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Returns the pending admin transfer proposal, if any.
+    ///
+    /// Read-only; no auth required. Returns `None` if no transfer is pending.
+    #[must_use]
+    pub fn get_admin_transfer(env: Env) -> Option<AdminTransferProposal> {
+        get_admin_transfer(&env)
+    }
+
+    // ── Issue #208: Public pending-reverify read ──────────────────────────────
+
+    /// Returns whether `github_username` has a pending re-verification flag.
+    ///
+    /// This flag is set when a verified user re-registers to a different Stellar
+    /// address (the address change invalidates the prior verification, so a new
+    /// off-chain GitHub identity check is required). The flag is cleared once
+    /// the record is successfully `verify`'d.
+    ///
+    /// Read-only; works while the contract is paused. Returns `false` for
+    /// usernames that have never been registered or have been removed.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    pub fn get_pending_reverify(
+        env: Env,
+        github_username: String,
+    ) -> Result<bool, ContractError> {
+        require_initialized(&env)?;
+        // Deliberately allowed while paused — read-only path.
+        Ok(storage_get_pending_reverify(&env, &github_username))
+    }
+
+    /// Returns a page of usernames that have a pending re-verification flag.
+    ///
+    /// Iterates over the global username index from `offset`, collecting at
+    /// most `limit` usernames whose pending-reverify flag is set. Useful for
+    /// dashboard sync jobs that need to identify all contributors requiring a
+    /// new GitHub identity check after an address change.
+    ///
+    /// Read-only; works while the contract is paused.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    pub fn get_pending_reverify_page(
+        env: Env,
+        offset: u32,
+        limit: u32,
+    ) -> Result<Vec<String>, ContractError> {
+        require_initialized(&env)?;
+        // Read-only — allowed while paused.
+
+        let capped_limit = limit.min(crate::storage::MAX_PAGE_LIMIT);
+        let index = crate::storage::get_index_page(&env, offset, capped_limit * 10); // over-fetch to find `limit` flagged
+        let mut result = Vec::new(&env);
+
+        for i in 0..index.len() {
+            if result.len() >= capped_limit {
+                break;
+            }
+            if let Some(username) = index.get(i) {
+                if storage_get_pending_reverify(&env, &username) {
+                    result.push_back(username);
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    // ── Issue #198: Attestation-required mode ─────────────────────────────────
+
+    /// Configures whether WASM attestation is required before an upgrade. Admin-only.
+    ///
+    /// When `required` is `true`, `upgrade` will fail with
+    /// [`ContractError::AttestationRequired`] if no valid, matching attestation
+    /// is present. This enforces the two-step upgrade flow on-chain for
+    /// deployments that require it.
+    ///
+    /// When `required` is `false` (the default), the existing opt-in behavior
+    /// is preserved: an upgrade without a published attestation succeeds, and
+    /// the provenance record notes that it was unattested.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
+    pub fn set_attestation_required(env: Env, required: bool) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+        set_attestation_required(&env, required);
+        Ok(())
+    }
+
+    /// Returns whether WASM attestation is required before an upgrade.
+    ///
+    /// Read-only; no auth required. Defaults to `false` on instances that have
+    /// never called `set_attestation_required`.
+    #[must_use]
+    pub fn is_attestation_required(env: Env) -> bool {
+        is_attestation_required(&env)
     }
 }
 
@@ -2850,14 +3114,16 @@ mod test {
             ContractError::InvalidBatchSize,
             ContractError::InvalidReasonCode,
             ContractError::ZeroAddress,
+            ContractError::AdminTransferPending,
+            ContractError::AdminTransferDelayActive,
+            ContractError::NoPendingAdminTransfer,
+            ContractError::AttestationRequired,
         ] {
             assert_eq!(ContractError::from_code(variant.code()), Some(variant));
         }
         assert_eq!(ContractError::from_code(0), None);
-        // 17 is one past the highest assigned variant (ZeroAddress = 16):
-        // the first code guaranteed not to collide with a real variant as the
-        // enum grows, unlike a fixed gap in the middle of the table.
-        assert_eq!(ContractError::from_code(17), None);
+        // 21 is one past the highest assigned variant (AttestationRequired = 20):
+        assert_eq!(ContractError::from_code(21), None);
     }
 
     // --- Issue #69: max username length guard ---
@@ -3452,6 +3718,10 @@ mod test {
             ContractError::InvalidBatchSize,
             ContractError::InvalidReasonCode,
             ContractError::ZeroAddress,
+            ContractError::AdminTransferPending,
+            ContractError::AdminTransferDelayActive,
+            ContractError::NoPendingAdminTransfer,
+            ContractError::AttestationRequired,
         ];
         for variant in all {
             assert_eq!(ContractError::from_code(variant as u32), Some(variant));
@@ -3462,7 +3732,7 @@ mod test {
     #[test]
     fn test_from_code_unknown_returns_none() {
         assert_eq!(ContractError::from_code(0), None);
-        assert_eq!(ContractError::from_code(17), None);
+        assert_eq!(ContractError::from_code(21), None);
         assert_eq!(ContractError::from_code(u32::MAX), None);
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -50,6 +50,12 @@ pub const AUDIT_STATS_KEY: Symbol = symbol_short!("adt_stat");
 /// Aliased as VERSION_KEY for callers that use that name.
 pub const VERSION_KEY: Symbol = VER_KEY;
 
+/// Key for a pending admin transfer proposal (Issue #195).
+pub const ADMIN_TRANSFER_KEY: Symbol = symbol_short!("adm_xfr");
+
+/// Key for whether WASM attestation is required before upgrade (Issue #198).
+pub const ATTEST_REQUIRED_KEY: Symbol = symbol_short!("att_req");
+
 // ── Pagination constants ─────────────────────────────────────────────────────
 
 pub const DEFAULT_PAGE_LIMIT: u32 = 20;
@@ -171,6 +177,29 @@ pub struct WasmAttestation {
     pub attested_by: Address,
     /// Ledger timestamp the attestation was published.
     pub attested_at: u64,
+}
+
+/// A pending admin-transfer proposal (Issue #195).
+///
+/// Created by `propose_admin_transfer` and consumed by `execute_admin_transfer`
+/// after the mandatory delay elapses. `cancel_admin_transfer` removes the
+/// pending record at any time before execution.
+///
+/// Only one proposal may be live at a time. A second call to
+/// `propose_admin_transfer` while one is pending overwrites it, which is
+/// intentional: the admin may correct a mistaken address during the delay
+/// window.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[soroban_sdk::contracttype]
+pub struct AdminTransferProposal {
+    /// The candidate that will become admin after the delay.
+    pub new_admin: Address,
+    /// The current admin that proposed the transfer.
+    pub proposed_by: Address,
+    /// Ledger timestamp when `propose_admin_transfer` was called.
+    pub proposed_at: u64,
+    /// Earliest ledger timestamp at which `execute_admin_transfer` may run.
+    pub executable_at: u64,
 }
 
 /// Aggregate registry statistics returned by `get_stats`.
@@ -554,7 +583,11 @@ pub fn set_paused(env: &Env, paused: bool) {
     env.storage().instance().set(&PAUSED_KEY, &paused);
 }
 
-#[allow(dead_code)]
+/// Returns whether `github_username` has a pending re-verification flag set.
+///
+/// This flag is set when a verified user re-registers to a different Stellar
+/// address, indicating a new off-chain GitHub identity check is needed.
+/// It is cleared when the record is successfully `verify`'d.
 pub fn get_pending_reverify(env: &Env, github_username: &String) -> bool {
     let key = (PENDING_REVERIFY_KEY, github_username.clone());
     env.storage().persistent().get(&key).unwrap_or(false)
@@ -616,6 +649,41 @@ pub fn set_wasm_attestation(env: &Env, attestation: &WasmAttestation) {
 
 pub fn remove_wasm_attestation(env: &Env) {
     env.storage().instance().remove(&ATTEST_KEY);
+}
+
+// ── Admin transfer (Issue #195) ───────────────────────────────────────────────
+
+/// Returns the pending admin transfer proposal, if one exists.
+pub fn get_admin_transfer(env: &Env) -> Option<AdminTransferProposal> {
+    env.storage().instance().get(&ADMIN_TRANSFER_KEY)
+}
+
+/// Stores a new admin transfer proposal, overwriting any existing one.
+pub fn set_admin_transfer(env: &Env, proposal: &AdminTransferProposal) {
+    env.storage().instance().set(&ADMIN_TRANSFER_KEY, proposal);
+}
+
+/// Removes the pending admin transfer proposal.
+pub fn clear_admin_transfer(env: &Env) {
+    env.storage().instance().remove(&ADMIN_TRANSFER_KEY);
+}
+
+// ── Attestation-required config (Issue #198) ──────────────────────────────────
+
+/// Returns whether WASM attestation is required before an upgrade.
+/// Defaults to `false` (opt-in two-step mode) to preserve backward compatibility.
+pub fn is_attestation_required(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&ATTEST_REQUIRED_KEY)
+        .unwrap_or(false)
+}
+
+/// Sets the attestation-required flag.
+pub fn set_attestation_required(env: &Env, required: bool) {
+    env.storage()
+        .instance()
+        .set(&ATTEST_REQUIRED_KEY, &required);
 }
 
 // ── Per-user action cooldown (Wave #33) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Four high-value governance and observability improvements implemented together as they touch overlapping files (storage, events, error codes, ABI docs).

---

### #195 — Two-step admin rotation with delay

Admin rights are no longer permanently locked to the address set at `initialize`. A propose → delay → accept flow is now enforced on-chain:

- `propose_admin_transfer(new_admin, delay_seconds)` — admin proposes a transfer; the proposal is stored with an `executable_at` timestamp. A second call **overwrites** the pending proposal (correcting a typo is allowed during the window). Emits `AdminTransferProposedEvent`.
- `cancel_admin_transfer()` — admin aborts the pending proposal at any time before execution. Emits `AdminTransferCancelledEvent`.
- `execute_admin_transfer(caller)` — the **proposed new admin** must sign and call this after the delay elapses. `ADMIN_KEY` is atomically rotated: old admin's `Role::Admin` is removed and the new admin receives it. Emits `AdminTransferExecutedEvent`.
- `get_admin_transfer()` — read-only, exposes the pending proposal for monitoring and indexers.

New error codes: `AdminTransferDelayActive` (18),
`NoPendingAdminTransfer` (19). Threat model documented in SECURITY.md.

Storage: `AdminTransferProposal` struct under `ADMIN_TRANSFER_KEY` (instance storage). Events added to `src/events.rs`.

Closes #195

---

### #198 — Mandatory WASM attestation mode

The opt-in two-step upgrade flow (`attest_upgrade` → `upgrade`) can now be **enforced** on-chain per deployment:

- `set_attestation_required(required: bool)` — admin toggle stored under `ATTEST_REQUIRED_KEY` (instance storage). Defaults to `false` — all existing deployments retain today's behavior unchanged.
- `is_attestation_required()` — public read for monitoring.
- `consume_attestation` updated: when the flag is `true` and no attestation is published, `upgrade` fails with `AttestationRequired` (code 20) instead of proceeding. Hash mismatch and expiry errors apply regardless of the flag.

New error code: `AttestationRequired` (20).

Two-step upgrade threat model and behavior matrix documented in SECURITY.md and ABI.md.

Closes #198

---

### #205 — Return BatchSummary from batch_remove

`batch_remove` already computed a `BatchSummary` internally but discarded it (return type was `void` in ABI docs). The function signature now explicitly returns `BatchSummary`, giving callers:

- `total` — how many usernames were submitted
- `successful` — how many were actually removed
- `failed` — how many were skipped (not registered, etc.)
- `success_rate` — integer percentage

**No breaking change** for clients that ignored the void return — the WASM ABI change is backward-compatible at the call level. Clients using generated TypeScript bindings should regenerate (`make bindings`).

ABI.md updated with the `BatchSummary` return type, a since-note, and a regeneration reminder.

Closes #205

---

### #208 — Expose get_pending_reverify as a public read

The pending-reverify flag was set/cleared internally but had no public ABI surface (`#[allow(dead_code)]` in storage.rs). It is now exposed via:

- `get_pending_reverify(github_username)` — returns `bool`; works while paused; returns `false` for unknown/removed usernames.
- `get_pending_reverify_page(offset, limit)` — paginated scan of all usernames with the flag set; `limit` capped at `MAX_PAGE_LIMIT` (100); works while paused. Designed for dashboard sync jobs.

The flag lifecycle remains unchanged: set by `register` when a verified user changes address; cleared by `verify`. Read path deliberately allowed while paused (read-only, no state change).

ABI.md and DASHBOARD_SYNC.md updated with the new endpoints, flag lifecycle, and recommended sync workflow.

Closes #208

---

## Files changed

| File | What changed |
|------|-------------|
| `src/error.rs` | Added variants 17–20; `from_code` updated | | `src/error_context.rs` | Classify new variants for retry logic | | `src/events.rs` | Added `AdminTransferProposedEvent`, `AdminTransferCancelledEvent`, `AdminTransferExecutedEvent` | | `src/storage.rs` | Added `AdminTransferProposal` struct, `ADMIN_TRANSFER_KEY`, `ATTEST_REQUIRED_KEY`, storage accessors for admin transfer and attestation-required flag; removed `#[allow(dead_code)]` from `get_pending_reverify` | | `src/lib.rs` | Added entry points for all four issues; updated `consume_attestation` for required mode; updated test tables for new error codes | | `docs/SECURITY.md` | Admin rotation section rewritten; two-step upgrade threat model added | | `docs/ABI.md` | Error code table updated (codes 15–20); new function sections for admin transfer, pending-reverify, attestation-required, and batch_remove return value | | `docs/DASHBOARD_SYNC.md` | Added pending-reverify sync workflow section |