### PR TITLE
feat: ever-verified counter, record proof, rename, and address rotation delay

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -746,6 +746,63 @@ after the record has already been through one full cycle. Covered by
 
 ---
 
+### `rename(caller, old_username, new_username) -> Result<(), ContractError>`
+
+Moves a registration from `old_username` to `new_username` (Issue #233).
+
+| | |
+|---|---|
+| **Auth** | `caller`, which must be the registered address or the admin |
+| **Mutates** | Yes — blocked while paused |
+
+GitHub users rename. Without this they had to `remove` and re-register, which
+drops the record and leaves the old name free for anyone to take in between.
+
+The move is **atomic**: the new record is written and the old removed in the
+same invocation, so there is no ledger state where the registration exists
+under both names or neither. `get_stats().total` is unchanged — a rename is a
+move, not a new registration. The old name is free to register afterwards.
+
+**Verified-state policy: the flag does not travel.** Verification attests that
+a particular GitHub identity controls the address. The contract cannot confirm
+the new handle is the same GitHub account, and carrying the badge across would
+let a verified throwaway rename onto a valuable handle and arrive pre-trusted.
+So `rename`:
+
+- clears `verified` on the moved record,
+- decrements `get_verified_count()`,
+- marks the new name **pending re-verify**,
+- leaves `get_ever_verified_count()` alone, which still remembers the original
+  verification.
+
+Re-verification is a normal `verify` call against the new name.
+
+Emits `RenamedEvent { old_username, new_username, stellar_address, verification_cleared, timestamp }`,
+with both usernames as topics so an indexer can follow the move from either side.
+
+Rejected with:
+
+| Error | When |
+|---|---|
+| `NotRegistered` | `old_username` is not registered |
+| `NotAuthorized` | `caller` is neither the holder nor the admin |
+| `InvalidUsername` | `new_username` is not a valid GitHub username, or equals `old_username` |
+| `UsernameReserved` | `new_username` is on the reserved list |
+| `UsernameTaken` | `new_username` is already registered |
+| `CooldownActive` | the username is in cooldown |
+| `ChallengeActive` | a challenge is open on either name |
+| `RotationPending` | an address rotation is queued on the old name |
+
+A case-only rename (`octocat` → `OctoCat`) is a real move and is allowed: the
+storage key is the exact string.
+
+```bash
+stellar contract invoke --id $ID --source holder --network testnet \
+  -- rename --caller $HOLDER --old_username octocat --new_username octocat2
+```
+
+---
+
 ### `get_verified_count() -> u32`
 
 Returns the number of **currently** verified registrations. This figure drops

--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -748,7 +748,9 @@ after the record has already been through one full cycle. Covered by
 
 ### `get_verified_count() -> u32`
 
-Returns the number of verified registrations.
+Returns the number of **currently** verified registrations. This figure drops
+when a verification is revoked. For "how many were ever verified", read
+[`get_ever_verified_count`](#get_ever_verified_count---u32) instead.
 
 | | |
 |---|---|
@@ -771,9 +773,39 @@ stellar contract invoke --id $ID --source deployer --network testnet \
 
 ---
 
+### `get_ever_verified_count() -> u32`
+
+Returns how many verifications have ever been granted, including any since
+revoked (Issue #229). Monotonic: it never decreases.
+
+| | |
+|---|---|
+| **Auth** | None |
+| **Mutates** | No |
+
+`get_verified_count()` answers "who is verified right now" and moves in both
+directions; this answers "how many did we ever verify" and only climbs. A
+contributor verified, revoked, and verified again counts twice here — the
+counter records verification events, not distinct contributors.
+
+Instances deployed before this counter existed have no stored value and report
+the live verified count instead of zero, which is the tightest lower bound the
+contract can still prove after the fact.
+
+```bash
+stellar contract invoke --id $ID --source deployer --network testnet \
+  -- get_ever_verified_count
+```
+
+---
+
 ### `get_stats() -> Stats`
 
-Returns `{ total, verified }` registration counts.
+Returns `{ total, verified, ever_verified }` registration counts.
+
+`verified` is the live count and falls on revoke; `ever_verified` is the
+monotonic historical count described above. `total` is the number of
+registered contributors.
 
 | | |
 |---|---|

--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -1386,9 +1386,11 @@ admin or any registrant to invoke them:
 |---|---|---|
 | `get_address(github_username)` | `Option<ContributorRecord>` | Core identity lookup |
 | `has_record(github_username)` | `bool` | Cheap existence check, avoids decoding the full record |
+| `get_record_proof(github_username)` | `RecordProof` | Existence proof for light clients: verified bit, storage key, TTL policy |
 | `get_public_paginated(cursor, limit)` | `Result<ExportPage, ContractError>` | Paginated read; fails with `Paused` while the registry is paused |
-| `get_stats()` | `Stats` | `{ total, verified }` |
-| `get_verified_count()` | `u32` | |
+| `get_stats()` | `Stats` | `{ total, verified, ever_verified }` |
+| `get_verified_count()` | `u32` | Live count; drops on revoke |
+| `get_ever_verified_count()` | `u32` | Monotonic; never drops |
 | `get_role(address)` | `Option<Role>` | RBAC lookup, e.g. to gate a payout on `Role::Verifier` |
 | `is_paused()` / `is_contract_paused()` | `bool` | Check before a call that would otherwise fail on `Paused` |
 | `is_registration_in_cooldown(github_username)` | `bool` | |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -661,6 +661,58 @@ during the window, the admin cancels the challenge and the registration is prese
 
 ---
 
+## Address Rotation Delay (Issue #234)
+
+`register` accepts an address change when both the outgoing and incoming
+addresses sign. Dual auth proves both keys were available *at that moment* — it
+does not prove the holder intended the change. An attacker who phishes a
+GitHub session and a wallet signature together holds both keys at once, and the
+swap lands instantly, redirecting every future payout before the real holder
+sees anything.
+
+The delay window closes that. With `set_rotation_delay(seconds)` armed:
+
+| Step | Entry point | Effect |
+|---|---|---|
+| Request | `request_address_rotation(username, new_address)` | Records the pending address, emits `RotationRequestedEvent`. **Nothing moves.** |
+| Wait | — | `executable_at = requested_at + delay` |
+| Execute | `execute_address_rotation(username)` | Applies the change, emits `RotationExecutedEvent` |
+| Stop | `cancel_address_rotation(caller, username)` | Holder or admin cancels, emits `RotationCancelledEvent` |
+
+Both addresses still `require_auth` on the request, exactly as before. What
+changes is that the authorisation buys a *queued* rotation rather than an
+immediate one, and the queue is visible: the request event gives indexers and
+the holder a window to notice a rotation nobody asked for, and
+`cancel_address_rotation` is how they stop it.
+
+While a rotation is pending:
+
+- **Reads return the current address.** `get_address`, `has_record`, and
+  `get_record_proof` all keep reporting the outgoing address until the rotation
+  executes. A pending rotation is a proposal, not a fact.
+- `get_pending_rotation(username)` exposes the queued address and its
+  `executable_at`, and works while paused so a holder can always see what is
+  queued against their name.
+- `verify` still operates on the record as it stands, against the current
+  address.
+- `register` refuses a direct address change with `RotationRequired`, so the
+  window cannot be stepped around.
+- A second request is refused with `RotationPending`; cancel first.
+- A rotation cannot be requested while a challenge is open on the username —
+  a challenge is an unresolved question about ownership, and queuing a rotation
+  underneath it would let the answer change mid-flight.
+
+Executing a rotation clears the verified flag and marks the username pending
+re-verify, the same policy a direct address change already applied: the
+verification vouched for the address, and the address has changed.
+
+**The delay defaults to 0, which disables all of the above** and preserves the
+direct dual-auth swap. This matches the existing `set_cooldown` convention.
+Operators handling real payouts should set it — 24h (`86400`) gives a holder a
+day to notice and cancel.
+
+---
+
 ## On-Chain Audit Logging
 
 The contract records structured audit log entries into contract storage upon state mutations (`initialize`, `register`, `remove`, `verify`, `batch_verify`, `pause`, `unpause`, `config_verification`, `set_role`).

--- a/docs/STORAGE_RENT.md
+++ b/docs/STORAGE_RENT.md
@@ -222,6 +222,44 @@ stellar contract invoke \
 
 ---
 
+## Reading a record's TTL from outside (Issue #230)
+
+`get_record_proof(github_username)` returns a `RecordProof`:
+
+| Field | Meaning |
+|---|---|
+| `exists` | Whether a record is stored for this username |
+| `verified` | The record's verified flag; `false` when `exists` is `false` |
+| `registered_at` | Ledger timestamp the record was last written |
+| `as_of_ledger` | Ledger sequence the proof was taken at |
+| `ttl_threshold_ledgers` | Remaining TTL below which the entry is bumped (`TTL_THRESHOLD`) |
+| `ttl_bump_ledgers` | How far ahead of the current ledger a bump extends it (`TTL_BUMP`) |
+| `key_prefix` | Symbol half of the storage key |
+
+It deliberately does **not** return `liveUntilLedgerSeq`. A contract cannot read
+its own entry's TTL on-chain — the host exposes `get_ttl` only to test
+utilities — so any number the contract reported would be inferred rather than
+observed, and would drift from the ledger the moment an extension landed.
+
+Read the real value from the ledger entry instead. The record's key is
+`(key_prefix, github_username)`, i.e. the `reg` symbol paired with the
+username, in **persistent** storage:
+
+```bash
+stellar contract read --id $ID --network testnet --durability persistent \
+  --key '["reg","octocat"]'
+```
+
+Over RPC, `getLedgerEntries` returns `liveUntilLedgerSeq` for the same key. A
+light client can then compare it against `as_of_ledger` from the proof and use
+`ttl_threshold_ledgers` / `ttl_bump_ledgers` to predict when the next read will
+bump the entry.
+
+If the entry has been archived, the same key is what
+[`extend_registry_ttl`](ABI.md) needs to revive it.
+
+---
+
 ## Related Docs
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — Storage layout, instance vs. persistent keys

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,18 @@ pub enum ContractError {
     /// Operation is blocked because a challenge is active on this username
     /// (Issue #214).
     ChallengeActive = 20,
+    /// `pause` / `unpause` was called with a code that is not a `PauseReason`.
+    InvalidPauseReason = 21,
+    /// `upgrade` was called while an attestation is required but none is live.
+    AttestationRequired = 22,
+    /// `add_reserved` was called with a username already on the reserved list.
+    AlreadyReserved = 23,
+    /// `remove_reserved` was called with a username that is not reserved.
+    NotReserved = 24,
+    /// `add_reserved` was called when the list already holds `MAX_RESERVED`.
+    ReservedListFull = 25,
+    /// `register` was called with a username on the reserved list.
+    UsernameReserved = 26,
 }
 
 impl ContractError {
@@ -110,6 +122,12 @@ impl ContractError {
             18 => Some(ContractError::NoChallengeActive),
             19 => Some(ContractError::ChallengeNotResolvable),
             20 => Some(ContractError::ChallengeActive),
+            21 => Some(ContractError::InvalidPauseReason),
+            22 => Some(ContractError::AttestationRequired),
+            23 => Some(ContractError::AlreadyReserved),
+            24 => Some(ContractError::NotReserved),
+            25 => Some(ContractError::ReservedListFull),
+            26 => Some(ContractError::UsernameReserved),
             _ => None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,6 +96,8 @@ pub enum ContractError {
     NoRotationPending = 29,
     /// The rotation's delay window has not elapsed yet.
     RotationNotReady = 30,
+    /// `rename` was called with a target username that is already registered.
+    UsernameTaken = 31,
 }
 
 impl ContractError {
@@ -141,6 +143,7 @@ impl ContractError {
             28 => Some(ContractError::RotationPending),
             29 => Some(ContractError::NoRotationPending),
             30 => Some(ContractError::RotationNotReady),
+            31 => Some(ContractError::UsernameTaken),
             _ => None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,6 +87,15 @@ pub enum ContractError {
     ReservedListFull = 25,
     /// `register` was called with a username on the reserved list.
     UsernameReserved = 26,
+    /// A rotation delay is configured, so the address must move through
+    /// `request_address_rotation` rather than a direct `register`.
+    RotationRequired = 27,
+    /// A rotation is already pending for this username.
+    RotationPending = 28,
+    /// No rotation is pending for this username.
+    NoRotationPending = 29,
+    /// The rotation's delay window has not elapsed yet.
+    RotationNotReady = 30,
 }
 
 impl ContractError {
@@ -128,6 +137,10 @@ impl ContractError {
             24 => Some(ContractError::NotReserved),
             25 => Some(ContractError::ReservedListFull),
             26 => Some(ContractError::UsernameReserved),
+            27 => Some(ContractError::RotationRequired),
+            28 => Some(ContractError::RotationPending),
+            29 => Some(ContractError::NoRotationPending),
+            30 => Some(ContractError::RotationNotReady),
             _ => None,
         }
     }

--- a/src/error_context.rs
+++ b/src/error_context.rs
@@ -105,6 +105,12 @@ pub fn classify_error(error: ContractError) -> ErrorCategory {
         ContractError::NoChallengeActive => ErrorCategory::Validation,
         ContractError::ChallengeNotResolvable => ErrorCategory::Transient,
         ContractError::ChallengeActive => ErrorCategory::Transient,
+        ContractError::InvalidPauseReason => ErrorCategory::Validation,
+        ContractError::AttestationRequired => ErrorCategory::Permanent,
+        ContractError::AlreadyReserved => ErrorCategory::Validation,
+        ContractError::NotReserved => ErrorCategory::Validation,
+        ContractError::ReservedListFull => ErrorCategory::Permanent,
+        ContractError::UsernameReserved => ErrorCategory::Validation,
     }
 }
 

--- a/src/error_context.rs
+++ b/src/error_context.rs
@@ -111,6 +111,10 @@ pub fn classify_error(error: ContractError) -> ErrorCategory {
         ContractError::NotReserved => ErrorCategory::Validation,
         ContractError::ReservedListFull => ErrorCategory::Permanent,
         ContractError::UsernameReserved => ErrorCategory::Validation,
+        ContractError::RotationRequired => ErrorCategory::Validation,
+        ContractError::RotationPending => ErrorCategory::Validation,
+        ContractError::NoRotationPending => ErrorCategory::Validation,
+        ContractError::RotationNotReady => ErrorCategory::Transient,
     }
 }
 

--- a/src/error_context.rs
+++ b/src/error_context.rs
@@ -115,6 +115,7 @@ pub fn classify_error(error: ContractError) -> ErrorCategory {
         ContractError::RotationPending => ErrorCategory::Validation,
         ContractError::NoRotationPending => ErrorCategory::Validation,
         ContractError::RotationNotReady => ErrorCategory::Transient,
+        ContractError::UsernameTaken => ErrorCategory::Validation,
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -159,3 +159,41 @@ mod test {
         );
     }
 }
+
+/// Emitted when the guardian trips the emergency circuit breaker (Issue #196).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EmergencyPausedEvent {
+    #[topic]
+    pub triggered_by: Address,
+    pub timestamp: u64,
+}
+
+/// Emitted when the admin clears an emergency pause (Issue #196).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EmergencyClearedEvent {
+    #[topic]
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+/// Emitted when a WASM hash is attested ahead of an upgrade.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpgradeAttestedEvent {
+    #[topic]
+    pub wasm_hash: BytesN<32>,
+    pub expires_at: u64,
+    pub timestamp: u64,
+}
+
+/// Emitted when a live attestation is cleared before it was consumed.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AttestationClearedEvent {
+    #[topic]
+    pub wasm_hash: BytesN<32>,
+    pub expires_at: u64,
+    pub timestamp: u64,
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -231,3 +231,17 @@ pub struct RotationCancelledEvent {
     pub cancelled_by: Address,
     pub timestamp: u64,
 }
+
+/// Emitted when a registration is renamed to a new GitHub username (Issue #233).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RenamedEvent {
+    #[topic]
+    pub old_username: String,
+    #[topic]
+    pub new_username: String,
+    pub stellar_address: Address,
+    /// Whether the verified flag was cleared by the rename.
+    pub verification_cleared: bool,
+    pub timestamp: u64,
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -197,3 +197,37 @@ pub struct AttestationClearedEvent {
     pub expires_at: u64,
     pub timestamp: u64,
 }
+
+/// Emitted when an address rotation is requested and starts its delay (Issue #234).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RotationRequestedEvent {
+    #[topic]
+    pub github_username: String,
+    pub current_address: Address,
+    pub new_address: Address,
+    /// Ledger timestamp from which the rotation may be executed.
+    pub executable_at: u64,
+    pub timestamp: u64,
+}
+
+/// Emitted when a pending address rotation is executed (Issue #234).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RotationExecutedEvent {
+    #[topic]
+    pub github_username: String,
+    pub old_address: Address,
+    pub new_address: Address,
+    pub timestamp: u64,
+}
+
+/// Emitted when a pending address rotation is cancelled (Issue #234).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RotationCancelledEvent {
+    #[topic]
+    pub github_username: String,
+    pub cancelled_by: Address,
+    pub timestamp: u64,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,8 @@ pub use events::{
     UpgradeAttestedEvent, UpgradedEvent, VerificationRevokedEvent, VerifiedEvent,
 };
 pub use storage::{
-    ChallengeRecord, ContributorRecord, ExportPage, HealthSnapshot, PauseReason, Role, Stats,
+    ChallengeRecord, ContributorRecord, ExportPage, HealthSnapshot, PauseReason, RecordProof, Role,
+    Stats,
     VerificationConfig, WasmAttestation, WasmProvenance,
 };
 pub use version::Version;
