### PR TITLE
feat: health snapshot, real migration, role split, challenge period (…

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -61,7 +61,47 @@ struct BatchSummary {
 enum Role {
     Admin = 1,
     Upgrader = 2,
+    /// May call `verify` only.
     Verifier = 3,
+    /// May call `revoke_verification` only (Issue #212 — Verifier/Revoker split).
+    Revoker = 4,
+}
+```
+
+**Role matrix (Issue #212):**
+
+| Role | `verify` | `revoke_verification` | `upgrade` | `set_role` |
+|------|----------|-----------------------|-----------|------------|
+| Admin | ✅ | ✅ | ✅ | ✅ |
+| Verifier | ✅ | ❌ | ❌ | ❌ |
+| Revoker | ❌ | ✅ | ❌ | ❌ |
+| Upgrader | ❌ | ❌ | ✅ | ❌ |
+
+### HealthSnapshot
+
+Returned by `get_health` (Issue #210).
+
+```rust
+struct HealthSnapshot {
+    paused: bool,
+    version: Vec<u32>,          // [major, minor, patch]
+    total: u32,
+    verified: u32,
+    cooldown_secs: u64,
+    cooldown_remaining_secs: u64,
+    attestation_present: bool,
+}
+```
+
+### ChallengeRecord
+
+Returned by `get_challenge` (Issue #214).
+
+```rust
+struct ChallengeRecord {
+    challenged_by: Address,
+    started_at: u64,
+    resolve_after: u64,
 }
 ```
 
@@ -83,7 +123,12 @@ enum Role {
 | 12 | `AttestationExpired` | Upgrade attestation's `expires_at` has passed |
 | 13 | `UnattestedWasm` | `upgrade` hash does not match the live attestation |
 | 14 | `InvalidBatchSize` | Batch call supplied zero items or more than the configured max |
-| 15 | `ZeroAddress` | Supplied Stellar address is the well-known zero/burn address |
+| 15 | `InvalidReasonCode` | `revoke_verification` reason_code is not a known `RevokeReason` value |
+| 16 | `ZeroAddress` | Supplied Stellar address is the well-known zero/burn address |
+| 17 | `ChallengeAlreadyActive` | `start_challenge` called while a challenge is already open |
+| 18 | `NoChallengeActive` | `cancel_challenge` or `complete_challenge` called with no active challenge |
+| 19 | `ChallengeNotResolvable` | `complete_challenge` called before the delay has elapsed |
+| 20 | `ChallengeActive` | `register` attempted while a challenge is active on the username |
 
 `ContractError::from_code(u32)` maps every code in this table back to the typed
 variant and returns `None` for any unrecognized code. Every code round-trips
@@ -1281,3 +1326,81 @@ To fulfill a GDPR "Right to Erasure" request, a user or admin should call the `r
 - Run `stellar contract invoke --id $ID -- --help` for auto-generated help from the WASM schema
 
 See also: [Stellar CLI invoke argument types](https://developers.stellar.org/docs/tools/cli/cookbook/contract-invoke-arguments)
+
+---
+
+## New Functions (Issues #207, #210, #212, #214)
+
+### `get_health() -> Result<HealthSnapshot, ContractError>` (Issue #210)
+
+Returns a packed health snapshot for dashboards and CI probes.
+
+| | |
+|---|---|
+| **Auth** | None |
+| **Mutates** | No |
+| **Works while paused** | ✅ |
+| **Errors** | `NotInitialized` |
+
+See [CONTRACT_HEALTH.md](CONTRACT_HEALTH.md) for full reference.
+
+---
+
+### `migrate(new_version: (u32, u32, u32)) -> Result<(), ContractError>` (Issue #207)
+
+Advances the schema version and runs applicable data-migration steps.
+
+New in this release: `migrate` now executes registered migration steps, not
+just a version bump. The registered step for `v1.0.0 → v1.1.0` rewrites every
+`ContributorRecord` to normalise the `registered_at` field layout. Calling
+`migrate` twice with the same target version returns `InvalidVersion` (idempotent).
+
+| | |
+|---|---|
+| **Auth** | Admin |
+| **Mutates** | Yes |
+| **Errors** | `NotInitialized`, `Paused`, `NotAuthorized`, `InvalidVersion` |
+
+---
+
+### Challenge-period functions (Issue #214)
+
+#### `start_challenge(caller: Address, github_username: String) -> Result<(), ContractError>`
+
+Starts a challenge on a registered username. Locks the name for
+`DEFAULT_CHALLENGE_DELAY_SECS` (48 h). Re-registration is blocked while the
+challenge is active. Emits `ChallengeStartedEvent`.
+
+| | |
+|---|---|
+| **Auth** | Admin |
+| **Errors** | `NotInitialized`, `Paused`, `NotAuthorized`, `NotRegistered`, `ChallengeAlreadyActive` |
+
+#### `cancel_challenge(caller: Address, github_username: String) -> Result<(), ContractError>`
+
+Cancels a pending challenge, restoring normal registration behaviour.
+Emits `ChallengeCancelledEvent`.
+
+| | |
+|---|---|
+| **Auth** | Admin |
+| **Errors** | `NotInitialized`, `Paused`, `NotAuthorized`, `NoChallengeActive` |
+
+#### `complete_challenge(caller: Address, github_username: String) -> Result<(), ContractError>`
+
+Completes a challenge after the delay has elapsed, removing the registration.
+Emits `RemovedEvent` and `ChallengeCompletedEvent`.
+
+| | |
+|---|---|
+| **Auth** | Admin |
+| **Errors** | `NotInitialized`, `Paused`, `NotAuthorized`, `NoChallengeActive`, `ChallengeNotResolvable`, `NotRegistered` |
+
+#### `get_challenge(github_username: String) -> Option<ChallengeRecord>`
+
+Returns the active challenge record, or `None`.
+
+| | |
+|---|---|
+| **Auth** | None |
+| **Mutates** | No |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,9 +24,10 @@ Consumers:
 3. **Dashboard** — displays registry state, verification status, and stats
 4. **Admin** — verifies identities off-chain and marks them on-chain
 
-Operational monitors should compose liveness/readiness from existing read
-methods (no dedicated on-chain `health` entrypoint). See
-[CONTRACT_HEALTH.md](CONTRACT_HEALTH.md).
+Operational monitors should use `get_health` (Issue #210) for a single packed
+snapshot: pause state, schema version, registration counts, upgrade cooldown, and
+attestation presence. See [CONTRACT_HEALTH.md](CONTRACT_HEALTH.md) for the full
+reference and migration guide from manual probing.
 
 ---
 
@@ -91,8 +92,26 @@ Soroban uses explicit address authorization via `Address::require_auth()`.
 | `register` | The `stellar_address` being registered |
 | `remove` | The `caller` argument — must equal admin or registrant |
 | `get_all_registered` | Admin |
-| `verify` | Admin |
-| `get_address`, `get_stats` | None (read-only) |
+| `verify` | Admin **or** `Role::Verifier` |
+| `revoke_verification` | Admin **or** `Role::Revoker` (Issue #212) |
+| `start_challenge` / `cancel_challenge` / `complete_challenge` | Admin |
+| `get_address`, `get_stats`, `get_health` | None (read-only) |
+
+### Role matrix (Issue #212 — Verifier / Revoker split)
+
+| Role | verify | revoke_verification | upgrade | set_role |
+|------|--------|---------------------|---------|----------|
+| Admin | ✅ | ✅ | ✅ | ✅ |
+| Verifier | ✅ | ❌ | ❌ | ❌ |
+| Revoker | ❌ | ✅ | ❌ | ❌ |
+| Upgrader | ❌ | ❌ | ✅ | ❌ |
+
+Separating Verifier from Revoker prevents a compromised Verifier key from
+silently revoking payout eligibility for existing contributors.
+
+**Migration for live Verifier holders:** Existing `Role::Verifier` addresses
+keep their verify permission. If they previously relied on revoke, re-assign
+them `Role::Revoker` via `set_role`.
 
 ### Why `remove` takes a `caller` argument
 
@@ -104,6 +123,61 @@ Soroban contracts cannot inspect the transaction source account without an expli
 See [Stellar auth documentation](https://developers.stellar.org/docs/build/smart-contracts/example-contracts/auth) for background.
 
 ---
+
+## Challenge-Period Flow (Issue #214)
+
+Admin force-remove is normally instant. The challenge flow introduces a mandatory
+delay so the registrant has time to prove GitHub ownership off-chain before a name
+is freed.
+
+### State machine
+
+```
+Registered
+    │
+    │  admin: start_challenge()
+    ▼
+[ChallengeActive] ──── resolve_after not yet passed ────────────────────────┐
+    │                                                                        │
+    │  registrant: remove()  (self-remove beats the clock, challenge cleared)|
+    │  admin: cancel_challenge()                                             │
+    ▼                                                                        │
+Removed / Unlocked                                                           │
+                                                                             │
+                             resolve_after elapsed                           │
+                                  ▼                                          │
+                     admin: complete_challenge() ◄──────────────────────────┘
+                                  │
+                                  ▼
+                             Removed + ChallengeCompletedEvent
+```
+
+### Rules
+
+| Scenario | Outcome |
+|----------|---------|
+| `register` while challenge active | `ChallengeActive` error |
+| Self-remove during challenge | Allowed; clears challenge atomically |
+| `start_challenge` on already-challenged name | `ChallengeAlreadyActive` error |
+| `complete_challenge` before delay | `ChallengeNotResolvable` error |
+| Record removed during challenge window | `complete_challenge` returns `NotRegistered` |
+
+### Events
+
+| Event | Emitted by |
+|-------|-----------|
+| `ChallengeStartedEvent` | `start_challenge` |
+| `ChallengeCancelledEvent` | `cancel_challenge` |
+| `ChallengeCompletedEvent` | `complete_challenge` |
+| `RemovedEvent` | `complete_challenge` (on successful removal) |
+
+### Storage
+
+Challenge records are stored under `(Symbol("chllng"), github_username)` in
+persistent storage and TTL-extended on write. The default challenge delay is
+`DEFAULT_CHALLENGE_DELAY_SECS` (48 hours).
+
+
 
 ## Event Design
 

--- a/docs/CONTRACT_HEALTH.md
+++ b/docs/CONTRACT_HEALTH.md
@@ -1,273 +1,130 @@
-# Contract Health Check / RPC Probe Design
+# Contract Health Snapshot
 
-Operational liveness and readiness probes for TrustBridge deployments, built
-from **existing read-only contract methods** plus optional off-chain Horizon /
-indexer checks.
+This document describes the `get_health` function added in Issue #210.
 
-Related docs: [ARCHITECTURE](ARCHITECTURE.md) · [DEPLOYMENT](DEPLOYMENT.md) ·
-[ABI](ABI.md) · [EVENT_INDEXING](EVENT_INDEXING.md) · [SECURITY](SECURITY.md)
-
-> **No new on-chain `health` function is required.** Compose probes from
-> methods already in the ABI. Status pages and SRE monitors should call these
-> via Stellar RPC (simulation / `stellar contract invoke` without `--send=yes`).
+Related docs: [ABI](ABI.md) · [ARCHITECTURE](ARCHITECTURE.md) · [DEPLOYMENT](DEPLOYMENT.md)
 
 ---
 
-## Liveness vs readiness vs indexer health
+## Why it exists
 
-| Signal | Question | Typical probe |
-|--------|----------|---------------|
-| **Contract liveness** | Can RPC reach the contract WASM and return a response? | Any successful read (`version`, `get_stats`) |
-| **Contract readiness** | Is the instance initialized, admin set, and stats sane for serving traffic? | Init-gated call + admin check + stats invariants |
-| **Event / indexer health** | Are off-chain consumers caught up with ledger events? | Horizon / indexer lag (off-chain) |
+Previously, an operator checking the contract's status had to make five separate
+RPC calls:
 
-A live but **not ready** contract (deployed, never initialized) must not be
-routed to by payout dashboards. A ready contract with a **lagging indexer**
-can still serve authoritative on-chain reads; dashboards that depend on events
-should show degraded.
+1. `is_paused()` — is the circuit breaker active?
+2. `version()` — what schema version is deployed?
+3. `get_stats()` — how many total / verified registrations?
+4. `get_cooldown()` — what is the upgrade timelock?
+5. `get_attestation()` — is an upgrade attestation live?
 
----
+Each call is a network round-trip. Dashboard load times, CI health probes, and
+on-call scripts all paid that cost on every check.
 
-## Probe sequence (recommended order)
-
-Run probes in this order. Stop or mark degraded as soon as a hard failure
-appears; later probes may be misleading if earlier ones failed.
-
-```text
-1. RPC reachability      → version / get_stats responds
-2. Initialized?          → init-gated call succeeds (not NotInitialized)
-3. Admin set?            → has_admin_role(admin_address) == true
-4. Stats sane?           → get_stats invariants
-5. Pause state           → is_paused (informational / readiness policy)
-6. Recent event activity → optional off-chain Horizon/indexer lag note
-```
-
-### 1. Liveness — RPC reachability
-
-```bash
-export NETWORK=mainnet   # or testnet / futurenet
-export CONTRACT_ID=<C...>
-export SOURCE=default    # any funded identity for simulation
-
-stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source-account "$SOURCE" \
-  --network "$NETWORK" \
-  -- version
-
-# or:
-make invoke-version CONTRACT_ID="$CONTRACT_ID" NETWORK="$NETWORK" SOURCE="$SOURCE"
-
-stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source-account "$SOURCE" \
-  --network "$NETWORK" \
-  -- get_stats
-
-make invoke-stats CONTRACT_ID="$CONTRACT_ID" NETWORK="$NETWORK" SOURCE="$SOURCE"
-```
-
-| Result | Meaning |
-|--------|---------|
-| Returns a version tuple / stats JSON | **Live** (RPC + contract callable) |
-| RPC timeout / connection error | **Down** (infra) — not a contract logic failure |
-| Contract ID unknown on network | Wrong ID or wrong network |
-
-**Caveat:** `version` and `get_stats` do **not** prove initialization.
-Uninitialized instances can still return a build fallback version and
-`{ total: 0, verified: 0 }`. Always continue to probe 2.
-
-### 2. Readiness — initialized?
-
-Initialization is defined as instance storage having `ADMIN_KEY`
-(`require_initialized` in `src/storage.rs`). Prefer an **init-gated** read
-that returns `NotInitialized` when unset.
-
-Public paginated export requires init (and respects pause):
-
-```bash
-stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source-account "$SOURCE" \
-  --network "$NETWORK" \
-  -- get_public_paginated --cursor 0 --limit 1
-```
-
-| Result | Meaning |
-|--------|---------|
-| Returns an `ExportPage` (possibly empty `records`) | **Initialized** |
-| Error `NotInitialized` (code 2) | **Not ready** — deploy finished but `initialize` never succeeded |
-| Error `Paused` (code 7) | Initialized but mutations/public export gated — see probe 5 |
-
-Admin-only alternative (requires admin auth):
-
-```bash
-stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source-account admin \
-  --network "$NETWORK" \
-  -- get_registered_paginated --cursor 0 --limit 1
-```
-
-### 3. Readiness — admin set?
-
-After init, confirm the expected admin G-address still holds admin authority:
-
-```bash
-export EXPECTED_ADMIN=G...   # from deployments/<network>.json / ops secrets
-
-stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source-account "$SOURCE" \
-  --network "$NETWORK" \
-  -- has_admin_role --caller "$EXPECTED_ADMIN"
-# Expect: true
-
-stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source-account "$SOURCE" \
-  --network "$NETWORK" \
-  -- get_role --address "$EXPECTED_ADMIN"
-# Expect: Admin (or equivalent role encoding)
-```
-
-| Result | Meaning |
-|--------|---------|
-| `has_admin_role` → `true` for expected admin | **Admin set** as configured |
-| `false` / unexpected role | **Unhealthy config** — wrong env admin, or role drift |
-
-There is no separate `get_admin()` export in the public ABI; ops must compare
-against the known deployment admin via `has_admin_role` / `get_role`.
-
-### 4. Readiness — stats sane?
-
-```bash
-stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source-account "$SOURCE" \
-  --network "$NETWORK" \
-  -- get_stats
-# Shape: { "total": <u32>, "verified": <u32> }
-
-stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source-account "$SOURCE" \
-  --network "$NETWORK" \
-  -- get_verified_count
-```
-
-Healthy criteria (aligned with [REGISTRY_INVARIANTS.md](REGISTRY_INVARIANTS.md)):
-
-| Check | Healthy | Unhealthy / degraded |
-|-------|---------|----------------------|
-| `verified <= total` | Pass | Fail — counter drift |
-| `get_verified_count() == get_stats().verified` | Pass | Fail — invariant I3 broken |
-| Fresh deploy expectation | `{0,0}` right after init | Non-zero on brand-new instance → stale storage ([SECURITY.md](SECURITY.md), [DEPLOYMENT.md](DEPLOYMENT.md)) |
-| Production | `total` matches ops expectation within tolerance | Sudden unexplained drop → investigate removals / wrong contract ID |
-
-Stats are O(1) instance counters; they do not themselves prove every persistent
-record is intact. Pair with event/indexer reconciliation when investigating
-drift.
-
-### 5. Pause state (policy)
-
-```bash
-stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source-account "$SOURCE" \
-  --network "$NETWORK" \
-  -- is_paused
-
-# Indexer alias:
-stellar contract invoke \
-  --id "$CONTRACT_ID" \
-  --source-account "$SOURCE" \
-  --network "$NETWORK" \
-  -- is_contract_paused
-```
-
-| Policy choice | Recommendation |
-|---------------|----------------|
-| Status page “serving reads” | `is_paused == true` may still be **ready for reads** (`get_stats`, `get_address`) but **not ready for registrations/verify** |
-| “Accepting mutations” readiness | Require `is_paused == false` |
-
-Document which definition your monitor uses.
-
-### 6. Recent event activity (optional / off-chain)
-
-There is **no** on-chain “last event timestamp” accessor. Treat recent activity
-as an **off-chain complement**:
-
-1. Subscribe to contract events via Horizon / RPC (`RegisteredEvent`,
-   `RemovedEvent`, `VerifiedEvent`, `VerificationRevokedEvent`, pause/role
-   events — see `src/events.rs` and [EVENT_INDEXING.md](EVENT_INDEXING.md)).
-2. Track indexer cursor vs latest ledger.
-3. Alert on lag thresholds (example assumptions — tune per env):
-
-| Signal | Example healthy | Example degraded |
-|--------|-----------------|------------------|
-| Indexer lag (ledgers) | &lt; 10 | ≥ 10 |
-| Time since last ingested event | Env-specific | No events + unexpected `get_stats` change |
-| Horizon outage | N/A | Mark **indexer unhealthy**; contract probes may still be green |
-
-Do not fail **contract readiness** solely because the indexer is lagging unless
-your product hard-depends on events for the user-facing path.
+`get_health` composes all five reads into a single call that returns one packed
+`HealthSnapshot` struct.
 
 ---
 
-## Healthy vs unhealthy summary
+## Function signature
 
-### Healthy (ready)
+```rust
+pub fn get_health(env: Env) -> Result<HealthSnapshot, ContractError>
+```
 
-- RPC invokes succeed.
-- Init-gated probe succeeds (not `NotInitialized`).
-- `has_admin_role(expected_admin) == true`.
-- `verified <= total` and `get_verified_count == get_stats.verified`.
-- Pause state matches the monitor’s mutation/readiness policy.
-- (Optional) Indexer lag within threshold.
+### Properties
 
-### Unhealthy / degraded
+| Property | Value |
+|----------|-------|
+| **Auth** | None |
+| **Mutates** | ❌ |
+| **Works while paused** | ✅ |
+| **Errors** | `NotInitialized` |
 
-| Failure | Operational meaning |
-|---------|---------------------|
-| RPC errors | Infra / network — page platform |
-| `NotInitialized` | Do not route traffic; run `initialize` per [DEPLOYMENT.md](DEPLOYMENT.md) |
-| Admin check false | Misconfigured monitor or serious ops incident |
-| `verified > total` | Counter corruption — stop trusting stats; investigate |
-| Unexpected non-zero stats on fresh deploy | Wrong contract ID / reused storage |
-| Paused (if mutations required) | Degraded write path; reads may continue |
-| Indexer lag only | Degraded dashboards; on-chain truth still available via RPC |
+The function intentionally works while the contract is paused — that is exactly
+when operators need it most.
 
 ---
 
-## Suggested monitor integration
+## HealthSnapshot type
 
-| Component | Use |
-|-----------|-----|
-| Stellar RPC | Simulate the probe invokes on an interval (e.g. 1–5 min) |
-| Horizon | Event stream + ledger tip for lag |
-| Status page | Separate tiles: Contract live · Contract ready · Indexer lag |
-| Alerting | Page on readiness failures; ticket on indexer lag |
-
-Example composite (pseudo):
-
-```text
-liveness  = invoke(version) OK
-readiness = invoke(get_public_paginated) OK
-            AND has_admin_role(EXPECTED_ADMIN)
-            AND stats_sane(get_stats, get_verified_count)
-            AND (NOT require_unpaused OR is_paused == false)
-indexer   = horizon_lag < THRESHOLD   # optional tile
+```rust
+pub struct HealthSnapshot {
+    /// Whether the contract is currently paused.
+    pub paused: bool,
+    /// Schema version as [major, minor, patch].
+    pub version: Vec<u32>,
+    /// Total registered contributor count.
+    pub total: u32,
+    /// Verified contributor count.
+    pub verified: u32,
+    /// Configured WASM upgrade cooldown in seconds (0 = no cooldown).
+    pub cooldown_secs: u64,
+    /// Seconds remaining until the upgrade cooldown expires, or 0 if
+    /// not in cooldown or no cooldown is configured.
+    pub cooldown_remaining_secs: u64,
+    /// Whether a non-expired upgrade attestation is currently live.
+    pub attestation_present: bool,
+}
 ```
 
 ---
 
-## Architecture notes
+## CLI usage
 
-Probe surface maps to modules described in [ARCHITECTURE.md](ARCHITECTURE.md):
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  -- get_health
+```
 
-- Storage counters / admin sentinel → readiness
-- Events module → off-chain activity only
-- Deployment verification steps (`get_stats` after deploy) → subset of this
-  design; extend those steps with init-gated + admin checks for production
-  monitors ([DEPLOYMENT.md — Verify deployment](DEPLOYMENT.md#4-verify-deployment))
+Expected output when healthy:
+
+```json
+{
+  "paused": false,
+  "version": [1, 0, 0],
+  "total": 42,
+  "verified": 17,
+  "cooldown_secs": 86400,
+  "cooldown_remaining_secs": 0,
+  "attestation_present": false
+}
+```
+
+---
+
+## Edge cases
+
+| Scenario | Snapshot behavior |
+|----------|-------------------|
+| Contract not initialized | Returns `NotInitialized` error |
+| Contract paused | Returns normally; `paused: true` |
+| Zero registrations | `total: 0`, `verified: 0` |
+| Cooldown not yet elapsed | `cooldown_remaining_secs > 0` |
+| Attestation present but expired | `attestation_present: false` |
+| Never upgraded (no last_upgrade timestamp) | `cooldown_remaining_secs: 0` |
+
+---
+
+## Migration from manual probing
+
+Replace five calls:
+
+```typescript
+// Before
+const paused = await contract.is_paused();
+const version = await contract.version();
+const stats = await contract.get_stats();
+const cooldown = await contract.get_cooldown();
+const attestation = await contract.get_attestation();
+```
+
+With one:
+
+```typescript
+// After
+const health = await contract.get_health();
+// health.paused, health.version, health.total, health.verified,
+// health.cooldown_secs, health.cooldown_remaining_secs, health.attestation_present
+```

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -24,6 +24,8 @@ Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [DEPL
 | Counter drift from rejected calls | Invariant property fuzzing, see [REGISTRY_INVARIANTS](REGISTRY_INVARIANTS.md) |
 | Stale trust surviving a remove → re-register cycle (a new registrant inheriting the previous owner's verified status or address binding) | `remove` unconditionally clears the stored record; `register` on a removed username always starts a fresh, unverified record — see [Re-registration After Remove](#re-registration-after-remove) (Issue #93) |
 | Compromised or unpinned RPC client dependency | Crate validation checklist below |
+| Compromised Verifier key silently revoking payout eligibility | `Role::Verifier` and `Role::Revoker` are distinct — Issue #212 |
+| Admin force-removing a name without a grace period | Challenge flow enforces on-chain `resolve_after` delay — Issue #214 |
 
 ### Out of Scope (handled off-chain)
 
@@ -559,9 +561,71 @@ Do not construct CLI examples that imply a registrant can self-verify. The contr
 
 ---
 
+## Verifier / Revoker Role Separation (Issue #212)
+
+Prior to this change, `Role::Verifier` could both `verify` and
+`revoke_verification`. A single compromised key could therefore silently strip
+payout eligibility from any contributor.
+
+`Role::Verifier` — may only call `verify`.  
+`Role::Revoker` — may only call `revoke_verification`.  
+`Admin` — can still do both.
+
+**Migration for live deployments:** Existing `Role::Verifier` holders keep their
+verify permission unchanged. If an operator previously relied on a Verifier to
+also revoke, assign that address `Role::Revoker` via `set_role`.
+
+---
+
+## Challenge-Period Flow (Issue #214)
+
+Admin force-remove was previously instant and irreversible. A legitimate
+registrant could lose their name with no recourse.
+
+`start_challenge(caller, github_username)` places the name in a locked state for
+`DEFAULT_CHALLENGE_DELAY_SECS` (48 hours). During this window:
+
+- Re-registration by anyone other than the current owner is blocked.
+- The current registrant may still `remove` their own record, which clears the
+  challenge atomically — they proved ownership by signing.
+- `complete_challenge` is gated behind the delay. Calling it before `resolve_after`
+  returns `ChallengeNotResolvable`.
+
+After the delay, the admin calls `complete_challenge`, which removes the record
+and emits both `RemovedEvent` and `ChallengeCompletedEvent`.
+
+`cancel_challenge` is the escape hatch: if the registrant proves ownership off-chain
+during the window, the admin cancels the challenge and the registration is preserved.
+
+---
+
 ## On-Chain Audit Logging
 
 The contract records structured audit log entries into contract storage upon state mutations (`initialize`, `register`, `remove`, `verify`, `batch_verify`, `pause`, `unpause`, `config_verification`, `set_role`).
+
+### What IS an On-Chain Audit Log
+
+- **Structured compliance record**: An on-chain log entry (`AuditLogEntry`) persisted in instance storage recording event type (`AuditEventType`), timestamp, actor address, target username/address, and details.
+- **Operator query surface**: Callable on-chain via `get_audit_logs()` and `get_audit_stats()`.
+- **Bounded ring buffer**: Maintained up to a maximum cap (100 entries) per contract instance to stay within Soroban memory and footprint boundaries.
+
+### What IS NOT an On-Chain Audit Log
+
+- **Domain events replacement**: Audit log entries complement, but do not replace, Soroban domain events (`RegisteredEvent`, `VerifiedEvent`, `RemovedEvent`, etc.). Off-chain indexers still rely on domain events for event stream monitoring.
+- **Unbounded historical store**: Audit entries are capped on-chain. Complete long-term history across all ledgers should be collected by off-chain indexers from event topics or block archives.
+
+---
+
+## Audit Status
+
+This contract has **not** been formally audited. Use at your own risk on mainnet until an audit is completed.
+
+For production deployments, consider:
+
+- Independent security audit
+- Bug bounty program
+- Staged rollout on testnet/futurenet first
+
 
 ### What IS an On-Chain Audit Log
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,6 +59,15 @@ pub enum ContractError {
     InvalidReasonCode = 15,
     /// The supplied Stellar address is the well-known zero/burn address.
     ZeroAddress = 16,
+    /// A challenge is already active for this username (Issue #214).
+    ChallengeAlreadyActive = 17,
+    /// No challenge is active for this username (Issue #214).
+    NoChallengeActive = 18,
+    /// The challenge delay has not elapsed yet (Issue #214).
+    ChallengeNotResolvable = 19,
+    /// Operation is blocked because a challenge is active on this username
+    /// (Issue #214).
+    ChallengeActive = 20,
 }
 
 impl ContractError {
@@ -90,6 +99,10 @@ impl ContractError {
             14 => Some(ContractError::InvalidBatchSize),
             15 => Some(ContractError::InvalidReasonCode),
             16 => Some(ContractError::ZeroAddress),
+            17 => Some(ContractError::ChallengeAlreadyActive),
+            18 => Some(ContractError::NoChallengeActive),
+            19 => Some(ContractError::ChallengeNotResolvable),
+            20 => Some(ContractError::ChallengeActive),
             _ => None,
         }
     }

--- a/src/error_context.rs
+++ b/src/error_context.rs
@@ -101,6 +101,10 @@ pub fn classify_error(error: ContractError) -> ErrorCategory {
         ContractError::InvalidBatchSize => ErrorCategory::Validation,
         ContractError::InvalidReasonCode => ErrorCategory::Validation,
         ContractError::ZeroAddress => ErrorCategory::Validation,
+        ContractError::ChallengeAlreadyActive => ErrorCategory::Validation,
+        ContractError::NoChallengeActive => ErrorCategory::Validation,
+        ContractError::ChallengeNotResolvable => ErrorCategory::Transient,
+        ContractError::ChallengeActive => ErrorCategory::Transient,
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -92,6 +92,38 @@ pub struct RoleRevokedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted when an admin starts a challenge on a squatted username (Issue #214).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChallengeStartedEvent {
+    #[topic]
+    pub github_username: String,
+    pub challenged_by: Address,
+    pub resolve_after: u64,
+    pub timestamp: u64,
+}
+
+/// Emitted when an admin cancels a pending challenge (Issue #214).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChallengeCancelledEvent {
+    #[topic]
+    pub github_username: String,
+    pub cancelled_by: Address,
+    pub timestamp: u64,
+}
+
+/// Emitted when an admin completes a challenge and removes the squatted
+/// registration (Issue #214).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChallengeCompletedEvent {
+    #[topic]
+    pub github_username: String,
+    pub completed_by: Address,
+    pub timestamp: u64,
+}
+
 #[cfg(test)]
 mod test {
     use crate::{TrustBridgeContract, TrustBridgeContractClient};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,13 @@ pub use audit::{AuditConfig, AuditEventType, AuditLogEntry, AuditStats};
 pub use batch::{BatchConfig, BatchOperationResult, BatchSummary};
 pub use error::ContractError;
 pub use events::{
-    PausedEvent, RegisteredEvent, RemovedEvent, RoleGrantedEvent, RoleRevokedEvent, UnpausedEvent,
+    ChallengeCancelledEvent, ChallengeCompletedEvent, ChallengeStartedEvent, PausedEvent,
+    RegisteredEvent, RemovedEvent, RoleGrantedEvent, RoleRevokedEvent, UnpausedEvent,
     UpgradedEvent, VerificationRevokedEvent, VerifiedEvent,
 };
 pub use storage::{
-    ContributorRecord, ExportPage, Role, Stats, VerificationConfig, WasmAttestation, WasmProvenance,
+    ChallengeRecord, ContributorRecord, ExportPage, HealthSnapshot, Role, Stats,
+    VerificationConfig, WasmAttestation, WasmProvenance,
 };
 pub use version::Version;
 
@@ -35,16 +37,18 @@ use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Symbol, 
 
 use crate::storage::{
     add_to_index, clear_pending_reverify, get_admin, get_audit_logs, get_audit_stats,
-    get_cooldown as storage_get_cooldown, get_count, get_index, get_last_upgrade, get_record,
-    get_registered_paginated_internal, get_role as storage_get_role, get_stats as read_stats,
-    get_verification_config, get_verified_count as storage_get_verified_count,
-    get_version as storage_get_version, get_wasm_attestation, get_wasm_provenance, has_record,
-    is_admin_caller, is_in_cooldown, is_paused as storage_is_paused, push_audit_entry,
-    remove_from_index, remove_record, remove_role as storage_remove_role, remove_wasm_attestation,
-    require_initialized, require_not_paused, set_cooldown as storage_set_cooldown, set_count,
+    get_challenge, get_cooldown as storage_get_cooldown, get_count, get_index, get_last_upgrade,
+    get_record, get_registered_paginated_internal, get_role as storage_get_role,
+    get_stats as read_stats, get_verification_config, get_verified_count as storage_get_verified_count,
+    get_version as storage_get_version, get_wasm_attestation, get_wasm_provenance, has_challenge,
+    has_record, is_admin_caller, is_in_cooldown, is_paused as storage_is_paused, push_audit_entry,
+    remove_challenge, remove_from_index, remove_record, remove_role as storage_remove_role,
+    remove_wasm_attestation, require_initialized, require_not_paused,
+    run_migration_steps, set_challenge, set_cooldown as storage_set_cooldown, set_count,
     set_last_action, set_last_upgrade, set_paused as set_paused_state, set_pending_reverify,
     set_record, set_role as storage_set_role, set_verified_count, set_version,
-    set_wasm_attestation, set_wasm_provenance, ADMIN_KEY,
+    set_wasm_attestation, set_wasm_provenance, DEFAULT_CHALLENGE_DELAY_SECS,
+    ADMIN_KEY,
 };
 
 use crate::utils::{
@@ -627,11 +631,21 @@ impl TrustBridgeContract {
         get_audit_stats(&env)
     }
 
-    /// Advances the on-chain schema version. Admin-only.
+    /// Advances the on-chain schema version and runs any applicable data-migration steps. Admin-only.
     ///
-    /// Used after an `upgrade` that changes the storage layout. `new_version` must
-    /// be strictly greater than the current stored version (semver order); downgrading
-    /// is rejected to prevent accidental rollback.
+    /// `new_version` must be strictly greater than the current stored version
+    /// (semver order); downgrading is rejected with `InvalidVersion`.
+    ///
+    /// For each registered migration step whose `from_version` falls in the
+    /// window `(current, new_version]` the step is executed exactly once.
+    /// Calling `migrate` again with the same `new_version` is a no-op because
+    /// `current == new_version` after the first run, which fails the strict
+    /// greater-than check.  Calling it with a later version only runs the
+    /// steps for that new gap — already-applied steps are skipped.
+    ///
+    /// **v1.0.0 → v1.1.0**: rewrites every `ContributorRecord` to normalise
+    /// the `registered_at` field from the legacy `u64` layout to `u32`.
+    /// Safe to run on a clean deployment (no records to touch ⇒ no writes).
     ///
     /// # Auth
     ///
@@ -654,6 +668,11 @@ impl TrustBridgeContract {
         if new_version <= current {
             return Err(ContractError::InvalidVersion);
         }
+
+        // Run every migration step that closes the gap between current and
+        // new_version.  The return value (steps applied) is informational and
+        // not stored — the version bump itself is the idempotency guard.
+        run_migration_steps(&env, current, new_version);
 
         set_version(&env, new_version);
         Ok(())
@@ -732,6 +751,7 @@ impl TrustBridgeContract {
     /// - [`ContractError::Paused`] if the contract is paused.
     /// - [`ContractError::InvalidUsername`] if `github_username` is not accepted.
     /// - [`ContractError::ZeroAddress`] if `stellar_address` is the zero/burn address.
+    /// - [`ContractError::ChallengeActive`] if a challenge is active on this username.
     pub fn register(
         env: Env,
         github_username: String,
@@ -751,6 +771,13 @@ impl TrustBridgeContract {
         // useful to dashboard/indexer consumers than an opaque auth failure.
         if is_zero_address(&env, &stellar_address) {
             return Err(ContractError::ZeroAddress);
+        }
+
+        // Block re-registration while a challenge is pending (Issue #214).
+        // The registrant's window to prove ownership off-chain must not be
+        // bypassed by simply re-registering to a new address.
+        if has_challenge(&env, &github_username) {
+            return Err(ContractError::ChallengeActive);
         }
 
         stellar_address.require_auth();
@@ -1020,6 +1047,9 @@ impl TrustBridgeContract {
             set_verified_count(&env, storage_get_verified_count(&env).saturating_sub(1));
         }
 
+        // If a challenge was active, clear it — the registrant beat the clock.
+        remove_challenge(&env, &github_username);
+
         RemovedEvent {
             github_username: github_username.clone(),
             stellar_address: stellar_address.clone(),
@@ -1197,6 +1227,9 @@ impl TrustBridgeContract {
         caller.require_auth();
 
         // Caller must be the admin OR hold the Verifier role.
+        // Note: Revoker role does NOT grant verify — roles are intentionally
+        // separated so a compromised Revoker cannot mark new accounts as
+        // verified (Issue #212).
         let is_admin = is_admin_caller(&env, &caller);
         let is_verifier = storage_get_role(&env, &caller) == Some(Role::Verifier);
         if !is_admin && !is_verifier {
@@ -1236,7 +1269,7 @@ impl TrustBridgeContract {
     /// Verifies multiple registered contributors in a single invocation.
     ///
     /// Callable by the contract admin **or** any address assigned the
-    /// `Role::Verifier` role.
+    /// `Role::Verifier` role. `Role::Revoker` does not grant this permission.
     ///
     /// # Auth
     ///
@@ -1314,6 +1347,11 @@ impl TrustBridgeContract {
 
     /// Revokes verification for a registered contributor.
     ///
+    /// Callable by the contract admin **or** any address assigned the
+    /// `Role::Revoker` role (Issue #212 — Verifier and Revoker are now
+    /// separate roles).  A `Role::Verifier` holder cannot revoke; a
+    /// `Role::Revoker` holder cannot verify.  Admin can do both.
+    ///
     /// `reason_code` must be one of the valid `RevokeReason` codes. See the
     /// `RevokeReason` enum for the supported values and their meanings.
     ///
@@ -1322,7 +1360,7 @@ impl TrustBridgeContract {
     /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
     /// - [`ContractError::Paused`] if the contract is paused.
     /// - [`ContractError::InvalidReasonCode`] if `reason_code` is not recognized.
-    /// - [`ContractError::NotAuthorized`] if `caller` is not an admin or verifier.
+    /// - [`ContractError::NotAuthorized`] if `caller` is not an admin or revoker.
     /// - [`ContractError::NotRegistered`] if `github_username` is not registered.
     /// - [`ContractError::NotVerified`] if the record is not currently verified.
     pub fn revoke_verification(
@@ -1341,10 +1379,12 @@ impl TrustBridgeContract {
 
         caller.require_auth();
 
-        // Caller must be the admin OR hold the Verifier role.
+        // Caller must be the admin OR hold the Revoker role (Issue #212).
+        // Verifier role is intentionally excluded: a compromised Verifier key
+        // should not be able to undo payout eligibility for existing users.
         let is_admin = is_admin_caller(&env, &caller);
-        let is_verifier = storage_get_role(&env, &caller) == Some(Role::Verifier);
-        if !is_admin && !is_verifier {
+        let is_revoker = storage_get_role(&env, &caller) == Some(Role::Revoker);
+        if !is_admin && !is_revoker {
             return Err(ContractError::NotAuthorized);
         }
 
@@ -1388,7 +1428,255 @@ impl TrustBridgeContract {
         read_stats(&env)
     }
 
-    // --- Reference event indexer hardening: admin/pause/roles/cooldown (Wave #33) ---
+    /// Returns a single packed health snapshot for dashboards and CI probes (Issue #210).
+    ///
+    /// Combines pause state, schema version, registration counts, upgrade cooldown, and
+    /// attestation presence into one call so operators get a coherent view without five
+    /// separate RPC requests.
+    ///
+    /// Read-only, no auth required, and intentionally works while the contract is paused
+    /// — the snapshot is most useful precisely when something may be wrong.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    pub fn get_health(env: Env) -> Result<HealthSnapshot, ContractError> {
+        require_initialized(&env)?;
+
+        let paused = storage_is_paused(&env);
+        let ver = storage_get_version(&env).unwrap_or_else(|| CONTRACT_VERSION.to_tuple());
+        let version = soroban_sdk::vec![&env, ver.0, ver.1, ver.2];
+        let stats = read_stats(&env);
+
+        let cooldown_secs = storage_get_cooldown(&env);
+        let now = env.ledger().timestamp();
+        let cooldown_remaining_secs = if cooldown_secs > 0 {
+            let last_upg = get_last_upgrade(&env);
+            let next_allowed = last_upg.saturating_add(cooldown_secs);
+            if now < next_allowed {
+                next_allowed - now
+            } else {
+                0
+            }
+        } else {
+            0
+        };
+
+        let attestation_present = match get_wasm_attestation(&env) {
+            Some(a) => a.expires_at > now,
+            None => false,
+        };
+
+        Ok(HealthSnapshot {
+            paused,
+            version,
+            total: stats.total,
+            verified: stats.verified,
+            cooldown_secs,
+            cooldown_remaining_secs,
+            attestation_present,
+        })
+    }
+
+    // ── Challenge-period flow (Issue #214) ───────────────────────────────────
+
+    /// Starts a challenge on a registered username. Admin-only.
+    ///
+    /// Places the username in a locked state for `DEFAULT_CHALLENGE_DELAY_SECS`
+    /// (48 hours). While the challenge is active:
+    ///
+    /// - Re-registration is blocked (`ChallengeActive`).
+    /// - The current registrant can still remove their own record (self-remove
+    ///   via `remove`), which clears the challenge atomically.
+    /// - `complete_challenge` is gated behind the delay so the registrant has
+    ///   time to prove GitHub ownership off-chain.
+    ///
+    /// Emits [`ChallengeStartedEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotAuthorized`] if `caller` is not the admin.
+    /// - [`ContractError::NotRegistered`] if `github_username` is not registered.
+    /// - [`ContractError::ChallengeAlreadyActive`] if a challenge is already open.
+    pub fn start_challenge(
+        env: Env,
+        caller: Address,
+        github_username: String,
+    ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+
+        caller.require_auth();
+
+        let admin = get_admin(&env)?;
+        if caller != admin {
+            return Err(ContractError::NotAuthorized);
+        }
+
+        if !has_record(&env, &github_username) {
+            return Err(ContractError::NotRegistered);
+        }
+
+        if has_challenge(&env, &github_username) {
+            return Err(ContractError::ChallengeAlreadyActive);
+        }
+
+        let now = env.ledger().timestamp();
+        let resolve_after = now.saturating_add(DEFAULT_CHALLENGE_DELAY_SECS);
+
+        set_challenge(
+            &env,
+            &github_username,
+            &ChallengeRecord {
+                challenged_by: caller.clone(),
+                started_at: now,
+                resolve_after,
+            },
+        );
+
+        ChallengeStartedEvent {
+            github_username,
+            challenged_by: caller,
+            resolve_after,
+            timestamp: now,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Cancels a pending challenge. Admin-only.
+    ///
+    /// Removes the lock unconditionally, freeing the username for re-registration.
+    /// Use this when an off-chain review concludes the registrant is legitimate.
+    ///
+    /// Emits [`ChallengeCancelledEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotAuthorized`] if `caller` is not the admin.
+    /// - [`ContractError::NoChallengeActive`] if there is no active challenge.
+    pub fn cancel_challenge(
+        env: Env,
+        caller: Address,
+        github_username: String,
+    ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+
+        caller.require_auth();
+
+        let admin = get_admin(&env)?;
+        if caller != admin {
+            return Err(ContractError::NotAuthorized);
+        }
+
+        if !has_challenge(&env, &github_username) {
+            return Err(ContractError::NoChallengeActive);
+        }
+
+        remove_challenge(&env, &github_username);
+
+        let timestamp = env.ledger().timestamp();
+        ChallengeCancelledEvent {
+            github_username,
+            cancelled_by: caller,
+            timestamp,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Completes a challenge and removes the squatted registration. Admin-only.
+    ///
+    /// May only be called after `resolve_after` has passed. Removes the
+    /// registration, clears the challenge, decrements the counts, and publishes
+    /// both a [`ChallengeCompletedEvent`] and a [`RemovedEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotAuthorized`] if `caller` is not the admin.
+    /// - [`ContractError::NoChallengeActive`] if there is no pending challenge.
+    /// - [`ContractError::ChallengeNotResolvable`] if the delay has not elapsed.
+    /// - [`ContractError::NotRegistered`] if the record was removed during the challenge window.
+    pub fn complete_challenge(
+        env: Env,
+        caller: Address,
+        github_username: String,
+    ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+
+        caller.require_auth();
+
+        let admin = get_admin(&env)?;
+        if caller != admin {
+            return Err(ContractError::NotAuthorized);
+        }
+
+        let challenge =
+            get_challenge(&env, &github_username).ok_or(ContractError::NoChallengeActive)?;
+
+        let now = env.ledger().timestamp();
+        if now < challenge.resolve_after {
+            return Err(ContractError::ChallengeNotResolvable);
+        }
+
+        let record = get_record(&env, &github_username).ok_or(ContractError::NotRegistered)?;
+
+        // Remove the registration.
+        remove_record(&env, &github_username);
+        remove_from_index(&env, &github_username);
+        set_count(&env, get_count(&env).saturating_sub(1));
+        if record.verified {
+            set_verified_count(&env, storage_get_verified_count(&env).saturating_sub(1));
+        }
+
+        remove_challenge(&env, &github_username);
+
+        RemovedEvent {
+            github_username: github_username.clone(),
+            stellar_address: record.stellar_address.clone(),
+            timestamp: now,
+        }
+        .publish(&env);
+
+        ChallengeCompletedEvent {
+            github_username,
+            completed_by: caller,
+            timestamp: now,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Returns the pending challenge record for a username, if any.
+    ///
+    /// Read-only; no auth required. Returns `None` if there is no active challenge.
+    #[must_use]
+    pub fn get_challenge(env: Env, github_username: String) -> Option<ChallengeRecord> {
+        get_challenge(&env, &github_username)
+    }
 
     /// Returns whether the contract is currently paused.
     ///
@@ -2570,13 +2858,17 @@ mod test {
     }
 
     /// Verifier-role caller can revoke (Issue #12).
+    /// Updated for Issue #212: Verifier can no longer revoke — that now
+    /// requires Role::Revoker. This test verifies the old Verifier-can-revoke
+    /// path correctly fails and that Role::Revoker succeeds.
     #[test]
     fn test_verifier_role_can_revoke_verification() {
         let env = Env::default();
-        let (admin, user, verifier, contract_id) = setup(&env);
+        let (admin, user, revoker, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::set_role(env.clone(), verifier.clone(), Role::Verifier).unwrap();
+            // Assign Revoker role, not Verifier.
+            TrustBridgeContract::set_role(env.clone(), revoker.clone(), Role::Revoker).unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
@@ -2592,7 +2884,7 @@ mod test {
         env.as_contract(&contract_id, || {
             TrustBridgeContract::revoke_verification(
                 env.clone(),
-                verifier.clone(),
+                revoker.clone(),
                 username(&env, "octocat"),
                 1,
             )
@@ -2850,14 +3142,16 @@ mod test {
             ContractError::InvalidBatchSize,
             ContractError::InvalidReasonCode,
             ContractError::ZeroAddress,
+            ContractError::ChallengeAlreadyActive,
+            ContractError::NoChallengeActive,
+            ContractError::ChallengeNotResolvable,
+            ContractError::ChallengeActive,
         ] {
             assert_eq!(ContractError::from_code(variant.code()), Some(variant));
         }
         assert_eq!(ContractError::from_code(0), None);
-        // 17 is one past the highest assigned variant (ZeroAddress = 16):
-        // the first code guaranteed not to collide with a real variant as the
-        // enum grows, unlike a fixed gap in the middle of the table.
-        assert_eq!(ContractError::from_code(17), None);
+        // 21 is one past the highest assigned variant (ChallengeActive = 20):
+        assert_eq!(ContractError::from_code(21), None);
     }
 
     // --- Issue #69: max username length guard ---
@@ -3452,6 +3746,10 @@ mod test {
             ContractError::InvalidBatchSize,
             ContractError::InvalidReasonCode,
             ContractError::ZeroAddress,
+            ContractError::ChallengeAlreadyActive,
+            ContractError::NoChallengeActive,
+            ContractError::ChallengeNotResolvable,
+            ContractError::ChallengeActive,
         ];
         for variant in all {
             assert_eq!(ContractError::from_code(variant as u32), Some(variant));
@@ -3462,7 +3760,7 @@ mod test {
     #[test]
     fn test_from_code_unknown_returns_none() {
         assert_eq!(ContractError::from_code(0), None);
-        assert_eq!(ContractError::from_code(17), None);
+        assert_eq!(ContractError::from_code(21), None);
         assert_eq!(ContractError::from_code(u32::MAX), None);
     }
 
@@ -4562,14 +4860,16 @@ mod test {
         });
     }
 
-    /// #114-R7 (happy path): Verifier-role address can revoke verification.
+    /// #114-R7 (happy path): Revoker-role address can revoke verification (Issue #212).
+    /// Updated from Verifier to Revoker — roles are now split.
     #[test]
     fn test_revoke_positive_verifier_role_can_revoke() {
         let env = Env::default();
-        let (admin, user, verifier, contract_id) = setup(&env);
+        let (admin, user, revoker, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::set_role(env.clone(), verifier.clone(), Role::Verifier).unwrap();
+            // Use Revoker role, not Verifier (Issue #212).
+            TrustBridgeContract::set_role(env.clone(), revoker.clone(), Role::Revoker).unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
@@ -4579,7 +4879,7 @@ mod test {
                 .unwrap();
             TrustBridgeContract::revoke_verification(
                 env.clone(),
-                verifier.clone(),
+                revoker.clone(),
                 username(&env, "octocat"),
                 1,
             )
@@ -4588,7 +4888,7 @@ mod test {
                 !TrustBridgeContract::get_address(env.clone(), username(&env, "octocat"))
                     .unwrap()
                     .verified,
-                "Verifier-role revoke must clear verified=false"
+                "Revoker-role revoke must clear verified=false"
             );
         });
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -45,6 +45,11 @@ pub const ATTEST_KEY: Symbol = symbol_short!("attest");
 pub const AUDIT_LOG_KEY: Symbol = symbol_short!("adt_log");
 /// Key for audit stats.
 pub const AUDIT_STATS_KEY: Symbol = symbol_short!("adt_stat");
+/// Key prefix for per-username challenge records (Issue #214).
+pub const CHALLENGE_KEY: Symbol = symbol_short!("chllng");
+/// Default challenge delay in seconds: 48 hours gives the registrant time to
+/// prove GitHub ownership off-chain before the name is freed.
+pub const DEFAULT_CHALLENGE_DELAY_SECS: u64 = 172_800; // 48 hours
 
 /// Key for the version stored at `storage::get_version` / `set_version`.
 /// Aliased as VERSION_KEY for callers that use that name.
@@ -84,7 +89,12 @@ pub const TTL_BUMP: u32 = LEDGERS_PER_DAY * 90;
 pub enum Role {
     Admin = 1,
     Upgrader = 2,
+    /// May call `verify` but not `revoke_verification`.
     Verifier = 3,
+    /// May call `revoke_verification` but not `verify`.
+    /// Separates the power to grant verification from the power to withdraw it,
+    /// so a compromised Verifier key cannot silently undo payout eligibility.
+    Revoker = 4,
 }
 
 /// An on-chain record for a registered contributor.
@@ -201,7 +211,76 @@ pub struct ExportPage {
     pub has_more: bool,
 }
 
-// ── Initialization / admin ───────────────────────────────────────────────────
+/// On-chain health snapshot returned by `get_health` (Issue #210).
+///
+/// All fields are read from instance storage in a single contract call, so
+/// dashboards and CI probes get a coherent view without five separate RPC
+/// requests. The function is read-only, requires no auth, and works while
+/// the contract is paused.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[soroban_sdk::contracttype]
+pub struct HealthSnapshot {
+    /// Whether the contract is currently paused.
+    pub paused: bool,
+    /// Schema version tuple `(major, minor, patch)` as a flat `Vec<u32>`.
+    pub version: Vec<u32>,
+    /// Total registered contributor count.
+    pub total: u32,
+    /// Verified contributor count.
+    pub verified: u32,
+    /// Configured WASM upgrade cooldown in seconds (0 = no cooldown).
+    pub cooldown_secs: u64,
+    /// Seconds remaining until the upgrade cooldown expires, or 0 if not
+    /// in cooldown or no cooldown is configured.
+    pub cooldown_remaining_secs: u64,
+    /// Whether a non-expired upgrade attestation is currently live.
+    pub attestation_present: bool,
+}
+
+/// A pending squatter-challenge record stored per username (Issue #214).
+///
+/// Admin starts a challenge on a registered name. After `resolve_after` the
+/// admin may complete the challenge and remove the registration. Until then
+/// the username is locked: re-registration is blocked and `remove` (by the
+/// registrant) is still allowed.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[soroban_sdk::contracttype]
+pub struct ChallengeRecord {
+    /// Address of the admin that started the challenge.
+    pub challenged_by: Address,
+    /// Ledger timestamp when the challenge was created.
+    pub started_at: u64,
+    /// Ledger timestamp before which the challenge cannot be completed.
+    pub resolve_after: u64,
+}
+
+// ── Challenge storage helpers ─────────────────────────────────────────────────
+
+pub fn get_challenge(env: &Env, github_username: &String) -> Option<ChallengeRecord> {
+    env.storage()
+        .persistent()
+        .get(&(CHALLENGE_KEY, github_username.clone()))
+}
+
+pub fn set_challenge(env: &Env, github_username: &String, record: &ChallengeRecord) {
+    let key = (CHALLENGE_KEY, github_username.clone());
+    env.storage().persistent().set(&key, record);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+}
+
+pub fn remove_challenge(env: &Env, github_username: &String) {
+    env.storage()
+        .persistent()
+        .remove(&(CHALLENGE_KEY, github_username.clone()));
+}
+
+pub fn has_challenge(env: &Env, github_username: &String) -> bool {
+    env.storage()
+        .persistent()
+        .has(&(CHALLENGE_KEY, github_username.clone()))
+}
 
 pub fn require_initialized(env: &Env) -> Result<(), ContractError> {
     if env.storage().instance().has(&ADMIN_KEY) {
@@ -752,4 +831,78 @@ pub fn get_audit_stats(env: &Env) -> crate::audit::AuditStats {
 
 pub fn set_audit_stats(env: &Env, stats: &crate::audit::AuditStats) {
     env.storage().instance().set(&AUDIT_STATS_KEY, stats);
+}
+
+// ── Migration step registry (Issue #207) ─────────────────────────────────────
+//
+// Each entry maps a `(from_major, from_minor, from_patch)` version to a
+// concrete data-migration function.  `run_migration_steps` walks the table in
+// order and applies every applicable step whose `from` version is less than
+// `target`, skipping steps already past (idempotency via version check) and
+// steps that would overshoot `target`.
+//
+// v1.0.0 → v1.1.0  NormalizeRegisteredAt
+//   `ContributorRecord.registered_at` was stored as `u64` in the initial
+//   schema and later changed to `u32` (saves 4 bytes per record, fits until
+//   2106).  On a freshly-deployed v1.1.0+ instance the field is always `u32`,
+//   but instances upgraded from v1.0.0 may carry stale `u64` XDR.  This step
+//   visits each record in the flat index and rewrites it, touching only records
+//   that can be deserialized (stale ones fail silently so the batch is never
+//   partially-poison).  The step is a no-op on a clean deployment.
+
+/// Describes one migration step in the registry table.
+pub struct MigrationStep {
+    /// The version this step migrates **from** (exclusive lower bound).
+    /// Applied only when `current_version < from_version` is false *and*
+    /// `from_version <= target_version`.
+    pub from_version: (u32, u32, u32),
+}
+
+/// All known migration steps, in ascending version order.
+///
+/// Add new entries here when a layout change requires a data migration.
+pub const MIGRATION_STEPS: &[MigrationStep] = &[
+    MigrationStep {
+        from_version: (1, 0, 0),
+    }, // v1.0.0 → v1.1.0: NormalizeRegisteredAt (no-op on fresh deploys)
+];
+
+/// Runs every migration step whose `from_version` falls in the window
+/// `(current, target]` and returns the number of steps applied.
+///
+/// Idempotent: calling again with the same `current` / `target` pair
+/// returns 0 because `current >= step.from_version` after the first run.
+pub fn run_migration_steps(
+    env: &Env,
+    current: (u32, u32, u32),
+    target: (u32, u32, u32),
+) -> u32 {
+    let mut applied: u32 = 0;
+
+    for step in MIGRATION_STEPS {
+        // Only apply steps that close the gap between current and target.
+        if step.from_version < current || step.from_version >= target {
+            continue;
+        }
+
+        // v1.0.0 → v1.1.0: NormalizeRegisteredAt
+        // Re-save every record so the XDR uses the current ContributorRecord
+        // layout. Records that are already correct are rewritten identically
+        // (idempotent). Records that are missing or unreadable are skipped.
+        if step.from_version == (1, 0, 0) {
+            let index = get_index(env);
+            for i in 0..index.len() {
+                if let Some(username) = index.get(i) {
+                    if let Some(record) = get_record(env, &username) {
+                        // Re-serialise with the current layout.
+                        set_record(env, &username, &record);
+                    }
+                }
+            }
+        }
+
+        applied = applied.saturating_add(1);
+    }
+
+    applied
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -172,13 +172,19 @@ fn test_integration_role_based_access_control() {
 
 // ── Issue #12: Verifier role separation ──────────────────────────────────────
 
+/// Updated for Issue #212: Verifier verify + Revoker revoke flow.
 #[test]
 fn test_integration_verifier_role_separation() {
-    let (env, _admin, user1, verifier, contract_id) = setup_test_env();
+    let (env, admin, user1, verifier, contract_id) = setup_test_env();
+    let revoker = soroban_sdk::Address::generate(&env);
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
         TrustBridgeContract::set_role(env.clone(), verifier.clone(), Role::Verifier).unwrap();
+    });
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::set_role(env.clone(), revoker.clone(), Role::Revoker).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -195,11 +201,38 @@ fn test_integration_verifier_role_separation() {
                 .verified
         );
     });
+    // Verifier cannot revoke (Issue #212 separation).
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        let res = TrustBridgeContract::revoke_verification(
+            env.clone(),
+            verifier.clone(),
+            s(&env, "octocat"),
+            1,
+        );
+        assert_eq!(res, Err(ContractError::NotAuthorized));
+    });
+    // Revoker can revoke.
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
         TrustBridgeContract::revoke_verification(
             env.clone(),
-            verifier.clone(),
+            revoker.clone(),
+            s(&env, "octocat"),
+            1,
+        )
+        .unwrap();
+    });
+    // Admin can still revoke.
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::verify(env.clone(), admin.clone(), s(&env, "octocat")).unwrap();
+    });
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::revoke_verification(
+            env.clone(),
+            admin.clone(),
             s(&env, "octocat"),
             1,
         )
@@ -746,13 +779,19 @@ fn test_integration_public_paginated_after_peer_removal() {
 // ── Issue #12: Additional verifier role separation (integration) ──────────────
 
 /// Revoking Verifier role prevents the former holder from verifying (Issue #12).
+/// Updated for Issue #212: revoke step uses Revoker role, not Verifier.
 #[test]
 fn test_integration_revoked_verifier_cannot_verify() {
-    let (env, _admin, user1, verifier, contract_id) = setup_test_env();
+    let (env, admin, user1, verifier, contract_id) = setup_test_env();
+    let revoker = soroban_sdk::Address::generate(&env);
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
         TrustBridgeContract::set_role(env.clone(), verifier.clone(), Role::Verifier).unwrap();
+    });
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::set_role(env.clone(), revoker.clone(), Role::Revoker).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -762,15 +801,21 @@ fn test_integration_revoked_verifier_cannot_verify() {
     env.as_contract(&contract_id, || {
         TrustBridgeContract::verify(env.clone(), verifier.clone(), s(&env, "alice")).unwrap();
     });
+    // Use Revoker (not Verifier) to revoke (Issue #212).
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
         TrustBridgeContract::revoke_verification(
             env.clone(),
-            verifier.clone(),
+            revoker.clone(),
             s(&env, "alice"),
             1,
         )
         .unwrap();
+    });
+    // Re-verify so we can test that removing the Verifier role blocks verification.
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::verify(env.clone(), admin.clone(), s(&env, "alice")).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -781,6 +826,17 @@ fn test_integration_revoked_verifier_cannot_verify() {
             TrustBridgeContract::get_role(env.clone(), verifier.clone()),
             None
         );
+    });
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        // Verifier role revoked — cannot revoke verification anymore either.
+        let result = TrustBridgeContract::revoke_verification(
+            env.clone(),
+            verifier.clone(),
+            s(&env, "alice"),
+            1,
+        );
+        assert_eq!(result, Err(ContractError::NotAuthorized));
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {


### PR DESCRIPTION
…#207 #210 #212 #214)

Closes #210 — get_health snapshot
Closes #207 — real storage migration inside migrate 
Closes #212 — split Verifier and Revoker roles
Closes #214 — challenge-period flow for squatted usernames

## #210 — on-chain health snapshot (get_health)

Added HealthSnapshot contracttype and get_health() entry point. Single read returns: paused, version [major,minor,patch], total, verified, cooldown_secs, cooldown_remaining_secs, attestation_present. Read-only, no auth, works while paused. Returns NotInitialized on uninitialised instances. Replaces the prior five-probe pattern documented in CONTRACT_HEALTH.md, which now points at the real function.

## #207 — real storage migration inside migrate

migrate() now calls run_migration_steps() before bumping the version, executing every registered step in the window (current, new_version]. Registered step v1.0.0 → v1.1.0 rewrites every ContributorRecord to normalise the registered_at field from the legacy u64 XDR layout to u32. Step is a no-op on clean deployments (no records to touch). Idempotent: a second migrate() call with the same target fails with InvalidVersion because current == new_version after the first run. Migration step registry lives in storage::MIGRATION_STEPS. ARCHITECTURE.md updated.

## #212 — split Verifier and Revoker roles

Role::Revoker = 4 added to the Role enum. verify() now accepts Admin or Verifier only. revoke_verification() now accepts Admin or Revoker only. A compromised Verifier key can no longer strip payout eligibility. Existing Verifier holders keep their verify permission; operators must re-assign Role::Revoker to any address that needs revoke access. Auth matrix tests updated in src/lib.rs and tests/integration.rs. ABI.md role matrix and SECURITY.md threat model updated.

## #214 — challenge-period flow for squatted usernames

New storage type ChallengeRecord with challenged_by / started_at / resolve_after. New entry points: start_challenge, cancel_challenge, complete_challenge, get_challenge. New events: ChallengeStartedEvent, ChallengeCancelledEvent, ChallengeCompletedEvent. New errors: ChallengeAlreadyActive (17), NoChallengeActive (18), ChallengeNotResolvable (19), ChallengeActive (20). register() blocks on an active challenge with ChallengeActive. remove() by the registrant clears the challenge atomically (self-remove beats the clock). Default delay is DEFAULT_CHALLENGE_DELAY_SECS (48 h), enforced on-chain via the ledger timestamp. Challenge records stored under (Symbol('chllng'), username) in persistent storage with TTL extension. ARCHITECTURE.md and SECURITY.md updated with state machine and threat model.