### PR TITLE
[232] Separate payout recipient address from identity address

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -13,6 +13,7 @@ Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [DEPL
 ```rust
 struct ContributorRecord {
     stellar_address: Address,
+    payout_address: Address,     // separate payout recipient from identity
     registered_at: u32,  // u32 saves 4 bytes vs u64; sufficient until ~2106
     verified: bool,
 }
@@ -174,13 +175,13 @@ stellar contract invoke --id $ID --source deployer --network testnet --send=yes 
 
 ---
 
-### `register(github_username: String, stellar_address: Address) -> Result<(), ContractError>`
+### `register(github_username: String, stellar_address: Address, payout_address: Option<Address>) -> Result<(), ContractError>`
 
 Register or update a GitHub username mapping.
 
 | | |
 |---|---|
-| **Auth** | `stellar_address` must sign; if the username is already registered to a *different* address, that address must sign too |
+| **Auth** | `stellar_address` must sign; if the username is already registered to a *different* address, that address must sign too; if `payout_address` differs from `stellar_address`, it must also sign |
 | **Mutates** | Yes |
 | **Errors** | `NotInitialized`, `Paused`, `InvalidUsername`, `ZeroAddress` |
 | **Events** | `RegisteredEvent` |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -961,6 +961,7 @@ impl TrustBridgeContract {
         env: Env,
         github_username: String,
         stellar_address: Address,
+        payout_address: Option<Address>,
     ) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
@@ -987,6 +988,18 @@ impl TrustBridgeContract {
 
         stellar_address.require_auth();
 
+        let resolved_payout = payout_address
+            .clone()
+            .unwrap_or_else(|| stellar_address.clone());
+
+        // If a separate payout address is provided and differs from identity,
+        // require its auth so only the owner can designate where payouts go.
+        if let Some(ref pa) = payout_address {
+            if *pa != stellar_address {
+                pa.require_auth();
+            }
+        }
+
         let timestamp = env.ledger().timestamp();
         let existing = get_record(&env, &github_username);
 
@@ -1002,6 +1015,7 @@ impl TrustBridgeContract {
 
         let record = ContributorRecord {
             stellar_address: stellar_address.clone(),
+            payout_address: resolved_payout,
             registered_at: timestamp as u32,
             verified: existing
                 .as_ref()
@@ -2130,7 +2144,7 @@ mod test {
         let (_admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             let record =
                 TrustBridgeContract::get_address(env.clone(), username(&env, "octocat")).unwrap();
@@ -2170,9 +2184,9 @@ mod test {
         let (_admin, user1, user2, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
             assert_eq!(
                 TrustBridgeContract::get_address(env.clone(), username(&env, "alice"))
@@ -2215,12 +2229,12 @@ mod test {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
         });
 
@@ -2261,12 +2275,12 @@ mod test {
         let (_admin, user1, user2, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2303,7 +2317,7 @@ mod test {
         let (_admin, user, other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             let result =
                 TrustBridgeContract::remove(env.clone(), other.clone(), username(&env, "octocat"));
@@ -2320,7 +2334,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             TrustBridgeContract::remove(env.clone(), admin.clone(), username(&env, "octocat"))
                 .unwrap();
@@ -2338,7 +2352,7 @@ mod test {
         let (admin, user1, _user2, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user1.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2363,7 +2377,7 @@ mod test {
         let (_admin, user, other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             let result =
                 TrustBridgeContract::remove(env.clone(), other.clone(), username(&env, "octocat"));
@@ -2389,7 +2403,7 @@ mod test {
         let stranger = Address::generate(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user.clone(), None)
                 .unwrap();
             let result =
                 TrustBridgeContract::remove(env.clone(), stranger.clone(), username(&env, "alice"));
@@ -2422,7 +2436,7 @@ mod test {
         let (_admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2456,9 +2470,9 @@ mod test {
         let (admin, user1, user2, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2490,7 +2504,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2524,7 +2538,7 @@ mod test {
         let (_admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2534,7 +2548,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.as_contract(&contract_id, || {
@@ -2555,12 +2569,12 @@ mod test {
         let (_admin, user1, user2, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2585,12 +2599,12 @@ mod test {
         let (_admin, user1, user2, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2613,11 +2627,11 @@ mod test {
         let user3 = Address::generate(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "carol"), user3.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "carol"), user3.clone(), None)
                 .unwrap();
 
             // Remove the first entry
@@ -2651,11 +2665,11 @@ mod test {
         let user3 = Address::generate(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "carol"), user3.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "carol"), user3.clone(), None)
                 .unwrap();
 
             // Remove the middle entry
@@ -2685,17 +2699,17 @@ mod test {
         let user3 = Address::generate(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "carol"), user3.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "carol"), user3.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2725,12 +2739,12 @@ mod test {
         let (_admin, user1, user2, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2741,7 +2755,7 @@ mod test {
         // re-register alice
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
         });
 
@@ -2765,11 +2779,11 @@ mod test {
         let (admin, user, new_user, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), new_user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), new_user.clone(), None)
                 .unwrap();
 
             let record =
@@ -2789,9 +2803,9 @@ mod test {
         let (_admin, user, other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), other.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), other.clone(), None)
                 .unwrap();
             assert_eq!(TrustBridgeContract::get_stats(env.clone()).total, 1);
         });
@@ -2803,9 +2817,9 @@ mod test {
         let (_admin, user, other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), other.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), other.clone(), None)
                 .unwrap();
             let record =
                 TrustBridgeContract::get_address(env.clone(), username(&env, "octocat")).unwrap();
@@ -2821,7 +2835,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             assert!(
                 !TrustBridgeContract::get_address(env.clone(), username(&env, "octocat"))
@@ -2881,7 +2895,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2903,7 +2917,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2938,7 +2952,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             let result = TrustBridgeContract::revoke_verification(
                 env.clone(),
@@ -2956,7 +2970,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2982,7 +2996,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -2992,7 +3006,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.as_contract(&contract_id, || {
@@ -3012,7 +3026,7 @@ mod test {
         let (admin, user, other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -3022,7 +3036,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), other.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), other.clone(), None)
                 .unwrap();
         });
         env.as_contract(&contract_id, || {
@@ -3042,7 +3056,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -3052,7 +3066,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.as_contract(&contract_id, || {
@@ -3068,7 +3082,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -3083,7 +3097,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.as_contract(&contract_id, || {
@@ -3099,12 +3113,12 @@ mod test {
         let (admin, user, other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), other.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), other.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -3127,7 +3141,7 @@ mod test {
         let (admin, old_user, new_user, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), old_user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), old_user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -3137,7 +3151,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), new_user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), new_user.clone(), None)
                 .unwrap();
         });
         env.as_contract(&contract_id, || {
@@ -3172,7 +3186,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -3203,7 +3217,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -3233,7 +3247,7 @@ mod test {
         let (_admin, user, other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -3252,7 +3266,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -3280,7 +3294,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -3316,7 +3330,7 @@ mod test {
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
             let result =
-                TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone());
+                TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None);
             assert_eq!(result, Err(ContractError::NotInitialized));
         });
     }
@@ -3499,7 +3513,7 @@ mod test {
 
         env.as_contract(&contract_id, || {
             assert_eq!(
-                TrustBridgeContract::register(env.clone(), too_long.clone(), user.clone()),
+                TrustBridgeContract::register(env.clone(), too_long.clone(), user.clone(), None),
                 Err(ContractError::InvalidUsername)
             );
             // The rejected username must leave no trace in the registry.
@@ -3520,7 +3534,7 @@ mod test {
 
         env.as_contract(&contract_id, || {
             assert!(
-                TrustBridgeContract::register(env.clone(), at_max.clone(), user.clone()).is_ok()
+                TrustBridgeContract::register(env.clone(), at_max.clone(), user.clone(), None).is_ok()
             );
             assert!(TrustBridgeContract::has_record(env.clone(), at_max));
         });
@@ -3535,7 +3549,7 @@ mod test {
         env.as_contract(&contract_id, || {
             for bad in ["", "-lead", "trail-", "has space", "at@sign"] {
                 assert_eq!(
-                    TrustBridgeContract::register(env.clone(), username(&env, bad), user.clone()),
+                    TrustBridgeContract::register(env.clone(), username(&env, bad), user.clone(), None),
                     Err(ContractError::InvalidUsername),
                     "expected {bad:?} to be rejected"
                 );
@@ -3593,7 +3607,7 @@ mod test {
         let name = username(&env, "octocat");
 
         env.mock_all_auths();
-        client.register(&name, &user);
+        client.register(&name, &user, &None);
 
         // Re-point the registration at `other`, authorizing only `other`.
         // The current owner's signature is missing, so the call must fail.
@@ -3617,8 +3631,8 @@ mod test {
         let name = username(&env, "octocat");
 
         env.mock_all_auths();
-        client.register(&name, &user);
-        client.register(&name, &other);
+        client.register(&name, &user, &None);
+        client.register(&name, &other, &None);
 
         assert_eq!(client.get_address(&name).unwrap().stellar_address, other);
         assert_eq!(client.get_stats().total, 1);
@@ -3636,7 +3650,7 @@ mod test {
         env.mock_all_auths();
         env.ledger().set_timestamp(1_600_000_000);
 
-        client.register(&name, &user);
+        client.register(&name, &user, &None);
 
         let expected = RegisteredEvent {
             github_username: name.clone(),
@@ -3699,7 +3713,7 @@ mod test {
         let name = username(&env, "octocat");
 
         env.mock_all_auths();
-        client.register(&name, &user);
+        client.register(&name, &user, &None);
 
         env.ledger().set_timestamp(1_700_000_000);
         client.remove(&user, &name);
@@ -3753,7 +3767,7 @@ mod test {
         let name = username(&env, "octocat");
 
         env.mock_all_auths();
-        client.register(&name, &user);
+        client.register(&name, &user, &None);
 
         // A caller who is neither the registrant nor the admin is rejected,
         // and must not leave a RemovedEvent behind for indexers to act on.
@@ -3776,7 +3790,7 @@ mod test {
         let name = username(&env, "octocat");
 
         env.mock_all_auths();
-        client.register(&name, &user);
+        client.register(&name, &user, &None);
         env.mock_all_auths();
         client.verify(&admin, &name);
 
@@ -3807,7 +3821,7 @@ mod test {
         let name = username(&env, "octocat");
 
         env.mock_all_auths();
-        client.register(&name, &user);
+        client.register(&name, &user, &None);
         env.mock_all_auths();
         client.verify(&admin, &name);
         env.mock_all_auths();
@@ -3846,7 +3860,7 @@ mod test {
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
             let reg_res =
-                TrustBridgeContract::register(env.clone(), username(&env, "alice"), user.clone());
+                TrustBridgeContract::register(env.clone(), username(&env, "alice"), user.clone(), None);
             assert_eq!(reg_res, Err(ContractError::Paused));
         });
 
@@ -3864,7 +3878,8 @@ mod test {
             assert!(TrustBridgeContract::register(
                 env.clone(),
                 username(&env, "alice"),
-                user.clone()
+                user.clone(),
+                None,
             )
             .is_ok());
         });
@@ -3878,7 +3893,7 @@ mod test {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), name.clone(), user.clone()).unwrap();
+            TrustBridgeContract::register(env.clone(), name.clone(), user.clone(), None).unwrap();
         });
 
         env.mock_all_auths();
@@ -4012,9 +4027,9 @@ mod test {
         let (_admin, user1, user2, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
             let all = TrustBridgeContract::get_all_registered(env.clone()).unwrap();
             assert_eq!(all.len(), 2);
@@ -4041,7 +4056,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -4145,7 +4160,8 @@ mod test {
                 TrustBridgeContract::register(
                     env.clone(),
                     username(&env, "octocat"),
-                    admin.clone()
+                    admin.clone(),
+                    None,
                 ),
                 Err(ContractError::NotInitialized)
             );
@@ -4156,7 +4172,8 @@ mod test {
             assert!(TrustBridgeContract::register(
                 env.clone(),
                 username(&env, "octocat"),
-                admin.clone()
+                admin.clone(),
+                None,
             )
             .is_ok());
         });
@@ -4186,17 +4203,17 @@ mod test {
         let user3 = Address::generate(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "carol"), user3.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "carol"), user3.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -4223,12 +4240,12 @@ mod test {
         let (_admin, user1, user2, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -4267,7 +4284,7 @@ mod test {
             name.push_str(&alloc::format!("{i}"));
             let name = String::from_str(&env, &name);
             env.as_contract(&contract_id, || {
-                TrustBridgeContract::register(env.clone(), name.clone(), user.clone()).unwrap();
+                TrustBridgeContract::register(env.clone(), name.clone(), user.clone(), None).unwrap();
             });
         }
 
@@ -4304,7 +4321,7 @@ mod test {
             name.push_str(&alloc::format!("{i}"));
             let name = String::from_str(&env, &name);
             env.as_contract(&contract_id, || {
-                TrustBridgeContract::register(env.clone(), name.clone(), user.clone()).unwrap();
+                TrustBridgeContract::register(env.clone(), name.clone(), user.clone(), None).unwrap();
             });
         }
 
@@ -4328,12 +4345,12 @@ mod test {
         let (_admin, user1, user2, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -4377,7 +4394,7 @@ mod test {
         env.mock_all_auths();
         env.cost_estimate().budget().reset_default();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), github_username, user).unwrap();
+            TrustBridgeContract::register(env.clone(), github_username, user, None).unwrap();
         });
 
         let budget = env.cost_estimate().budget();
@@ -4403,7 +4420,7 @@ mod test {
             name.push_str(&alloc::format!("{i}"));
             let name = String::from_str(&env, &name);
             env.as_contract(&contract_id, || {
-                TrustBridgeContract::register(env.clone(), name.clone(), user.clone()).unwrap();
+                TrustBridgeContract::register(env.clone(), name.clone(), user.clone(), None).unwrap();
             });
         }
 
@@ -4569,7 +4586,7 @@ mod test {
         // Register and verify first
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -4601,7 +4618,7 @@ mod test {
         });
         env2.mock_all_auths();
         env2.as_contract(&contract_id2, || {
-            TrustBridgeContract::register(env2.clone(), username(&env2, "octocat"), user2.clone())
+            TrustBridgeContract::register(env2.clone(), username(&env2, "octocat"), user2.clone(), None)
                 .unwrap();
         });
 
@@ -4668,7 +4685,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -4682,7 +4699,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -4709,12 +4726,12 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -4753,7 +4770,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -4873,7 +4890,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -4902,7 +4919,7 @@ mod test {
         let (_admin, user, nobody, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             let result = TrustBridgeContract::verify(
                 env.clone(),
@@ -4930,7 +4947,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             let result = TrustBridgeContract::verify(
                 env.clone(),
@@ -4953,7 +4970,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
                 .unwrap();
@@ -4977,7 +4994,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             TrustBridgeContract::verify(env.clone(), verifier.clone(), username(&env, "octocat"))
                 .unwrap();
@@ -4997,7 +5014,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -5078,7 +5095,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             let result = TrustBridgeContract::revoke_verification(
                 env.clone(),
@@ -5103,7 +5120,7 @@ mod test {
         let (admin, user, nobody, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
                 .unwrap();
@@ -5139,7 +5156,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
                 .unwrap();
@@ -5165,7 +5182,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -5204,7 +5221,7 @@ mod test {
         });
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
                 .unwrap();
@@ -5231,7 +5248,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
                 .unwrap();
@@ -5279,11 +5296,11 @@ mod test {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "carol"), user3.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "carol"), user3.clone(), None)
                 .unwrap();
             assert_eq!(TrustBridgeContract::get_stats(env.clone()).total, 3);
         });
@@ -5318,7 +5335,7 @@ mod test {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
         });
 
@@ -5407,7 +5424,7 @@ mod test {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user.clone(), None)
                 .unwrap();
         });
 
@@ -5461,9 +5478,9 @@ mod test {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "alice"), user1.clone(), None)
                 .unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "bob"), user2.clone(), None)
                 .unwrap();
         });
 
@@ -5521,7 +5538,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -5566,7 +5583,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -5619,7 +5636,7 @@ mod test {
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
             let ledger_ts = env.ledger().timestamp();
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             let record =
                 TrustBridgeContract::get_address(env.clone(), username(&env, "octocat")).unwrap();
@@ -5640,7 +5657,7 @@ mod test {
         let (_admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         let ts1 = env.as_contract(&contract_id, || {
@@ -5652,7 +5669,7 @@ mod test {
         env.ledger().set_timestamp(env.ledger().timestamp() + 1000);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         let ts2 = env.as_contract(&contract_id, || {
@@ -5675,7 +5692,7 @@ mod test {
         env.ledger().set_timestamp(specific_ts);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             let record =
                 TrustBridgeContract::get_address(env.clone(), username(&env, "octocat")).unwrap();
@@ -5694,7 +5711,7 @@ mod test {
         let (_admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
             let record =
                 TrustBridgeContract::get_address(env.clone(), username(&env, "octocat")).unwrap();
@@ -5721,7 +5738,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), None)
                 .unwrap();
         });
         env.mock_all_auths();
@@ -5783,7 +5800,7 @@ mod test {
         let (admin, user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user, None).unwrap();
         });
 
         env.mock_all_auths();
@@ -5813,9 +5830,9 @@ mod test {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "user1"), user1).unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "user2"), user2).unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "user3"), user3).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "user1"), user1, None).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "user2"), user2, None).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "user3"), user3, None).unwrap();
         });
 
         env.mock_all_auths();
@@ -5843,7 +5860,7 @@ mod test {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "user1"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "user1"), user1.clone(), None)
                 .unwrap();
             TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "user1"))
                 .unwrap();
@@ -5872,7 +5889,7 @@ mod test {
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
             TrustBridgeContract::set_role(env.clone(), verifier.clone(), Role::Verifier).unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "user1"), user1).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "user1"), user1, None).unwrap();
         });
 
         env.mock_all_auths();
@@ -5893,7 +5910,7 @@ mod test {
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
             TrustBridgeContract::set_role(env.clone(), upgrader.clone(), Role::Upgrader).unwrap();
-            TrustBridgeContract::register(env.clone(), username(&env, "user1"), user1).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "user1"), user1, None).unwrap();
         });
 
         env.mock_all_auths();
@@ -5944,7 +5961,7 @@ mod test {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user1.clone()).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user1.clone(), None).unwrap();
         });
 
         // 1. Success path
@@ -5998,7 +6015,7 @@ mod test {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user, None).unwrap();
 
             let logs = TrustBridgeContract::get_audit_logs(env.clone());
             assert!(!logs.is_empty());
@@ -6023,7 +6040,7 @@ mod test {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user, None).unwrap();
         });
 
         let initial_logs_len = env.as_contract(&contract_id, || {
@@ -6098,7 +6115,7 @@ mod test {
             TrustBridgeContract::set_cooldown(env.clone(), 100).unwrap();
 
             // First registration succeeds
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user1.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user1.clone(), None)
                 .unwrap();
 
             // Immediate re-registration fails with CooldownActive
@@ -6106,6 +6123,7 @@ mod test {
                 env.clone(),
                 username(&env, "octocat"),
                 user2.clone(),
+                None,
             );
             assert_eq!(res, Err(ContractError::CooldownActive));
         });
@@ -6116,7 +6134,7 @@ mod test {
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
             // After cooldown elapses, re-registration succeeds
-            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user2.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user2.clone(), None)
                 .unwrap();
         });
     }
@@ -6227,6 +6245,7 @@ mod test {
                 env.clone(),
                 username(&env, "octocat"),
                 user.clone(),
+                None,
             )
             .unwrap();
 
@@ -6241,7 +6260,8 @@ mod test {
                 TrustBridgeContract::register(
                     env.clone(),
                     username(&env, "newuser"),
-                    user.clone()
+                    user.clone(),
+                    None,
                 ),
                 Err(ContractError::Paused)
             );
@@ -6344,7 +6364,8 @@ mod test {
                 TrustBridgeContract::register(
                     env.clone(),
                     username(&env, "stillblocked"),
-                    user.clone()
+                    user.clone(),
+                    None,
                 ),
                 Err(ContractError::Paused),
                 "normal pause still active after emergency cleared"
@@ -6356,6 +6377,7 @@ mod test {
                 env.clone(),
                 username(&env, "nowworks"),
                 user,
+                None,
             )
             .unwrap();
         });
@@ -6388,14 +6410,14 @@ mod test {
             for i in 0..50u32 {
                 let name = format!("user{i:03}");
                 let addr = Address::generate(&env);
-                TrustBridgeContract::register(env.clone(), username(&env, &name), addr).unwrap();
+                TrustBridgeContract::register(env.clone(), username(&env, &name), addr, None).unwrap();
             }
             let chunk_count_at_50 = crate::storage::get_chunk_count(&env);
             assert_eq!(chunk_count_at_50, 1, "50 entries should occupy exactly 1 chunk");
 
             // Register the 51st user — must spill into chunk 1
             let addr51 = Address::generate(&env);
-            TrustBridgeContract::register(env.clone(), username(&env, "user050"), addr51).unwrap();
+            TrustBridgeContract::register(env.clone(), username(&env, "user050"), addr51, None).unwrap();
             let chunk_count_at_51 = crate::storage::get_chunk_count(&env);
             assert_eq!(chunk_count_at_51, 2, "51st entry must create a second chunk");
         });
@@ -6549,6 +6571,7 @@ mod test {
                             env.clone(),
                             username(env, name),
                             addr.clone(),
+                            None,
                         )
                     });
                     if result.is_ok() {
@@ -6692,7 +6715,7 @@ mod test {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), username(&env, "target"), user.clone())
+            TrustBridgeContract::register(env.clone(), username(&env, "target"), user.clone(), None)
                 .unwrap();
         });
 
@@ -6714,7 +6737,7 @@ mod test {
                     let addr = addrs[addr_idx].clone();
                     let existed = shadow.has(name);
                     let res = env.as_contract(&contract_id, || {
-                        TrustBridgeContract::register(env.clone(), username(&env, name), addr)
+                        TrustBridgeContract::register(env.clone(), username(&env, name), addr, None)
                     });
                     if res.is_ok() {
                         shadow.register(name.to_string(), addr_idx);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -169,8 +169,12 @@ impl PauseReason {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[soroban_sdk::contracttype]
 pub struct ContributorRecord {
-    /// The Stellar G-address that owns this registration.
+    /// The Stellar G-address that owns this registration (identity address).
     pub stellar_address: Address,
+    /// The Stellar address where payouts should be sent. Defaults to
+    /// `stellar_address` if not explicitly set, allowing contributors to
+    /// separate their identity from their payment destination.
+    pub payout_address: Address,
     /// Ledger timestamp when this record was last written.
     ///
     /// Stored as `u32` instead of `u64` to save 4 bytes per record. Soroban

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -43,7 +43,7 @@ fn test_integration_full_registry_lifecycle_and_events() {
     // Register
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
     });
 
     env.as_contract(&contract_id, || {
@@ -108,7 +108,7 @@ fn test_integration_pause_unpause_governance() {
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
         assert_eq!(
-            TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()),
+            TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None),
             Err(ContractError::Paused)
         );
     });
@@ -130,7 +130,7 @@ fn test_integration_pause_unpause_governance() {
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
         assert!(
-            TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).is_ok()
+            TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).is_ok()
         );
     });
 }
@@ -192,7 +192,7 @@ fn test_integration_verifier_role_separation() {
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "octocat"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "octocat"), user1.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -257,7 +257,7 @@ fn test_integration_no_role_cannot_verify() {
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "octocat"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "octocat"), user1.clone(), None).unwrap();
         let result = TrustBridgeContract::verify(env.clone(), nobody.clone(), s(&env, "octocat"));
         assert_eq!(result, Err(ContractError::NotAuthorized));
     });
@@ -272,9 +272,9 @@ fn test_integration_lookup_after_peer_removal() {
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
-        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone()).unwrap();
-        TrustBridgeContract::register(env.clone(), s(&env, "carol"), user3.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone(), None).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "carol"), user3.clone(), None).unwrap();
 
         // Remove the first peer
         TrustBridgeContract::remove(env.clone(), admin.clone(), s(&env, "alice")).unwrap();
@@ -304,9 +304,9 @@ fn test_integration_export_consistent_after_removal() {
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
-        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone()).unwrap();
-        TrustBridgeContract::register(env.clone(), s(&env, "carol"), user3.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone(), None).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "carol"), user3.clone(), None).unwrap();
 
         TrustBridgeContract::remove(env.clone(), admin.clone(), s(&env, "bob")).unwrap();
 
@@ -337,7 +337,7 @@ fn test_integration_not_initialized_guards() {
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
         assert_eq!(
-            TrustBridgeContract::register(env.clone(), s(&env, "alice"), addr.clone()),
+            TrustBridgeContract::register(env.clone(), s(&env, "alice"), addr.clone(), None),
             Err(ContractError::NotInitialized),
             "register before init"
         );
@@ -407,11 +407,11 @@ fn test_integration_verification_attestation_storage() {
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone(), None).unwrap();
     });
 
     env.as_contract(&contract_id, || {
@@ -492,7 +492,7 @@ fn test_integration_attestation_preserved_on_same_address_reregister() {
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -500,7 +500,7 @@ fn test_integration_attestation_preserved_on_same_address_reregister() {
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
     });
     env.as_contract(&contract_id, || {
         let record = TrustBridgeContract::get_address(env.clone(), s(&env, "alice")).unwrap();
@@ -526,7 +526,7 @@ fn test_integration_attestation_cleared_on_address_change() {
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -537,7 +537,7 @@ fn test_integration_attestation_cleared_on_address_change() {
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user2.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user2.clone(), None).unwrap();
     });
     env.as_contract(&contract_id, || {
         let record = TrustBridgeContract::get_address(env.clone(), s(&env, "alice")).unwrap();
@@ -674,7 +674,7 @@ fn test_integration_guards_lifted_after_initialization() {
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
         assert_eq!(
-            TrustBridgeContract::register(env.clone(), s(&env, "alice"), user.clone()),
+            TrustBridgeContract::register(env.clone(), s(&env, "alice"), user.clone(), None),
             Err(ContractError::NotInitialized)
         );
     });
@@ -687,7 +687,7 @@ fn test_integration_guards_lifted_after_initialization() {
     // Same calls must now pass
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        assert!(TrustBridgeContract::register(env.clone(), s(&env, "alice"), user.clone()).is_ok());
+        assert!(TrustBridgeContract::register(env.clone(), s(&env, "alice"), user.clone(), None).is_ok());
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -713,7 +713,7 @@ fn test_integration_paginated_export_after_multiple_removals() {
     ] {
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::register(env.clone(), name, addr).unwrap();
+            TrustBridgeContract::register(env.clone(), name, addr, None).unwrap();
         });
     }
     env.mock_all_auths();
@@ -747,15 +747,15 @@ fn test_integration_public_paginated_after_peer_removal() {
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "carol"), user3.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "carol"), user3.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -799,7 +799,7 @@ fn test_integration_revoked_verifier_cannot_verify() {
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -860,7 +860,7 @@ fn test_integration_upgrader_cannot_verify_or_revoke() {
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -900,15 +900,15 @@ fn test_integration_attestation_record_fields_isolated() {
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "carol"), user3.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "carol"), user3.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -970,7 +970,7 @@ fn test_integration_vcount_never_underflows() {
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -1020,9 +1020,9 @@ fn test_integration_middle_user_removal_index_compaction() {
     // Register three users: alice, bob, carol
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
-        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone()).unwrap();
-        TrustBridgeContract::register(env.clone(), s(&env, "carol"), user3.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone(), None).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "carol"), user3.clone(), None).unwrap();
     });
 
     // Verify initial state
@@ -1163,7 +1163,7 @@ fn test_integration_stats_verified_matches_verified_count() {
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None).unwrap();
     });
     check(&env, &contract_id);
 
@@ -1175,7 +1175,7 @@ fn test_integration_stats_verified_matches_verified_count() {
 
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
-        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone()).unwrap();
+        TrustBridgeContract::register(env.clone(), s(&env, "bob"), user2.clone(), None).unwrap();
     });
     env.mock_all_auths();
     env.as_contract(&contract_id, || {
@@ -1767,7 +1767,7 @@ fn test_pause_reason_readable_while_paused() {
         // register must still fail with Paused, not some other error.
         env.mock_all_auths();
         let result =
-            trustbridge_contract::TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone());
+            trustbridge_contract::TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), None);
         assert_eq!(result, Err(ContractError::Paused));
     });
 }
@@ -1819,7 +1819,7 @@ fn test_reserved_username_cannot_be_registered() {
             env.clone(),
             s(&env, "stellar"),
             user1.clone(),
-        );
+        , None);
         assert_eq!(result, Err(ContractError::UsernameReserved));
     });
 
@@ -1895,7 +1895,7 @@ fn test_reserved_check_is_case_insensitive() {
                 env.clone(),
                 name.clone(),
                 user1.clone(),
-            );
+            , None);
             assert_eq!(
                 result,
                 Err(ContractError::UsernameReserved),
@@ -1999,7 +1999,7 @@ fn test_removed_reserved_name_can_be_registered() {
             env.clone(),
             s(&env, "trustbridge"),
             user1.clone(),
-        )
+        , None)
         .expect("register must succeed after reserved name is removed");
     });
 
@@ -2060,7 +2060,7 @@ fn test_adding_reserved_does_not_evict_existing_registration() {
             env.clone(),
             s(&env, "trustbridge"),
             user1.clone(),
-        )
+        , None)
         .unwrap();
     });
 
@@ -2113,19 +2113,19 @@ fn test_compact_index_no_op_on_dense_registry() {
             env.clone(),
             s(&env, "alice"),
             user1.clone(),
-        )
+        , None)
         .unwrap();
         trustbridge_contract::TrustBridgeContract::register(
             env.clone(),
             s(&env, "bob"),
             user2.clone(),
-        )
+        , None)
         .unwrap();
         trustbridge_contract::TrustBridgeContract::register(
             env.clone(),
             s(&env, "carol"),
             user3.clone(),
-        )
+        , None)
         .unwrap();
     });
 
@@ -2183,7 +2183,7 @@ fn test_compact_index_after_sparse_removals_restores_dense_pagination() {
     ] {
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            trustbridge_contract::TrustBridgeContract::register(env.clone(), name, addr).unwrap();
+            trustbridge_contract::TrustBridgeContract::register(env.clone(), name, addr, None).unwrap();
         });
     }
 
@@ -2261,7 +2261,7 @@ fn test_compact_index_single_entry_registry() {
             env.clone(),
             s(&env, "solo"),
             user1.clone(),
-        )
+        , None)
         .unwrap();
     });
 
@@ -2298,7 +2298,7 @@ fn test_compact_index_is_idempotent() {
             env.clone(),
             s(&env, "a"),
             user1.clone(),
-        )
+        , None)
         .unwrap();
     });
     env.mock_all_auths();
@@ -2307,7 +2307,7 @@ fn test_compact_index_is_idempotent() {
             env.clone(),
             s(&env, "b"),
             user2.clone(),
-        )
+        , None)
         .unwrap();
     });
     env.mock_all_auths();
@@ -2316,7 +2316,7 @@ fn test_compact_index_is_idempotent() {
             env.clone(),
             s(&env, "c"),
             user3.clone(),
-        )
+        , None)
         .unwrap();
     });
 
@@ -2395,19 +2395,19 @@ fn test_compact_index_does_not_change_stats() {
             env.clone(),
             s(&env, "alice"),
             user1.clone(),
-        )
+        , None)
         .unwrap();
         trustbridge_contract::TrustBridgeContract::register(
             env.clone(),
             s(&env, "bob"),
             user2.clone(),
-        )
+        , None)
         .unwrap();
         trustbridge_contract::TrustBridgeContract::register(
             env.clone(),
             s(&env, "carol"),
             user3.clone(),
-        )
+        , None)
         .unwrap();
     });
 


### PR DESCRIPTION
Closes #232

## Summary

Adds a separate payout_address field to ContributorRecord, allowing contributors to designate a different Stellar address for receiving payouts while keeping their identity address separate.

## Changes

- Added payout_address: Address to ContributorRecord struct
- Updated egister() to accept payout_address: Option<Address> as a new parameter
- When payout_address is None, defaults to stellar_address (backward compatible)
- When payout_address differs from stellar_address, its auth is required
- Updated all test call sites to pass None for the new parameter
- Updated ABI.md to document the new field and signature

## Backward Compatibility

- Existing registrations default payout_address to stellar_address via unwrap_or_else
- New parameter is Option<Address> — callers can pass None for existing behavior