@@ -46,7 +47,8 @@ use crate::storage::{
     is_attestation_required, is_guardian, remove_guardian as storage_remove_guardian,
     set_emergency_pause, set_emergency_pause_ts, set_guardian_address,
     get_version as storage_get_version, get_wasm_attestation, get_wasm_provenance, has_challenge,
-    has_record, is_admin_caller, is_in_cooldown, is_paused as storage_is_paused, push_audit_entry,
+    build_record_proof, has_record, is_admin_caller, is_in_cooldown, is_paused as storage_is_paused,
+    push_audit_entry,
     remove_challenge, remove_from_index, remove_record, remove_role as storage_remove_role,
     remove_wasm_attestation, require_initialized, require_not_paused,
     run_migration_steps, set_challenge, set_cooldown as storage_set_cooldown, set_count,
@@ -1223,6 +1225,28 @@ impl TrustBridgeContract {
     #[must_use]
     pub fn has_record(env: Env, github_username: String) -> bool {
         has_record(&env, &github_username)
+    }
+
+    /// Returns a light-client existence proof for `github_username` (Issue #230).
+    ///
+    /// [`Self::has_record`] answers only yes/no. This carries the verified bit,
+    /// when the record was written, the ledger the answer was taken at, and the
+    /// storage key plus TTL policy needed to read or revive the ledger entry —
+    /// enough for an indexer or the GitHub action to confirm one registration
+    /// without paging the whole registry.
+    ///
+    /// A missing username is not an error: the proof comes back with
+    /// `exists: false`, which is itself the answer a light client needs.
+    ///
+    /// The exact `liveUntilLedgerSeq` is **not** included, because a contract
+    /// cannot read its own entry's TTL on-chain. Read it from the ledger entry
+    /// at `(key_prefix, github_username)`; see
+    /// [`docs/STORAGE_RENT.md`](../docs/STORAGE_RENT.md).
+    ///
+    /// Read-only; no auth required; works while paused.
+    #[must_use]
+    pub fn get_record_proof(env: Env, github_username: String) -> RecordProof {
+        build_record_proof(&env, &github_username)
     }
 
     /// Removes the registration for `github_username`. Callable by the registrant or the admin.
@@ -2944,6 +2968,105 @@ mod test {
             let result =
                 TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"));
             assert_eq!(result, Err(ContractError::AlreadyVerified));
+        });
+    }
+
+    // ── Issue #230: light-client record proof ────────────────────────────────
+
+    #[test]
+    fn test_record_proof_for_registered_username() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+                .unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            let proof = TrustBridgeContract::get_record_proof(env.clone(), username(&env, "octocat"));
+            assert!(proof.exists);
+            assert!(!proof.verified, "a fresh registration is unverified");
+            assert_eq!(proof.as_of_ledger, env.ledger().sequence());
+            assert_eq!(proof.key_prefix, soroban_sdk::symbol_short!("reg"));
+            assert_eq!(proof.ttl_threshold_ledgers, crate::storage::TTL_THRESHOLD);
+            assert_eq!(proof.ttl_bump_ledgers, crate::storage::TTL_BUMP);
+        });
+    }
+
+    #[test]
+    fn test_record_proof_reports_verified_bit() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+                .unwrap();
+        });
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            let proof = TrustBridgeContract::get_record_proof(env.clone(), username(&env, "octocat"));
+            assert!(proof.exists);
+            assert!(proof.verified);
+        });
+    }
+
+    /// A missing username is an answer, not an error.
+    #[test]
+    fn test_record_proof_for_missing_username() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        env.as_contract(&contract_id, || {
+            let proof = TrustBridgeContract::get_record_proof(env.clone(), username(&env, "ghost"));
+            assert!(!proof.exists);
+            assert!(!proof.verified);
+            assert_eq!(proof.registered_at, 0);
+            // The key and policy still come back so a client can look for the
+            // entry — including an archived one — itself.
+            assert_eq!(proof.key_prefix, soroban_sdk::symbol_short!("reg"));
+            assert_eq!(proof.ttl_bump_ledgers, crate::storage::TTL_BUMP);
+        });
+    }
+
+    #[test]
+    fn test_record_proof_agrees_with_has_record() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+                .unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            for name in ["octocat", "ghost"] {
+                assert_eq!(
+                    TrustBridgeContract::get_record_proof(env.clone(), username(&env, name)).exists,
+                    TrustBridgeContract::has_record(env.clone(), username(&env, name)),
+                    "proof.exists must agree with has_record for '{name}'"
+                );
+            }
+        });
+    }
+
+    /// The proof is a read: it must work while the contract is paused.
+    #[test]
+    fn test_record_proof_works_while_paused() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+                .unwrap();
+        });
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::pause(env.clone(), 1).unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            assert!(TrustBridgeContract::get_record_proof(env.clone(), username(&env, "octocat")).exists);
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use audit::{AuditConfig, AuditEventType, AuditLogEntry, AuditStats};
 pub use batch::{BatchConfig, BatchOperationResult, BatchSummary};
 pub use error::ContractError;
 pub use events::{
-    AttestationClearedEvent, ChallengeCancelledEvent, ChallengeCompletedEvent,
+    AttestationClearedEvent, ChallengeCancelledEvent, ChallengeCompletedEvent, RenamedEvent,
     RotationCancelledEvent, RotationExecutedEvent, RotationRequestedEvent,
     ChallengeStartedEvent, EmergencyClearedEvent, EmergencyPausedEvent, PausedEvent,
     RegisteredEvent, RemovedEvent, RoleGrantedEvent, RoleRevokedEvent, UnpausedEvent,
@@ -1720,6 +1720,146 @@ impl TrustBridgeContract {
         storage_get_verified_count(&env)
     }
 
+    /// Moves a registration from `old_username` to `new_username` (Issue #233).
+    ///
+    /// GitHub users rename. Without this they had to `remove` and re-register,
+    /// which drops the record entirely and leaves the old name free for anyone
+    /// to take in between.
+    ///
+    /// The move is atomic: the new record is written and the old one removed in
+    /// the same invocation, so there is no ledger state where the registration
+    /// exists under both names or neither. The total registration count is
+    /// unchanged — this is a move, not a new registration.
+    ///
+    /// # Verified state
+    ///
+    /// **The verified flag does not travel.** Verification attests that a
+    /// particular GitHub identity controls the address; the contract cannot
+    /// confirm that the new handle is the same GitHub account, and carrying the
+    /// badge across would let a verified throwaway rename onto a valuable
+    /// handle and arrive pre-trusted. The record is marked pending re-verify
+    /// instead, and `get_ever_verified_count` still remembers the original
+    /// verification. See `docs/ABI.md`.
+    ///
+    /// Emits [`RenamedEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from `caller`, which must be the registered address or the
+    /// contract admin — the same rule `remove` applies.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotRegistered`] if `old_username` is not registered.
+    /// - [`ContractError::NotAuthorized`] if `caller` is neither holder nor admin.
+    /// - [`ContractError::InvalidUsername`] if `new_username` is not a valid
+    ///   GitHub username, or is the same as `old_username`.
+    /// - [`ContractError::UsernameReserved`] if `new_username` is reserved.
+    /// - [`ContractError::UsernameTaken`] if `new_username` is already registered.
+    /// - [`ContractError::CooldownActive`] if the username is in cooldown.
+    /// - [`ContractError::ChallengeActive`] if a challenge is open on either name.
+    /// - [`ContractError::RotationPending`] if an address rotation is pending.
+    pub fn rename(
+        env: Env,
+        caller: Address,
+        old_username: String,
+        new_username: String,
+    ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+
+        let record = get_record(&env, &old_username).ok_or(ContractError::NotRegistered)?;
+        let admin = get_admin(&env)?;
+
+        caller.require_auth();
+        Self::require_remove_auth(&caller, &admin, &record.stellar_address)?;
+
+        if !is_valid_github_username(&new_username) {
+            return Err(ContractError::InvalidUsername);
+        }
+
+        // A rename to the identical string is a no-op dressed as a state
+        // change; reject it rather than emit an event for nothing. A
+        // case-only rename is a real move and stays allowed, since the storage
+        // key is the exact string.
+        if new_username == old_username {
+            return Err(ContractError::InvalidUsername);
+        }
+
+        if crate::storage::is_reserved(&env, &new_username) {
+            return Err(ContractError::UsernameReserved);
+        }
+
+        if has_record(&env, &new_username) {
+            return Err(ContractError::UsernameTaken);
+        }
+
+        // An open challenge on either name is an unresolved ownership question.
+        if has_challenge(&env, &old_username) || has_challenge(&env, &new_username) {
+            return Err(ContractError::ChallengeActive);
+        }
+
+        // A queued address rotation is scoped to the old key; let it settle or
+        // be cancelled before the name moves out from under it.
+        if has_pending_rotation(&env, &old_username) {
+            return Err(ContractError::RotationPending);
+        }
+
+        if is_in_cooldown(&env, &old_username) {
+            return Err(ContractError::CooldownActive);
+        }
+
+        let timestamp = env.ledger().timestamp();
+        let verification_cleared = record.verified;
+
+        // Verification attested the old handle; it does not follow the rename.
+        if verification_cleared {
+            set_verified_count(&env, storage_get_verified_count(&env).saturating_sub(1));
+        }
+
+        let moved = ContributorRecord {
+            stellar_address: record.stellar_address.clone(),
+            registered_at: timestamp as u32,
+            verified: false,
+        };
+
+        // Write the new key and drop the old one in the same invocation: the
+        // registration is never visible under both names, nor missing from both.
+        set_record(&env, &new_username, &moved);
+        add_to_index(&env, &new_username);
+        remove_record(&env, &old_username);
+        remove_from_index(&env, &old_username);
+
+        clear_pending_reverify(&env, &old_username);
+        if verification_cleared {
+            set_pending_reverify(&env, &new_username, true);
+        }
+
+        set_last_action(&env, &new_username, timestamp);
+
+        RenamedEvent {
+            old_username: old_username.clone(),
+            new_username: new_username.clone(),
+            stellar_address: record.stellar_address.clone(),
+            verification_cleared,
+            timestamp,
+        }
+        .publish(&env);
+
+        push_audit_entry(
+            &env,
+            AuditLogEntry::new(
+                AuditEventType::UserRegistered,
+                timestamp,
+                Some(record.stellar_address),
+            ),
+        );
+
+        Ok(())
+    }
+
     // ── Address rotation with a delay window (Issue #234) ────────────────────
 
     /// Sets how long a requested address rotation must wait before it can be
@@ -3236,6 +3376,297 @@ mod test {
             let result =
                 TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"));
             assert_eq!(result, Err(ContractError::AlreadyVerified));
+        });
+    }
+
+    // ── Issue #233: username rename ──────────────────────────────────────────
+
+    fn register_as(env: &Env, contract_id: &Address, name: &str, addr: &Address) {
+        env.mock_all_auths();
+        env.as_contract(contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(env, name), addr.clone()).unwrap();
+        });
+    }
+
+    #[test]
+    fn test_rename_moves_the_registration_atomically() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        register_as(&env, &contract_id, "octocat", &user);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::rename(
+                env.clone(),
+                user.clone(),
+                username(&env, "octocat"),
+                username(&env, "octocat2"),
+            )
+            .unwrap();
+        });
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                !TrustBridgeContract::has_record(env.clone(), username(&env, "octocat")),
+                "old name must be gone"
+            );
+            assert_eq!(
+                TrustBridgeContract::get_address(env.clone(), username(&env, "octocat2"))
+                    .unwrap()
+                    .stellar_address,
+                user,
+                "new name must hold the same address"
+            );
+            assert_eq!(
+                TrustBridgeContract::get_stats(env.clone()).total,
+                1,
+                "a rename is a move, not a new registration"
+            );
+        });
+    }
+
+    #[test]
+    fn test_rename_updates_the_index() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        register_as(&env, &contract_id, "octocat", &user);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::rename(
+                env.clone(),
+                user.clone(),
+                username(&env, "octocat"),
+                username(&env, "octocat2"),
+            )
+            .unwrap();
+        });
+
+        env.as_contract(&contract_id, || {
+            let page = TrustBridgeContract::get_registered_paginated(env.clone(), 0, 50).unwrap();
+            let names: alloc::vec::Vec<_> = page
+                .records
+                .iter()
+                .map(|(name, _)| name.clone())
+                .collect();
+            assert!(
+                names.contains(&username(&env, "octocat2")),
+                "index must list the new name"
+            );
+            assert!(
+                !names.contains(&username(&env, "octocat")),
+                "index must not still list the old name"
+            );
+        });
+    }
+
+    /// Verification attested the old handle, so it does not follow the rename.
+    #[test]
+    fn test_rename_clears_verification_and_flags_reverify() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        register_as(&env, &contract_id, "octocat", &user);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::rename(
+                env.clone(),
+                user.clone(),
+                username(&env, "octocat"),
+                username(&env, "octocat2"),
+            )
+            .unwrap();
+        });
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                !TrustBridgeContract::get_address(env.clone(), username(&env, "octocat2"))
+                    .unwrap()
+                    .verified,
+                "the badge must not travel to the new handle"
+            );
+            assert_eq!(TrustBridgeContract::get_verified_count(env.clone()), 0);
+            assert_eq!(
+                TrustBridgeContract::get_ever_verified_count(env.clone()),
+                1,
+                "history still remembers the original verification"
+            );
+        });
+    }
+
+    #[test]
+    fn test_rename_rejects_a_taken_username() {
+        let env = Env::default();
+        let (_admin, user, other, contract_id) = setup(&env);
+        register_as(&env, &contract_id, "octocat", &user);
+        register_as(&env, &contract_id, "hubber", &other);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::rename(
+                    env.clone(),
+                    user.clone(),
+                    username(&env, "octocat"),
+                    username(&env, "hubber"),
+                ),
+                Err(ContractError::UsernameTaken)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::get_address(env.clone(), username(&env, "hubber"))
+                    .unwrap()
+                    .stellar_address,
+                other,
+                "the existing registration must be untouched"
+            );
+        });
+    }
+
+    #[test]
+    fn test_rename_rejects_a_reserved_username() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        register_as(&env, &contract_id, "octocat", &user);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::add_reserved(env.clone(), username(&env, "stellar")).unwrap();
+        });
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::rename(
+                    env.clone(),
+                    user.clone(),
+                    username(&env, "octocat"),
+                    username(&env, "stellar"),
+                ),
+                Err(ContractError::UsernameReserved)
+            );
+        });
+    }
+
+    #[test]
+    fn test_rename_rejects_an_unregistered_username() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::rename(
+                    env.clone(),
+                    user.clone(),
+                    username(&env, "ghost"),
+                    username(&env, "ghost2"),
+                ),
+                Err(ContractError::NotRegistered)
+            );
+        });
+    }
+
+    #[test]
+    fn test_rename_rejects_renaming_to_the_same_name() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        register_as(&env, &contract_id, "octocat", &user);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::rename(
+                    env.clone(),
+                    user.clone(),
+                    username(&env, "octocat"),
+                    username(&env, "octocat"),
+                ),
+                Err(ContractError::InvalidUsername)
+            );
+        });
+    }
+
+    #[test]
+    fn test_rename_rejects_a_non_holder() {
+        let env = Env::default();
+        let (_admin, user, other, contract_id) = setup(&env);
+        register_as(&env, &contract_id, "octocat", &user);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::rename(
+                    env.clone(),
+                    other.clone(),
+                    username(&env, "octocat"),
+                    username(&env, "octocat2"),
+                ),
+                Err(ContractError::NotAuthorized)
+            );
+        });
+    }
+
+    /// A case-only change is a real move, since the storage key is the exact string.
+    #[test]
+    fn test_rename_allows_a_case_only_change() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        register_as(&env, &contract_id, "octocat", &user);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::rename(
+                env.clone(),
+                user.clone(),
+                username(&env, "octocat"),
+                username(&env, "OctoCat"),
+            )
+            .unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            assert!(TrustBridgeContract::has_record(env.clone(), username(&env, "OctoCat")));
+            assert!(!TrustBridgeContract::has_record(env.clone(), username(&env, "octocat")));
+        });
+    }
+
+    /// The old name is free again, and taking it does not disturb the moved record.
+    #[test]
+    fn test_old_name_is_registerable_after_a_rename() {
+        let env = Env::default();
+        let (_admin, user, other, contract_id) = setup(&env);
+        register_as(&env, &contract_id, "octocat", &user);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::rename(
+                env.clone(),
+                user.clone(),
+                username(&env, "octocat"),
+                username(&env, "octocat2"),
+            )
+            .unwrap();
+        });
+
+        register_as(&env, &contract_id, "octocat", &other);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::get_address(env.clone(), username(&env, "octocat"))
+                    .unwrap()
+                    .stellar_address,
+                other
+            );
+            assert_eq!(
+                TrustBridgeContract::get_address(env.clone(), username(&env, "octocat2"))
+                    .unwrap()
+                    .stellar_address,
+                user
+            );
+            assert_eq!(TrustBridgeContract::get_stats(env.clone()).total, 2);
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,12 +23,13 @@ pub use audit::{AuditConfig, AuditEventType, AuditLogEntry, AuditStats};
 pub use batch::{BatchConfig, BatchOperationResult, BatchSummary};
 pub use error::ContractError;
 pub use events::{
-    ChallengeCancelledEvent, ChallengeCompletedEvent, ChallengeStartedEvent, PausedEvent,
+    AttestationClearedEvent, ChallengeCancelledEvent, ChallengeCompletedEvent,
+    ChallengeStartedEvent, EmergencyClearedEvent, EmergencyPausedEvent, PausedEvent,
     RegisteredEvent, RemovedEvent, RoleGrantedEvent, RoleRevokedEvent, UnpausedEvent,
-    UpgradedEvent, VerificationRevokedEvent, VerifiedEvent,
+    UpgradeAttestedEvent, UpgradedEvent, VerificationRevokedEvent, VerifiedEvent,
 };
 pub use storage::{
-    ChallengeRecord, ContributorRecord, ExportPage, HealthSnapshot, Role, Stats,
+    ChallengeRecord, ContributorRecord, ExportPage, HealthSnapshot, PauseReason, Role, Stats,
     VerificationConfig, WasmAttestation, WasmProvenance,
 };
 pub use version::Version;
@@ -39,14 +40,19 @@ use crate::storage::{
     add_to_index, clear_pending_reverify, get_admin, get_audit_logs, get_audit_stats,
     get_challenge, get_cooldown as storage_get_cooldown, get_count, get_index, get_last_upgrade,
     get_record, get_registered_paginated_internal, get_role as storage_get_role,
+    bump_ever_verified_count, get_emergency_pause, get_emergency_pause_ts,
+    get_ever_verified_count as storage_get_ever_verified_count, get_guardian as storage_get_guardian,
     get_stats as read_stats, get_verification_config, get_verified_count as storage_get_verified_count,
+    is_attestation_required, is_guardian, remove_guardian as storage_remove_guardian,
+    set_emergency_pause, set_emergency_pause_ts, set_guardian_address,
     get_version as storage_get_version, get_wasm_attestation, get_wasm_provenance, has_challenge,
     has_record, is_admin_caller, is_in_cooldown, is_paused as storage_is_paused, push_audit_entry,
     remove_challenge, remove_from_index, remove_record, remove_role as storage_remove_role,
     remove_wasm_attestation, require_initialized, require_not_paused,
     run_migration_steps, set_challenge, set_cooldown as storage_set_cooldown, set_count,
     set_last_action, set_last_upgrade, set_paused as set_paused_state, set_pending_reverify,
-    set_record, set_role as storage_set_role, set_verified_count, set_version,
+    set_ever_verified_count, set_record, set_role as storage_set_role, set_verified_count,
+    set_version,
     set_wasm_attestation, set_wasm_provenance, DEFAULT_CHALLENGE_DELAY_SECS,
     ADMIN_KEY,
 };
@@ -120,6 +126,7 @@ impl TrustBridgeContract {
         env.storage().instance().set(&ADMIN_KEY, &admin);
         set_count(&env, 0);
         set_verified_count(&env, 0);
+        set_ever_verified_count(&env, 0);
         set_paused_state(&env, false);
         storage_set_cooldown(&env, 0);
         set_version(&env, (1, 0, 0));
@@ -978,6 +985,12 @@ impl TrustBridgeContract {
             return Err(ContractError::ZeroAddress);
         }
 
+        // Reserved names are held back for their real owners; the check is
+        // case-insensitive so "Stellar" cannot slip past a reserved "stellar".
+        if crate::storage::is_reserved(&env, &github_username) {
+            return Err(ContractError::UsernameReserved);
+        }
+
         // Block re-registration while a challenge is pending (Issue #214).
         // The registrant's window to prove ownership off-chain must not be
         // bypassed by simply re-registering to a new address.
@@ -1419,24 +1432,32 @@ impl TrustBridgeContract {
         let admin = get_admin(&env)?;
         admin.require_auth();
 
+        if !PauseReason::is_valid(reason_code) {
+            return Err(ContractError::InvalidPauseReason);
+        }
+        let reason = PauseReason::from_code(reason_code).unwrap_or(PauseReason::Other);
+
         // Idempotent: skip event emission if already in the requested state.
         if storage_is_paused(&env) == paused {
             return Ok(());
         }
 
         set_paused_state(&env, paused);
+        crate::storage::set_pause_reason(&env, reason);
         let timestamp = env.ledger().timestamp();
 
         if paused {
             PausedEvent {
                 admin: admin.clone(),
                 timestamp,
+                reason_code,
             }
             .publish(&env);
         } else {
             UnpausedEvent {
                 admin: admin.clone(),
                 timestamp,
+                reason_code,
             }
             .publish(&env);
         }
@@ -1486,6 +1507,7 @@ impl TrustBridgeContract {
         record.verified = true;
         set_record(&env, &github_username, &record);
         set_verified_count(&env, storage_get_verified_count(&env).saturating_add(1));
+        bump_ever_verified_count(&env);
 
         // Clear pending reverify flag upon successful verification
         clear_pending_reverify(&env, &github_username);
@@ -1560,6 +1582,7 @@ impl TrustBridgeContract {
             record.verified = true;
             set_record(&env, &username, &record);
             set_verified_count(&env, storage_get_verified_count(&env).saturating_add(1));
+            bump_ever_verified_count(&env);
             clear_pending_reverify(&env, &username);
 
             VerifiedEvent {
@@ -1658,6 +1681,31 @@ impl TrustBridgeContract {
     #[must_use]
     pub fn get_verified_count(env: Env) -> u32 {
         storage_get_verified_count(&env)
+    }
+
+    /// Returns the reason recorded by the most recent `pause` / `unpause`.
+    ///
+    /// Defaults to [`PauseReason::Other`] on an instance that has never been
+    /// paused, so the read is always answerable.
+    ///
+    /// Read-only; no auth required; works while paused.
+    #[must_use]
+    pub fn get_pause_reason(env: Env) -> PauseReason {
+        crate::storage::get_pause_reason(&env).unwrap_or(PauseReason::Other)
+    }
+
+    /// Returns how many verifications have ever been granted, including any
+    /// since revoked (Issue #229).
+    ///
+    /// Unlike [`Self::get_verified_count`], which reports who is verified
+    /// *right now* and drops when a verification is revoked, this figure only
+    /// ever grows. Reports asking "how many contributors did we ever verify"
+    /// should read this one.
+    ///
+    /// Read-only; no auth required; works while paused.
+    #[must_use]
+    pub fn get_ever_verified_count(env: Env) -> u32 {
+        storage_get_ever_verified_count(&env)
     }
 
     /// Returns aggregate registry statistics: total and verified registration counts.
@@ -2054,6 +2102,8 @@ extern crate std;
 #[cfg(test)]
 mod test {
     use super::*;
+    use alloc::format;
+    use alloc::string::ToString;
     use soroban_sdk::{
         testutils::{Address as _, Events as _, Ledger as _},
         Address, Env, Event as _, String, TryFromVal,
@@ -3477,12 +3527,18 @@ mod test {
             ContractError::NoChallengeActive,
             ContractError::ChallengeNotResolvable,
             ContractError::ChallengeActive,
+            ContractError::InvalidPauseReason,
+            ContractError::AttestationRequired,
+            ContractError::AlreadyReserved,
+            ContractError::NotReserved,
+            ContractError::ReservedListFull,
+            ContractError::UsernameReserved,
         ] {
             assert_eq!(ContractError::from_code(variant.code()), Some(variant));
         }
         assert_eq!(ContractError::from_code(0), None);
-        // 21 is one past the highest assigned variant (ChallengeActive = 20):
-        assert_eq!(ContractError::from_code(21), None);
+        // 27 is one past the highest assigned variant (UsernameReserved = 26):
+        assert_eq!(ContractError::from_code(27), None);
     }
 
     // --- Issue #69: max username length guard ---
@@ -4091,7 +4147,7 @@ mod test {
     #[test]
     fn test_from_code_unknown_returns_none() {
         assert_eq!(ContractError::from_code(0), None);
-        assert_eq!(ContractError::from_code(21), None);
+        assert_eq!(ContractError::from_code(27), None);
         assert_eq!(ContractError::from_code(u32::MAX), None);
     }
 
@@ -5982,7 +6038,7 @@ mod test {
         // 5. Works while paused
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::pause(env.clone()).unwrap();
+            TrustBridgeContract::pause(env.clone(), 1).unwrap();
             let usernames = soroban_sdk::vec![&env, username(&env, "octocat")];
             let extended = TrustBridgeContract::extend_registry_ttl(env.clone(), usernames).unwrap();
             assert_eq!(extended, 1);
@@ -6129,16 +6185,14 @@ mod test {
         let (admin, _user, _other, contract_id) = setup(&env);
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            TrustBridgeContract::set_paused(env.clone(), true).unwrap();
+            TrustBridgeContract::set_paused(env.clone(), true, 1).unwrap();
             let events = env.events().all();
+            let expected_topic = soroban_sdk::xdr::ScVal::Symbol(
+                soroban_sdk::xdr::ScSymbol("paused_event".try_into().unwrap()),
+            );
             let found = events.events().iter().any(|e| {
-                let topics = e.topics;
-                if topics.len() >= 2 {
-                    if let Ok(s) = soroban_sdk::Symbol::try_from_val(&env, &topics.get_unchecked(1)) {
-                        return s == soroban_sdk::Symbol::new(&env, "paused_event");
-                    }
-                }
-                false
+                let soroban_sdk::xdr::ContractEventBody::V0(body) = &e.body;
+                body.topics.iter().any(|t| t == &expected_topic)
             });
             assert!(found, "set_paused(true) must emit PausedEvent");
         });
@@ -6151,18 +6205,16 @@ mod test {
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
             // First pause, then unpause via set_paused
-            TrustBridgeContract::pause(env.clone()).unwrap();
+            TrustBridgeContract::pause(env.clone(), 1).unwrap();
             env.events().all(); // consume
-            TrustBridgeContract::set_paused(env.clone(), false).unwrap();
+            TrustBridgeContract::set_paused(env.clone(), false, 4).unwrap();
             let events = env.events().all();
+            let expected_topic = soroban_sdk::xdr::ScVal::Symbol(
+                soroban_sdk::xdr::ScSymbol("unpaused_event".try_into().unwrap()),
+            );
             let found = events.events().iter().any(|e| {
-                let topics = e.topics;
-                if topics.len() >= 2 {
-                    if let Ok(s) = soroban_sdk::Symbol::try_from_val(&env, &topics.get_unchecked(1)) {
-                        return s == soroban_sdk::Symbol::new(&env, "unpaused_event");
-                    }
-                }
-                false
+                let soroban_sdk::xdr::ContractEventBody::V0(body) = &e.body;
+                body.topics.iter().any(|t| t == &expected_topic)
             });
             assert!(found, "set_paused(false) must emit UnpausedEvent");
         });
@@ -6176,7 +6228,7 @@ mod test {
         env.as_contract(&contract_id, || {
             // Already unpaused — calling set_paused(false) again should be a no-op
             let count_before = env.events().all().events().len();
-            TrustBridgeContract::set_paused(env.clone(), false).unwrap();
+            TrustBridgeContract::set_paused(env.clone(), false, 4).unwrap();
             let count_after = env.events().all().events().len();
             assert_eq!(
                 count_before, count_after,
@@ -6184,9 +6236,9 @@ mod test {
             );
 
             // Pause, then call set_paused(true) again — still a no-op
-            TrustBridgeContract::set_paused(env.clone(), true).unwrap();
+            TrustBridgeContract::set_paused(env.clone(), true, 1).unwrap();
             let count_before2 = env.events().all().events().len();
-            TrustBridgeContract::set_paused(env.clone(), true).unwrap();
+            TrustBridgeContract::set_paused(env.clone(), true, 1).unwrap();
             let count_after2 = env.events().all().events().len();
             assert_eq!(
                 count_before2, count_after2,
@@ -6205,7 +6257,7 @@ mod test {
             // We mock all auths so this tests the logical path — the admin key is
             // the only one that satisfies the check.
             assert!(
-                TrustBridgeContract::set_paused(env.clone(), true).is_ok(),
+                TrustBridgeContract::set_paused(env.clone(), true, 1).is_ok(),
                 "mock_all_auths must satisfy require_auth()"
             );
         });
@@ -6334,7 +6386,7 @@ mod test {
             TrustBridgeContract::set_guardian(env.clone(), guardian.clone()).unwrap();
 
             // Trip both flags
-            TrustBridgeContract::pause(env.clone()).unwrap();
+            TrustBridgeContract::pause(env.clone(), 1).unwrap();
             TrustBridgeContract::emergency_pause(env.clone(), guardian.clone()).unwrap();
 
             // Clear emergency pause only — normal pause still blocks
@@ -6351,7 +6403,7 @@ mod test {
             );
 
             // Clear normal pause too — now unblocked
-            TrustBridgeContract::unpause(env.clone()).unwrap();
+            TrustBridgeContract::unpause(env.clone(), 4).unwrap();
             TrustBridgeContract::register(
                 env.clone(),
                 username(&env, "nowworks"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2947,6 +2947,114 @@ mod test {
         });
     }
 
+    // ── Issue #229: monotonic ever-verified counter ──────────────────────────
+
+    /// A verify/revoke/verify cycle: the live count moves with the flag, the
+    /// historical count only ever climbs.
+    #[test]
+    fn test_ever_verified_count_survives_a_revoke_cycle() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+                .unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(TrustBridgeContract::get_ever_verified_count(env.clone()), 0);
+        });
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(TrustBridgeContract::get_verified_count(env.clone()), 1);
+            assert_eq!(TrustBridgeContract::get_ever_verified_count(env.clone()), 1);
+        });
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::revoke_verification(
+                env.clone(),
+                admin.clone(),
+                username(&env, "octocat"),
+                1,
+            )
+            .unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::get_verified_count(env.clone()),
+                0,
+                "live count must drop on revoke"
+            );
+            assert_eq!(
+                TrustBridgeContract::get_ever_verified_count(env.clone()),
+                1,
+                "historical count must not drop on revoke"
+            );
+        });
+
+        // Verifying the same contributor again counts as a second verification.
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(TrustBridgeContract::get_verified_count(env.clone()), 1);
+            assert_eq!(TrustBridgeContract::get_ever_verified_count(env.clone()), 2);
+        });
+    }
+
+    /// `get_stats` reports the live and historical counts side by side.
+    #[test]
+    fn test_stats_reports_live_and_ever_verified() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+                .unwrap();
+        });
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::revoke_verification(
+                env.clone(),
+                admin.clone(),
+                username(&env, "octocat"),
+                1,
+            )
+            .unwrap();
+        });
+
+        env.as_contract(&contract_id, || {
+            let stats = TrustBridgeContract::get_stats(env.clone());
+            assert_eq!(stats.total, 1);
+            assert_eq!(stats.verified, 0, "verified is the live figure");
+            assert_eq!(stats.ever_verified, 1, "ever_verified keeps the history");
+        });
+    }
+
+    /// A fresh instance starts both counters at zero.
+    #[test]
+    fn test_ever_verified_count_starts_at_zero() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        env.as_contract(&contract_id, || {
+            assert_eq!(TrustBridgeContract::get_ever_verified_count(env.clone()), 0);
+        });
+    }
+
     #[test]
     fn test_revoke_verification_clears_flag_and_decrements_vcount() {
         let env = Env::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4792,12 +4792,13 @@ mod test {
             ContractError::RotationPending,
             ContractError::NoRotationPending,
             ContractError::RotationNotReady,
+            ContractError::UsernameTaken,
         ] {
             assert_eq!(ContractError::from_code(variant.code()), Some(variant));
         }
         assert_eq!(ContractError::from_code(0), None);
-        // 31 is one past the highest assigned variant (RotationNotReady = 30):
-        assert_eq!(ContractError::from_code(31), None);
+        // 32 is one past the highest assigned variant (UsernameTaken = 31):
+        assert_eq!(ContractError::from_code(32), None);
     }
 
     // --- Issue #69: max username length guard ---
@@ -5406,7 +5407,7 @@ mod test {
     #[test]
     fn test_from_code_unknown_returns_none() {
         assert_eq!(ContractError::from_code(0), None);
-        assert_eq!(ContractError::from_code(31), None);
+        assert_eq!(ContractError::from_code(32), None);
         assert_eq!(ContractError::from_code(u32::MAX), None);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,13 +24,14 @@ pub use batch::{BatchConfig, BatchOperationResult, BatchSummary};
 pub use error::ContractError;
 pub use events::{
     AttestationClearedEvent, ChallengeCancelledEvent, ChallengeCompletedEvent,
+    RotationCancelledEvent, RotationExecutedEvent, RotationRequestedEvent,
     ChallengeStartedEvent, EmergencyClearedEvent, EmergencyPausedEvent, PausedEvent,
     RegisteredEvent, RemovedEvent, RoleGrantedEvent, RoleRevokedEvent, UnpausedEvent,
     UpgradeAttestedEvent, UpgradedEvent, VerificationRevokedEvent, VerifiedEvent,
 };
 pub use storage::{
-    ChallengeRecord, ContributorRecord, ExportPage, HealthSnapshot, PauseReason, RecordProof, Role,
-    Stats,
+    ChallengeRecord, ContributorRecord, ExportPage, HealthSnapshot, PauseReason, PendingRotation,
+    RecordProof, Role, Stats,
     VerificationConfig, WasmAttestation, WasmProvenance,
 };
 pub use version::Version;
@@ -47,8 +48,10 @@ use crate::storage::{
     is_attestation_required, is_guardian, remove_guardian as storage_remove_guardian,
     set_emergency_pause, set_emergency_pause_ts, set_guardian_address,
     get_version as storage_get_version, get_wasm_attestation, get_wasm_provenance, has_challenge,
-    build_record_proof, has_record, is_admin_caller, is_in_cooldown, is_paused as storage_is_paused,
-    push_audit_entry,
+    build_record_proof, get_pending_rotation as storage_get_pending_rotation,
+    get_rotation_delay as storage_get_rotation_delay, has_pending_rotation, has_record,
+    is_admin_caller, is_in_cooldown, is_paused as storage_is_paused, push_audit_entry,
+    remove_pending_rotation, set_pending_rotation, set_rotation_delay as storage_set_rotation_delay,
     remove_challenge, remove_from_index, remove_record, remove_role as storage_remove_role,
     remove_wasm_attestation, require_initialized, require_not_paused,
     run_migration_steps, set_challenge, set_cooldown as storage_set_cooldown, set_count,
@@ -1015,6 +1018,16 @@ impl TrustBridgeContract {
             return Err(ContractError::CooldownActive);
         }
 
+        // With a rotation delay configured, an address change must go through
+        // request/execute so the delay window and its events actually apply.
+        // A direct swap here would be exactly the instant takeover the delay
+        // exists to prevent (Issue #234).
+        if let Some(ref old) = existing {
+            if old.stellar_address != stellar_address && storage_get_rotation_delay(&env) > 0 {
+                return Err(ContractError::RotationRequired);
+            }
+        }
+
         let record = ContributorRecord {
             stellar_address: stellar_address.clone(),
             registered_at: timestamp as u32,
@@ -1705,6 +1718,261 @@ impl TrustBridgeContract {
     #[must_use]
     pub fn get_verified_count(env: Env) -> u32 {
         storage_get_verified_count(&env)
+    }
+
+    // ── Address rotation with a delay window (Issue #234) ────────────────────
+
+    /// Sets how long a requested address rotation must wait before it can be
+    /// executed, in seconds. Admin-only. 0 disables the delay.
+    ///
+    /// While the delay is 0, `register` keeps its direct dual-auth address
+    /// change. Once it is set, an address change must go through
+    /// [`Self::request_address_rotation`] and
+    /// [`Self::execute_address_rotation`], and `register` rejects a direct
+    /// change with [`ContractError::RotationRequired`].
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
+    pub fn set_rotation_delay(env: Env, seconds: u64) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+        storage_set_rotation_delay(&env, seconds);
+        Ok(())
+    }
+
+    /// Returns the configured rotation delay in seconds. 0 means disabled.
+    ///
+    /// Read-only; no auth required.
+    #[must_use]
+    pub fn get_rotation_delay(env: Env) -> u64 {
+        storage_get_rotation_delay(&env)
+    }
+
+    /// Returns the pending address rotation for `github_username`, if any.
+    ///
+    /// Read-only; no auth required; works while paused, so a holder can always
+    /// see that a rotation is queued against their name.
+    #[must_use]
+    pub fn get_pending_rotation(env: Env, github_username: String) -> Option<PendingRotation> {
+        storage_get_pending_rotation(&env, &github_username)
+    }
+
+    /// Requests moving `github_username` to `new_address` after the delay.
+    ///
+    /// Both the current address and the new one must sign, exactly as a direct
+    /// re-registration required. The difference is that nothing moves yet: the
+    /// request is recorded, [`RotationRequestedEvent`] is emitted so indexers
+    /// and the holder can see it immediately, and the rotation only becomes
+    /// executable once the delay has elapsed. That window is what turns a
+    /// phished GitHub-plus-wallet session from an instant payout redirect into
+    /// something the real holder can notice and cancel.
+    ///
+    /// Reads keep returning the **current** address for the whole window.
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from both the currently registered address and `new_address`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotRegistered`] if the username is not registered.
+    /// - [`ContractError::ZeroAddress`] if `new_address` is the burn address.
+    /// - [`ContractError::RotationPending`] if a rotation is already pending.
+    /// - [`ContractError::ChallengeActive`] if a challenge is open on the username.
+    pub fn request_address_rotation(
+        env: Env,
+        github_username: String,
+        new_address: Address,
+    ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+
+        let record = get_record(&env, &github_username).ok_or(ContractError::NotRegistered)?;
+
+        if is_zero_address(&env, &new_address) {
+            return Err(ContractError::ZeroAddress);
+        }
+
+        // A challenge is an open question about who owns this name; queuing a
+        // rotation underneath it would let the answer change mid-flight.
+        if has_challenge(&env, &github_username) {
+            return Err(ContractError::ChallengeActive);
+        }
+
+        if has_pending_rotation(&env, &github_username) {
+            return Err(ContractError::RotationPending);
+        }
+
+        // Same dual-auth requirement as a direct re-registration.
+        record.stellar_address.require_auth();
+        if new_address != record.stellar_address {
+            new_address.require_auth();
+        }
+
+        let timestamp = env.ledger().timestamp();
+        let executable_at = timestamp.saturating_add(storage_get_rotation_delay(&env));
+
+        set_pending_rotation(
+            &env,
+            &github_username,
+            &PendingRotation {
+                new_address: new_address.clone(),
+                requested_at: timestamp,
+                executable_at,
+            },
+        );
+
+        RotationRequestedEvent {
+            github_username: github_username.clone(),
+            current_address: record.stellar_address.clone(),
+            new_address,
+            executable_at,
+            timestamp,
+        }
+        .publish(&env);
+
+        push_audit_entry(
+            &env,
+            AuditLogEntry::new(
+                AuditEventType::UserRegistered,
+                timestamp,
+                Some(record.stellar_address),
+            ),
+        );
+
+        Ok(())
+    }
+
+    /// Executes a pending rotation once its delay has elapsed.
+    ///
+    /// Applies the same verified-state policy a direct address change had: the
+    /// verified flag is cleared and the username is marked pending re-verify,
+    /// because the address that was vouched for is no longer the one on file.
+    ///
+    /// Emits [`RotationExecutedEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the incoming address.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotRegistered`] if the username is not registered.
+    /// - [`ContractError::NoRotationPending`] if nothing is pending.
+    /// - [`ContractError::RotationNotReady`] if the delay has not elapsed.
+    pub fn execute_address_rotation(
+        env: Env,
+        github_username: String,
+    ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+
+        let mut record = get_record(&env, &github_username).ok_or(ContractError::NotRegistered)?;
+        let pending = storage_get_pending_rotation(&env, &github_username)
+            .ok_or(ContractError::NoRotationPending)?;
+
+        let timestamp = env.ledger().timestamp();
+        if timestamp < pending.executable_at {
+            return Err(ContractError::RotationNotReady);
+        }
+
+        pending.new_address.require_auth();
+
+        let old_address = record.stellar_address.clone();
+
+        // The verification vouched for the old address, so it does not travel.
+        if record.verified {
+            set_verified_count(&env, storage_get_verified_count(&env).saturating_sub(1));
+            set_pending_reverify(&env, &github_username, true);
+        }
+
+        record.stellar_address = pending.new_address.clone();
+        record.registered_at = timestamp as u32;
+        record.verified = false;
+
+        set_record(&env, &github_username, &record);
+        set_last_action(&env, &github_username, timestamp);
+        remove_pending_rotation(&env, &github_username);
+
+        RotationExecutedEvent {
+            github_username: github_username.clone(),
+            old_address,
+            new_address: pending.new_address.clone(),
+            timestamp,
+        }
+        .publish(&env);
+
+        push_audit_entry(
+            &env,
+            AuditLogEntry::new(
+                AuditEventType::UserRegistered,
+                timestamp,
+                Some(pending.new_address),
+            ),
+        );
+
+        Ok(())
+    }
+
+    /// Cancels a pending rotation. Callable by the current holder or the admin.
+    ///
+    /// This is the half of the delay window that matters: it gives the real
+    /// holder a way to stop a rotation they did not intend.
+    ///
+    /// Emits [`RotationCancelledEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from `caller`, which must be the currently registered
+    /// address or the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotRegistered`] if the username is not registered.
+    /// - [`ContractError::NoRotationPending`] if nothing is pending.
+    /// - [`ContractError::NotAuthorized`] if `caller` is neither holder nor admin.
+    pub fn cancel_address_rotation(
+        env: Env,
+        caller: Address,
+        github_username: String,
+    ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+
+        let record = get_record(&env, &github_username).ok_or(ContractError::NotRegistered)?;
+        if !has_pending_rotation(&env, &github_username) {
+            return Err(ContractError::NoRotationPending);
+        }
+
+        caller.require_auth();
+        let admin = get_admin(&env)?;
+        if caller != record.stellar_address && caller != admin {
+            return Err(ContractError::NotAuthorized);
+        }
+
+        remove_pending_rotation(&env, &github_username);
+
+        let timestamp = env.ledger().timestamp();
+        RotationCancelledEvent {
+            github_username: github_username.clone(),
+            cancelled_by: caller.clone(),
+            timestamp,
+        }
+        .publish(&env);
+
+        push_audit_entry(
+            &env,
+            AuditLogEntry::new(AuditEventType::UserRegistered, timestamp, Some(caller)),
+        );
+
+        Ok(())
     }
 
     /// Returns the reason recorded by the most recent `pause` / `unpause`.
@@ -2971,6 +3239,331 @@ mod test {
         });
     }
 
+    // ── Issue #234: address rotation delay window ────────────────────────────
+
+    const ROT_DELAY: u64 = 86_400;
+
+    /// Register `octocat` to `user` and arm the rotation delay.
+    fn setup_rotation(env: &Env, contract_id: &Address, user: &Address) {
+        env.mock_all_auths();
+        env.as_contract(contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(env, "octocat"), user.clone())
+                .unwrap();
+        });
+        env.mock_all_auths();
+        env.as_contract(contract_id, || {
+            TrustBridgeContract::set_rotation_delay(env.clone(), ROT_DELAY).unwrap();
+        });
+    }
+
+    #[test]
+    fn test_rotation_delay_defaults_to_zero() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        env.as_contract(&contract_id, || {
+            assert_eq!(TrustBridgeContract::get_rotation_delay(env.clone()), 0);
+        });
+    }
+
+    /// With no delay configured, register keeps its direct dual-auth swap.
+    #[test]
+    fn test_register_still_swaps_directly_when_delay_is_zero() {
+        let env = Env::default();
+        let (_admin, user, other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+                .unwrap();
+        });
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), other.clone())
+                .unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::get_address(env.clone(), username(&env, "octocat"))
+                    .unwrap()
+                    .stellar_address,
+                other
+            );
+        });
+    }
+
+    /// Once a delay is armed, the instant swap is refused.
+    #[test]
+    fn test_register_refuses_direct_address_change_when_delay_armed() {
+        let env = Env::default();
+        let (_admin, user, other, contract_id) = setup(&env);
+        setup_rotation(&env, &contract_id, &user);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::register(env.clone(), username(&env, "octocat"), other.clone()),
+                Err(ContractError::RotationRequired)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::get_address(env.clone(), username(&env, "octocat"))
+                    .unwrap()
+                    .stellar_address,
+                user,
+                "the address must not have moved"
+            );
+        });
+    }
+
+    /// Re-registering the same address is not a rotation and stays allowed.
+    #[test]
+    fn test_register_same_address_still_allowed_with_delay_armed() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        setup_rotation(&env, &contract_id, &user);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone())
+                .unwrap();
+        });
+    }
+
+    #[test]
+    fn test_requesting_a_rotation_does_not_move_the_address() {
+        let env = Env::default();
+        let (_admin, user, other, contract_id) = setup(&env);
+        setup_rotation(&env, &contract_id, &user);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::request_address_rotation(
+                env.clone(),
+                username(&env, "octocat"),
+                other.clone(),
+            )
+            .unwrap();
+        });
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::get_address(env.clone(), username(&env, "octocat"))
+                    .unwrap()
+                    .stellar_address,
+                user,
+                "reads return the current address for the whole window"
+            );
+            let pending =
+                TrustBridgeContract::get_pending_rotation(env.clone(), username(&env, "octocat"))
+                    .expect("rotation must be pending");
+            assert_eq!(pending.new_address, other);
+            assert_eq!(pending.executable_at, pending.requested_at + ROT_DELAY);
+        });
+    }
+
+    #[test]
+    fn test_rotation_cannot_execute_before_the_delay_elapses() {
+        let env = Env::default();
+        let (_admin, user, other, contract_id) = setup(&env);
+        setup_rotation(&env, &contract_id, &user);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::request_address_rotation(
+                env.clone(),
+                username(&env, "octocat"),
+                other.clone(),
+            )
+            .unwrap();
+        });
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::execute_address_rotation(env.clone(), username(&env, "octocat")),
+                Err(ContractError::RotationNotReady)
+            );
+        });
+    }
+
+    #[test]
+    fn test_rotation_executes_once_the_delay_has_elapsed() {
+        let env = Env::default();
+        let (_admin, user, other, contract_id) = setup(&env);
+        setup_rotation(&env, &contract_id, &user);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::request_address_rotation(
+                env.clone(),
+                username(&env, "octocat"),
+                other.clone(),
+            )
+            .unwrap();
+        });
+
+        env.ledger().with_mut(|li| li.timestamp += ROT_DELAY);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::execute_address_rotation(env.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::get_address(env.clone(), username(&env, "octocat"))
+                    .unwrap()
+                    .stellar_address,
+                other
+            );
+            assert!(
+                TrustBridgeContract::get_pending_rotation(env.clone(), username(&env, "octocat"))
+                    .is_none(),
+                "the pending entry must be cleared"
+            );
+        });
+    }
+
+    /// The window is only useful if the real holder can stop the rotation.
+    #[test]
+    fn test_holder_can_cancel_a_pending_rotation() {
+        let env = Env::default();
+        let (_admin, user, other, contract_id) = setup(&env);
+        setup_rotation(&env, &contract_id, &user);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::request_address_rotation(
+                env.clone(),
+                username(&env, "octocat"),
+                other.clone(),
+            )
+            .unwrap();
+        });
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::cancel_address_rotation(
+                env.clone(),
+                user.clone(),
+                username(&env, "octocat"),
+            )
+            .unwrap();
+        });
+
+        env.ledger().with_mut(|li| li.timestamp += ROT_DELAY);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::execute_address_rotation(env.clone(), username(&env, "octocat")),
+                Err(ContractError::NoRotationPending),
+                "a cancelled rotation must not become executable"
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::get_address(env.clone(), username(&env, "octocat"))
+                    .unwrap()
+                    .stellar_address,
+                user
+            );
+        });
+    }
+
+    #[test]
+    fn test_second_rotation_request_is_rejected_while_one_is_pending() {
+        let env = Env::default();
+        let (_admin, user, other, contract_id) = setup(&env);
+        setup_rotation(&env, &contract_id, &user);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::request_address_rotation(
+                env.clone(),
+                username(&env, "octocat"),
+                other.clone(),
+            )
+            .unwrap();
+        });
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::request_address_rotation(
+                    env.clone(),
+                    username(&env, "octocat"),
+                    other.clone(),
+                ),
+                Err(ContractError::RotationPending)
+            );
+        });
+    }
+
+    #[test]
+    fn test_rotation_requires_a_registered_username() {
+        let env = Env::default();
+        let (_admin, _user, other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::request_address_rotation(
+                    env.clone(),
+                    username(&env, "ghost"),
+                    other.clone(),
+                ),
+                Err(ContractError::NotRegistered)
+            );
+        });
+    }
+
+    /// A verified registration loses its badge when the address moves.
+    #[test]
+    fn test_executing_a_rotation_clears_the_verified_flag() {
+        let env = Env::default();
+        let (admin, user, other, contract_id) = setup(&env);
+        setup_rotation(&env, &contract_id, &user);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(TrustBridgeContract::get_verified_count(env.clone()), 1);
+        });
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::request_address_rotation(
+                env.clone(),
+                username(&env, "octocat"),
+                other.clone(),
+            )
+            .unwrap();
+        });
+        env.ledger().with_mut(|li| li.timestamp += ROT_DELAY);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::execute_address_rotation(env.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                !TrustBridgeContract::get_address(env.clone(), username(&env, "octocat"))
+                    .unwrap()
+                    .verified,
+                "verification vouched for the old address"
+            );
+            assert_eq!(TrustBridgeContract::get_verified_count(env.clone()), 0);
+            assert_eq!(
+                TrustBridgeContract::get_ever_verified_count(env.clone()),
+                1,
+                "the historical count still remembers it"
+            );
+        });
+    }
+
     // ── Issue #230: light-client record proof ────────────────────────────────
 
     #[test]
@@ -3764,12 +4357,16 @@ mod test {
             ContractError::NotReserved,
             ContractError::ReservedListFull,
             ContractError::UsernameReserved,
+            ContractError::RotationRequired,
+            ContractError::RotationPending,
+            ContractError::NoRotationPending,
+            ContractError::RotationNotReady,
         ] {
             assert_eq!(ContractError::from_code(variant.code()), Some(variant));
         }
         assert_eq!(ContractError::from_code(0), None);
-        // 27 is one past the highest assigned variant (UsernameReserved = 26):
-        assert_eq!(ContractError::from_code(27), None);
+        // 31 is one past the highest assigned variant (RotationNotReady = 30):
+        assert_eq!(ContractError::from_code(31), None);
     }
 
     // --- Issue #69: max username length guard ---
@@ -4378,7 +4975,7 @@ mod test {
     #[test]
     fn test_from_code_unknown_returns_none() {
         assert_eq!(ContractError::from_code(0), None);
-        assert_eq!(ContractError::from_code(27), None);
+        assert_eq!(ContractError::from_code(31), None);
         assert_eq!(ContractError::from_code(u32::MAX), None);
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -276,6 +276,31 @@ pub struct AdminTransferProposal {
     pub executable_at: u64,
 }
 
+/// Existence proof for a single record, shaped for light clients (Issue #230).
+///
+/// Lets an indexer or the GitHub action confirm one registration without
+/// paging the whole registry, and carries what it needs to fetch or revive the
+/// underlying ledger entry itself.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[soroban_sdk::contracttype]
+pub struct RecordProof {
+    /// Whether a record is currently stored for this username.
+    pub exists: bool,
+    /// The record's verified flag. Always `false` when `exists` is `false`.
+    pub verified: bool,
+    /// Ledger timestamp the record was last written, or 0 when absent.
+    pub registered_at: u32,
+    /// Ledger sequence this proof was taken at.
+    pub as_of_ledger: u32,
+    /// Remaining-TTL threshold below which the entry is bumped, in ledgers.
+    pub ttl_threshold_ledgers: u32,
+    /// How far ahead of the current ledger a bump extends the entry.
+    pub ttl_bump_ledgers: u32,
+    /// Symbol half of the record's storage key. The full key is
+    /// `(key_prefix, github_username)` — see `docs/STORAGE_RENT.md`.
+    pub key_prefix: Symbol,
+}
+
 /// Aggregate registry statistics returned by `get_stats`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[soroban_sdk::contracttype]
@@ -439,6 +464,41 @@ pub fn remove_record(env: &Env, github_username: &String) {
 
 pub fn has_record(env: &Env, github_username: &String) -> bool {
     get_record(env, github_username).is_some()
+}
+
+/// Build the light-client existence proof for `github_username` (Issue #230).
+///
+/// Deliberately reads through `get_record`, so an existing record gets the same
+/// TTL bump any other read would give it and a proof cannot be used to sidestep
+/// keeping a live record alive.
+///
+/// The exact `liveUntilLedgerSeq` is not returned: a contract cannot read its
+/// own entry's TTL on-chain. The key and the TTL policy are returned instead so
+/// a client can read `liveUntilLedgerSeq` straight from the ledger entry — see
+/// `docs/STORAGE_RENT.md`.
+pub fn build_record_proof(env: &Env, github_username: &String) -> RecordProof {
+    let record = get_record(env, github_username);
+    let as_of_ledger = env.ledger().sequence();
+    match record {
+        Some(record) => RecordProof {
+            exists: true,
+            verified: record.verified,
+            registered_at: record.registered_at,
+            as_of_ledger,
+            ttl_threshold_ledgers: TTL_THRESHOLD,
+            ttl_bump_ledgers: TTL_BUMP,
+            key_prefix: REG_KEY,
+        },
+        None => RecordProof {
+            exists: false,
+            verified: false,
+            registered_at: 0,
+            as_of_ledger,
+            ttl_threshold_ledgers: TTL_THRESHOLD,
+            ttl_bump_ledgers: TTL_BUMP,
+            key_prefix: REG_KEY,
+        },
+    }
 }
 
 // ── Counters ─────────────────────────────────────────────────────────────────

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -19,8 +19,14 @@ pub const REG_KEY: Symbol = symbol_short!("reg");
 pub const ADMIN_KEY: Symbol = symbol_short!("admin");
 pub const COUNT_KEY: Symbol = symbol_short!("count");
 pub const VCOUNT_KEY: Symbol = symbol_short!("vcount");
+/// Monotonic count of verifications ever granted (Issue #229). Unlike
+/// `VCOUNT_KEY` this never decreases, so revoking does not erase the fact that
+/// a contributor was verified at some point.
+pub const EVER_VCOUNT_KEY: Symbol = symbol_short!("evcount");
 pub const INDEX_KEY: Symbol = symbol_short!("idx");
 pub const PAUSED_KEY: Symbol = symbol_short!("pause");
+/// Last `PauseReason` recorded by `pause` / `unpause`.
+pub const PAUSE_RSN_KEY: Symbol = symbol_short!("pause_rsn");
 pub const COOLDOWN_KEY: Symbol = symbol_short!("cdown");
 // Pending reverify flag per username
 pub const PENDING_REVERIFY_KEY: Symbol = symbol_short!("pend_rev");
@@ -276,8 +282,11 @@ pub struct AdminTransferProposal {
 pub struct Stats {
     /// Total number of registered contributors.
     pub total: u32,
-    /// Number of contributors who have been verified.
+    /// Number of contributors **currently** verified. Decreases on revoke.
     pub verified: u32,
+    /// Number of verifications ever granted, including any later revoked
+    /// (Issue #229). Monotonic: this never decreases.
+    pub ever_verified: u32,
 }
 
 /// A single page of registry records returned by paginated export functions.
@@ -448,6 +457,30 @@ pub fn get_verified_count(env: &Env) -> u32 {
 
 pub fn set_verified_count(env: &Env, count: u32) {
     env.storage().instance().set(&VCOUNT_KEY, &count);
+}
+
+/// Verifications ever granted, including those later revoked (Issue #229).
+///
+/// Instances deployed before this counter existed have no stored value. Rather
+/// than reporting zero — which would claim nobody was ever verified while
+/// `get_verified_count` says otherwise — they fall back to the live verified
+/// count, the tightest lower bound the contract can still prove.
+pub fn get_ever_verified_count(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&EVER_VCOUNT_KEY)
+        .unwrap_or_else(|| get_verified_count(env))
+}
+
+pub fn set_ever_verified_count(env: &Env, count: u32) {
+    env.storage().instance().set(&EVER_VCOUNT_KEY, &count);
+}
+
+/// Record one more verification in the monotonic counter. Saturates rather than
+/// wrapping, so the figure can only ever stall, never run backwards.
+pub fn bump_ever_verified_count(env: &Env) {
+    let next = get_ever_verified_count(env).saturating_add(1);
+    set_ever_verified_count(env, next);
 }
 
 // ── Flat username index ──────────────────────────────────────────────────────
@@ -655,12 +688,20 @@ pub fn get_registered_paginated_internal(
 // All stats reads (get_stats, and any future indexer/dashboard aggregate
 // endpoints) should route through it rather than building `Stats { .. }`
 // literals directly, so count/verified-count semantics stay in one place.
-pub fn build_stats(total: u32, verified: u32) -> Stats {
-    Stats { total, verified }
+pub fn build_stats(total: u32, verified: u32, ever_verified: u32) -> Stats {
+    Stats {
+        total,
+        verified,
+        ever_verified,
+    }
 }
 
 pub fn get_stats(env: &Env) -> Stats {
-    build_stats(get_count(env), get_verified_count(env))
+    build_stats(
+        get_count(env),
+        get_verified_count(env),
+        get_ever_verified_count(env),
+    )
 }
 
 // ── Cooldown / upgrade timelock ───────────────────────────────────────────────
@@ -1058,4 +1099,126 @@ pub fn run_migration_steps(
     }
 
     applied
+}
+
+// ── Pause reason ─────────────────────────────────────────────────────────────
+
+/// Record why the contract was last paused or unpaused.
+pub fn set_pause_reason(env: &Env, reason: PauseReason) {
+    env.storage()
+        .instance()
+        .set(&PAUSE_RSN_KEY, &(reason as u32));
+}
+
+/// The last recorded pause reason, or `None` if the contract has never been
+/// paused on this instance.
+pub fn get_pause_reason(env: &Env) -> Option<PauseReason> {
+    env.storage()
+        .instance()
+        .get::<Symbol, u32>(&PAUSE_RSN_KEY)
+        .and_then(PauseReason::from_code)
+}
+
+// ── Reserved usernames (Issue #213) ──────────────────────────────────────────
+
+/// The reserved username list, empty when nothing has been reserved.
+pub fn get_reserved_list(env: &Env) -> Vec<String> {
+    env.storage()
+        .instance()
+        .get(&RESERVED_KEY)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Case-insensitive membership test against the reserved list.
+pub fn is_reserved(env: &Env, username: &String) -> bool {
+    let reserved = get_reserved_list(env);
+    for entry in reserved.iter() {
+        if crate::utils::eq_ignore_ascii_case(&entry, username) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Add `username` to the reserved list.
+///
+/// # Errors
+///
+/// - [`ContractError::AlreadyReserved`] if it is already on the list.
+/// - [`ContractError::ReservedListFull`] if the list already holds
+///   `MAX_RESERVED` entries.
+pub fn add_to_reserved(env: &Env, username: &String) -> Result<(), ContractError> {
+    if is_reserved(env, username) {
+        return Err(ContractError::AlreadyReserved);
+    }
+    let mut reserved = get_reserved_list(env);
+    if reserved.len() >= MAX_RESERVED {
+        return Err(ContractError::ReservedListFull);
+    }
+    reserved.push_back(username.clone());
+    env.storage().instance().set(&RESERVED_KEY, &reserved);
+    Ok(())
+}
+
+/// Remove `username` from the reserved list.
+///
+/// # Errors
+///
+/// - [`ContractError::NotReserved`] if it is not currently reserved.
+pub fn remove_from_reserved(env: &Env, username: &String) -> Result<(), ContractError> {
+    let reserved = get_reserved_list(env);
+    let mut remaining: Vec<String> = Vec::new(env);
+    let mut found = false;
+    for entry in reserved.iter() {
+        if crate::utils::eq_ignore_ascii_case(&entry, username) {
+            found = true;
+        } else {
+            remaining.push_back(entry);
+        }
+    }
+    if !found {
+        return Err(ContractError::NotReserved);
+    }
+    env.storage().instance().set(&RESERVED_KEY, &remaining);
+    Ok(())
+}
+
+// ── Index compaction (Issue #209) ────────────────────────────────────────────
+
+/// Rebuild the chunked index densely from the flat index.
+///
+/// Removals leave holes in the chunk pages; this re-partitions the flat index
+/// into contiguous full chunks plus one partial tail and drops the persistent
+/// entries that are no longer backed by any username. Returns the number of
+/// chunks written.
+pub fn compact_chunked_index(env: &Env) -> u32 {
+    let index = get_index(env);
+    let previous_chunks = get_chunk_count(env);
+
+    let mut chunk_idx: u32 = 0;
+    let mut current: Vec<String> = Vec::new(env);
+    for username in index.iter() {
+        current.push_back(username);
+        if current.len() >= CHUNK_SIZE {
+            set_chunk(env, chunk_idx, &current);
+            chunk_idx += 1;
+            current = Vec::new(env);
+        }
+    }
+
+    // A partial tail still needs a page of its own.
+    if !current.is_empty() {
+        set_chunk(env, chunk_idx, &current);
+        chunk_idx += 1;
+    }
+
+    // Reclaim pages the compacted index no longer reaches.
+    let mut stale = chunk_idx;
+    while stale < previous_chunks {
+        env.storage().persistent().remove(&(CHUNK_KEY, stale));
+        stale += 1;
+    }
+
+    set_chunk_count(env, chunk_idx);
+    chunk_idx
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -28,6 +28,11 @@ pub const PAUSED_KEY: Symbol = symbol_short!("pause");
 /// Last `PauseReason` recorded by `pause` / `unpause`.
 pub const PAUSE_RSN_KEY: Symbol = symbol_short!("pause_rsn");
 pub const COOLDOWN_KEY: Symbol = symbol_short!("cdown");
+/// Seconds a requested address rotation must wait before it can execute
+/// (Issue #234). 0 disables the delay, matching the cooldown convention.
+pub const ROT_DELAY_KEY: Symbol = symbol_short!("rotdelay");
+/// Key prefix for a username's pending address rotation (Issue #234).
+pub const PENDING_ROT_KEY: Symbol = symbol_short!("pendrot");
 // Pending reverify flag per username
 pub const PENDING_REVERIFY_KEY: Symbol = symbol_short!("pend_rev");
 // Emergency pause flag and timestamp — wired as guardian circuit breaker (Issue #196)
@@ -273,6 +278,18 @@ pub struct AdminTransferProposal {
     /// Ledger timestamp when `propose_admin_transfer` was called.
     pub proposed_at: u64,
     /// Earliest ledger timestamp at which `execute_admin_transfer` may run.
+    pub executable_at: u64,
+}
+
+/// An address rotation that has been requested but not yet executed (Issue #234).
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[soroban_sdk::contracttype]
+pub struct PendingRotation {
+    /// The address the registration will move to once executed.
+    pub new_address: Address,
+    /// Ledger timestamp the rotation was requested.
+    pub requested_at: u64,
+    /// Ledger timestamp from which the rotation may be executed.
     pub executable_at: u64,
 }
 
@@ -1281,4 +1298,47 @@ pub fn compact_chunked_index(env: &Env) -> u32 {
 
     set_chunk_count(env, chunk_idx);
     chunk_idx
+}
+
+// ── Address rotation (Issue #234) ────────────────────────────────────────────
+
+/// Seconds a requested rotation must wait before it can execute. 0 disables the
+/// delay, in which case `register` keeps its direct dual-auth address change.
+pub fn get_rotation_delay(env: &Env) -> u64 {
+    env.storage().instance().get(&ROT_DELAY_KEY).unwrap_or(0)
+}
+
+pub fn set_rotation_delay(env: &Env, seconds: u64) {
+    env.storage().instance().set(&ROT_DELAY_KEY, &seconds);
+}
+
+pub fn get_pending_rotation(env: &Env, github_username: &String) -> Option<PendingRotation> {
+    let key = (PENDING_ROT_KEY, github_username.clone());
+    let pending: Option<PendingRotation> = env.storage().persistent().get(&key);
+    if pending.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+    }
+    pending
+}
+
+pub fn set_pending_rotation(env: &Env, github_username: &String, rotation: &PendingRotation) {
+    let key = (PENDING_ROT_KEY, github_username.clone());
+    env.storage().persistent().set(&key, rotation);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+}
+
+pub fn remove_pending_rotation(env: &Env, github_username: &String) {
+    env.storage()
+        .persistent()
+        .remove(&(PENDING_ROT_KEY, github_username.clone()));
+}
+
+pub fn has_pending_rotation(env: &Env, github_username: &String) -> bool {
+    env.storage()
+        .persistent()
+        .has(&(PENDING_ROT_KEY, github_username.clone()))
 }


### PR DESCRIPTION
## Summary

Four assigned issues, one commit each, plus the repair `main` needs before any of them can be built.

| Issue | Change |
|---|---|
| Closes #229 | Monotonic ever-verified counter |
| Closes #230 | Light-client record existence proof |
| Closes #233 | Username rename |
| Closes #234 | Address rotation delay window |

## First: `main` does not compile

Before anything else — `cargo build` on a clean checkout of `main` fails with **35 errors**, and the test targets never built either, so nothing in this crate could be run or verified.

`lib.rs` calls into storage, events, and error APIs that were never merged alongside it. The first commit restores the missing half rather than reverting the caller:

- **`error.rs`** — `InvalidPauseReason`, `AttestationRequired`, `AlreadyReserved`, `NotReserved`, `ReservedListFull`, `UsernameReserved`. Appended at 21–26: the doc table's older numbering collides with the challenge codes already shipped at 17–20, and renumbering those would break every client decoding a raw code.
- **`storage.rs`** — `set/get_pause_reason`, the reserved-list helpers, `compact_chunked_index`. `RESERVED_KEY` and `MAX_RESERVED` were already there; only the functions were missing.
- **`events.rs`** — `EmergencyPausedEvent`, `EmergencyClearedEvent`, `UpgradeAttestedEvent`, `AttestationClearedEvent`.
- **`lib.rs`** — imports for the guardian/emergency/attestation helpers `storage.rs` already defined, plus the `reason_code` field `set_paused` had stopped supplying to its events.
- **`register` now honours the reserved list**, which is what `add_reserved` exists for and what the integration tests assert.

Test-side drift fixed alongside it: `alloc` imports for `format!`/`to_string`, the `pause`/`unpause`/`set_paused` call arity, reading event topics through the xdr body now that `ContractEvent` no longer exposes a `topics` field, and the `from_code` bounds that assumed 20 was the highest code.

## #229 — ever-verified counter

`get_verified_count` tracks who is verified *right now*, so revoking erases the fact that it happened. Adds a monotonic counter bumped by both verify paths and never decremented, exposed as `get_ever_verified_count()` and as a third `ever_verified` field on `Stats`. `get_verified_count` keeps its meaning exactly and the parity invariant is untouched.

The counter records verification *events*, not distinct contributors — a verify/revoke/verify cycle counts twice, which is the figure the Wave reports want, and the ABI says so. Instances upgraded in place have no stored value; rather than reporting zero while `get_verified_count` says otherwise, they fall back to the live count, the tightest lower bound still provable.

## #230 — record proof

`get_record_proof` returns `exists`, the verified bit, when the record was written, the ledger the answer was taken at, and the storage key plus TTL policy needed to read or revive the entry. A missing username is not an error — `exists: false` is the answer. It reads through `get_record`, so an existing record gets the same TTL bump any read gives it.

**`liveUntilLedgerSeq` is deliberately absent.** A contract cannot read its own entry's TTL on-chain — the host exposes `get_ttl` to test utilities only — so any figure returned would be inferred rather than observed, and would drift the moment an extension landed. `STORAGE_RENT.md` documents reading the real value from the ledger entry over RPC, which is what a light client does anyway.

## #233 — rename

Moves a record in one invocation: new key written, old removed together, so no state has the registration under both names or neither. Total count unchanged; the old name is registerable afterwards.

**The verified flag does not travel.** Verification attests a GitHub identity controls the address; the contract cannot confirm the new handle is the same account, and carrying the badge would let a verified throwaway rename onto a valuable handle and arrive pre-trusted. The record is marked pending re-verify instead, and `ever_verified` still remembers the original. This is the policy decision the issue asked to have documented — it's in `ABI.md`.

Guarded against a taken target, a reserved target, an open challenge on either name, a queued rotation on the old name, and cooldown. A case-only rename is a real move and is allowed, since the storage key is the exact string.

## #234 — rotation delay

`register` swapped an address the moment both keys signed. Dual auth proves both were available at that moment, not that the holder meant it.

`request_address_rotation` records the incoming address and emits `RotationRequestedEvent` without moving anything; `execute_address_rotation` applies it once `executable_at` passes; `cancel_address_rotation` lets the holder or admin stop it. Both addresses still `require_auth` on the request — what changes is that the signature buys a *queued* rotation, and the queue is visible while it waits.

Reads keep returning the current address for the whole window (documented in `SECURITY.md`), and `get_pending_rotation` works while paused so a holder can always see what is queued against their name. Executing clears the verified flag and marks pending re-verify.

**The delay defaults to 0**, which disables the flow and leaves `register`'s direct swap exactly as it was — matching the existing `set_cooldown` convention, so no existing behaviour or test changes. Operators handling real payouts should arm it; `SECURITY.md` explains why.

## Tests

28 new tests across the four features: the verify/revoke/verify cycle and stats parity, proofs for present/missing/verified/paused records, rename atomicity and index maintenance and every rejection path, and the rotation window including cancel-then-execute.

```
cargo test    # 222 passed, 6 failed
```

The 6 failures are pre-existing structural drift against `soroban-env-host 26`, not related to anything here: five call two admin-authed entry points inside one `as_contract` frame, which the host now rejects as *"frame is already authorized"*, and one registers 50 users in a single invocation and trips the ledger-entry limit. They need their own change — happy to take that separately.

Docs updated: `ABI.md` (all four), `STORAGE_RENT.md` (#230), `SECURITY.md` (#234).
