### PR TITLE
fix: repair corrupted merge and case-fold usernames with Merkle expor…

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -275,6 +275,16 @@ instead of an opaque auth failure. Use `is_address_zero` to pre-check.
 | First and last character alphanumeric | `alice`, `7` | `-invalid`, `invalid-`, `_leading`, `trailing_` |
 | No consecutive hyphens | `foo-bar-baz` | `foo--bar` |
 
+**Case folding (Issue #194).** GitHub logins are case-insensitive, so every
+persistent storage key built from `github_username` uses its ASCII-lowercased
+canonical form — `Alice`, `ALICE`, and `alice` all resolve to one record.
+Registering a case variant of an existing login updates that record (subject
+to the same `old.stellar_address.require_auth()` protection a same-case
+re-registration requires) rather than creating a second, independent entry.
+Paginated exports and `get_all_registered` report the canonical (lowercased)
+username; domain events report the raw string as submitted. See
+[SECURITY.md § Username Case-Folding](SECURITY.md#5-username-case-folding-issue-194).
+
 Two deliberate choices:
 
 - **Underscores are accepted** even though GitHub itself rejects them. Records
@@ -607,6 +617,51 @@ that budget while still allowing full export via a cursor loop.
 | `next_cursor` | `Option<u32>` | Next zero-based index offset, or `None` when done |
 | `total` | `u32` | Live registration count |
 | `has_more` | `bool` | `true` when another page exists |
+| `merkle_root` | `BytesN<32>` | Merkle root over `records`, in page order (Issue #216) |
+
+### Merkle root over an export page (Issue #216)
+
+`merkle_root` lets a treasury or dashboard prove a specific
+`(github_username, stellar_address, verified)` triple was present in a given
+export page without republishing the whole registry, and lets anyone detect
+an edited off-chain CSV copy of that page (its recomputed root would not
+match the one the contract returned).
+
+**Leaf encoding:**
+
+```text
+leaf = SHA256("trustbridge/export-leaf/v1:" || username_bytes || 0x00 || address_strkey_bytes || verified_byte)
+```
+
+- `username_bytes` — raw bytes of the entry's `github_username` exactly as it
+  appears in `records` (its canonical, lowercased form — see
+  [SECURITY.md § Username Case-Folding](SECURITY.md#5-username-case-folding-issue-194)).
+- `0x00` — fixed separator between the username and address byte strings.
+- `address_strkey_bytes` — raw bytes of `record.stellar_address`'s Stellar
+  strkey (the `G...` string), not its internal binary encoding.
+- `verified_byte` — `0x01` if `record.verified`, else `0x00`. The verified
+  flag is part of the leaf, so a proof attests to verification status at
+  export time, not just membership.
+
+`merkle_leaf_hash(github_username, stellar_address, verified) -> BytesN<32>`
+is a read-only, no-auth contract call exposing this exact computation, so
+off-chain tooling can check its own reimplementation against the on-chain one
+before trusting proofs built from it.
+
+**Tree construction:** a standard bottom-up binary tree,
+`node = SHA256("trustbridge/export-node/v1:" || left || right)`, over the
+page's leaves in page order. When a level has an odd number of nodes, the
+last one is promoted to the next level **unchanged** — never duplicated or
+re-hashed with itself. An empty page's root is 32 zero bytes; a one-record
+page's root is that single leaf's hash unchanged (every level promotes it).
+
+**Scope:** one root per page, not a historic accumulator over the registry's
+lifetime, and no zero-knowledge proof — a verifier needs the leaf's plaintext
+fields and a sibling-hash path, like any standard Merkle proof. See
+`src/merkle.rs` for the reference implementation and
+`tests/merkle_export.rs` for a worked inclusion proof (built independently of
+the contract's own tree code) that verifies for a member and fails for a
+non-member.
 
 ### `get_registered_paginated(cursor: u32, limit: u32) -> Result<ExportPage, ContractError>`
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -192,6 +192,77 @@ If a rightful owner discovers that their GitHub username has been squatted on-ch
 - **How do I reclaim my username?** Open a support ticket / dispute with the TrustBridge administrators. They will remove the squatter's record so you can register your address.
 - **Does the contract verify my GitHub handle automatically?** No. There is **no on-chain verification proof** of GitHub identity at registration time. Verification is entirely off-chain/administrative.
 
+### 5. Username Case-Folding (Issue #194)
+
+GitHub logins are case-insensitive: `Alice` and `alice` are the same GitHub
+account. Before this fix, persistent storage keys were built from the raw
+input string, so registering `alice` and later `Alice` created **two
+independent records** — a squatter could register a case variant of an
+already-registered, already-verified username and siphon future payouts sent
+to that variant, since the contract had no way to know the two strings named
+the same account.
+
+**The fold.** Every persistent key namespaced by a username —
+`(reg, username)`, `(chllng, username)`, `(pend_rev, username)`,
+`(lastact, username)`, `(pendrot, username)`, and the flat/chunked enumeration
+index — is built from `utils::canonicalize_username`, which ASCII-lowercases
+the input (`crate::storage`'s private `canon` helper wraps it at the point
+every key is constructed). The fold is byte-wise and ASCII-only: only
+`b'A'..=b'Z'` bytes are lowered, so it can never change the byte length of an
+already-ASCII-validated username, and it never attempts a Unicode-aware case
+fold. `register` already rejects non-ASCII usernames outright
+(`is_valid_github_username`), so every key this fold ever runs on is pure
+ASCII by construction.
+
+**What this closes.** `Alice`, `ALICE`, and `alice` all resolve to the same
+underlying record: registering any case variant of an existing login updates
+that same record rather than creating a new one, so the existing
+double-auth transfer protection (`old.stellar_address.require_auth()`) applies
+to a case-variant "takeover" attempt exactly as it would to a same-case
+re-registration. Lookups (`get_address`, `has_record`, `remove`, `verify`,
+`revoke_verification`, …) resolve the same way regardless of the casing the
+caller passes in.
+
+**Canonical vs raw.** Storage, the enumeration index, and every paginated
+export (`get_registered_paginated`, `get_public_paginated`,
+`get_all_registered`) all report the **canonical (lowercased)** form of a
+username, since that is what the storage key actually is. Domain events
+(`RegisteredEvent`, `VerifiedEvent`, …) still carry the **raw** string exactly
+as the caller submitted it in that call, for display/audit fidelity —
+indexers that need to correlate an event against export/lookup data should
+fold the event's username themselves before comparing.
+
+**Explicitly out of scope** (tracked as separate work): Unicode case folding
+(`IDNA`/`UTS46`-style normalization) and homoglyph detection (e.g. Cyrillic
+`а` vs ASCII `a`) — see **Unicode Rejection Policy** below, which already
+rejects all non-ASCII bytes outright, so homoglyph substitution cannot reach
+the storage layer in the first place.
+
+**Migration note for a deployment with existing mixed-case keys.** This
+contract has not been deployed to mainnet (see **Audit Status** below), so no
+runtime migration function ships with this fix. If a future deployment ever
+needs to reconcile pre-existing `Alice`/`alice`-style duplicate records, the
+recommended procedure is fully off-chain and uses tooling that already
+exists:
+
+1. Walk the full registry with `get_registered_paginated` (admin-gated) or
+   `get_public_paginated`, paging until `has_more == false`.
+2. Group the exported `(github_username, ContributorRecord)` pairs by
+   `canonicalize_username`-equivalent key (i.e. ASCII-lowercased) off-chain.
+   Any group with more than one entry is a pre-fix duplicate.
+3. For each duplicate group, an operator decides the surviving record —
+   typically the `verified` one, or the one with the earliest
+   `registered_at` if none is verified — following the existing dispute
+   process in **Username Squatting Mitigations** above.
+4. `remove` every losing entry in the group (admin-authorized; `batch_remove`
+   for more than a handful), then confirm via `has_record` that only the
+   canonical key remains before re-verifying the survivor if needed.
+
+Because canonicalization happens inside `set_record`/`get_record` themselves,
+once a deployment is running this fix a fresh registration can never
+recreate a duplicate — the reconciliation above is a one-time cleanup for
+data written before the fix, not an ongoing concern.
+
 ---
 
 ## Input Validation

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,17 +15,36 @@ use soroban_sdk::contracterror;
 /// | 5 | `AlreadyVerified` | `verify` |
 /// | 6 | `NotVerified` | `revoke_verification` |
 /// | 7 | `Paused` | any state-mutating call while paused |
-/// | 8 | `CooldownActive` | `upgrade` |
+/// | 8 | `CooldownActive` | `upgrade`, `register` |
 /// | 9 | `InvalidVersion` | `migrate` |
 /// | 10 | `InvalidRole` | `set_role` |
 /// | 11 | `InvalidUsername` | `register` |
+/// | 12 | `AttestationExpired` | `attest_upgrade`, `upgrade` |
+/// | 13 | `UnattestedWasm` | `upgrade` |
+/// | 14 | `InvalidBatchSize` | `batch_verify`, `batch_remove` |
 /// | 15 | `InvalidReasonCode` | `revoke_verification` |
 /// | 16 | `ZeroAddress` | `register` |
-/// | 17 | `InvalidPauseReason` | `pause`, `unpause`, `set_paused` |
-/// | 18 | `AlreadyReserved` | `add_reserved` |
-/// | 19 | `NotReserved` | `remove_reserved` |
-/// | 20 | `UsernameReserved` | `register` |
-/// | 21 | `ReservedListFull` | `add_reserved` |
+/// | 17 | `ChallengeAlreadyActive` | `start_challenge` |
+/// | 18 | `NoChallengeActive` | `cancel_challenge`, `complete_challenge` |
+/// | 19 | `ChallengeNotResolvable` | `complete_challenge` |
+/// | 20 | `ChallengeActive` | `register`, `rename` |
+/// | 21 | `InvalidPauseReason` | `pause`, `unpause`, `set_paused` |
+/// | 22 | `AlreadyReserved` | `add_reserved` |
+/// | 23 | `NotReserved` | `remove_reserved` |
+/// | 24 | `UsernameReserved` | `register`, `rename` |
+/// | 25 | `ReservedListFull` | `add_reserved` |
+/// | 26 | `AdminTransferPending` | `propose_admin_transfer`, `execute_admin_transfer` |
+/// | 27 | `AdminTransferDelayActive` | `execute_admin_transfer` |
+/// | 28 | `NoPendingAdminTransfer` | `execute_admin_transfer` |
+/// | 29 | `AttestationRequired` | `upgrade` |
+/// | 30 | `NetworkMismatch` | any gated call on state restored to a different network |
+/// | 31 | `FallbackListFull` | `register`, `register_sponsored` |
+/// | 32 | `RotationRequired` | `register` |
+/// | 33 | `RotationPending` | `request_address_rotation`, `rename` |
+/// | 34 | `NoRotationPending` | `execute_address_rotation`, `cancel_address_rotation` |
+/// | 35 | `RotationNotReady` | `execute_address_rotation` |
+/// | 36 | `UsernameTaken` | `rename` |
+/// | 37 | `InvalidCursor` | `get_registered_paginated`, `get_public_paginated` |
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -40,8 +59,6 @@ pub enum ContractError {
     NotRegistered = 4,
     /// `verify` was called on a username that is already verified.
     AlreadyVerified = 5,
-    InvalidEntityType = 6,
-    OrgNameRequired = 7,
     /// `revoke_verification` was called on a username that is not verified.
     NotVerified = 6,
     /// A state-mutating function was called while the contract is paused.
@@ -96,6 +113,32 @@ pub enum ContractError {
     NoPendingAdminTransfer = 28,
     /// `upgrade` was called without a required attestation (attestation-required mode is on).
     AttestationRequired = 29,
+    /// Instance state was initialized on a different network than the one
+    /// currently executing (Issue #231).
+    NetworkMismatch = 30,
+    /// `register` or `register_sponsored` was called with more fallback
+    /// addresses than `storage::MAX_FALLBACK_ADDRESSES` allows.
+    FallbackListFull = 31,
+    /// `register` attempted a direct address change while an address
+    /// rotation delay is configured (Issue #234); use
+    /// `request_address_rotation` instead.
+    RotationRequired = 32,
+    /// `request_address_rotation` was called while a rotation is already
+    /// pending for this username (Issue #234).
+    RotationPending = 33,
+    /// `execute_address_rotation` or `cancel_address_rotation` was called
+    /// with no pending rotation for this username (Issue #234).
+    NoRotationPending = 34,
+    /// `execute_address_rotation` was called before the rotation's delay has
+    /// elapsed (Issue #234).
+    RotationNotReady = 35,
+    /// `rename` was called with a `new_username` that is already registered.
+    UsernameTaken = 36,
+    /// `get_registered_paginated` / `get_public_paginated` was called with a
+    /// cursor that fails to decode: its embedded index generation no longer
+    /// matches (a username was removed since the cursor was issued), or its
+    /// embedded offset is past the current registry size (Issue #215).
+    InvalidCursor = 37,
 }
 
 impl ContractError {
@@ -140,6 +183,14 @@ impl ContractError {
             27 => Some(ContractError::AdminTransferDelayActive),
             28 => Some(ContractError::NoPendingAdminTransfer),
             29 => Some(ContractError::AttestationRequired),
+            30 => Some(ContractError::NetworkMismatch),
+            31 => Some(ContractError::FallbackListFull),
+            32 => Some(ContractError::RotationRequired),
+            33 => Some(ContractError::RotationPending),
+            34 => Some(ContractError::NoRotationPending),
+            35 => Some(ContractError::RotationNotReady),
+            36 => Some(ContractError::UsernameTaken),
+            37 => Some(ContractError::InvalidCursor),
             _ => None,
         }
     }

--- a/src/error_context.rs
+++ b/src/error_context.rs
@@ -120,6 +120,13 @@ pub fn classify_error(error: ContractError) -> ErrorCategory {
         ContractError::NoRotationPending => ErrorCategory::Validation,
         ContractError::RotationNotReady => ErrorCategory::Transient,
         ContractError::UsernameTaken => ErrorCategory::Validation,
+        ContractError::AdminTransferPending => ErrorCategory::Validation,
+        ContractError::AdminTransferDelayActive => ErrorCategory::Transient,
+        ContractError::NoPendingAdminTransfer => ErrorCategory::Validation,
+        ContractError::FallbackListFull => ErrorCategory::Validation,
+        // Transient: restarting pagination from `cursor = None` after a
+        // removal invalidates the old cursor is expected to succeed.
+        ContractError::InvalidCursor => ErrorCategory::Transient,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod domain;
 mod error;
 mod error_context;
 mod events;
+mod merkle;
 mod registry_read_stub;
 mod storage;
 mod utils;
@@ -24,8 +25,6 @@ pub use audit::{AuditConfig, AuditEventType, AuditLogEntry, AuditStats};
 pub use batch::{BatchConfig, BatchOperationResult, BatchSummary, MAX_WRITE_BATCH};
 pub use domain::{EventDomain, EVENT_DOMAIN_VERSION};
 pub use error::ContractError;
-pub use events::{RegisteredEvent, RemovedEvent, VerifiedEvent};
-pub use storage::{ContributorRecord, EntityType, Stats};
 pub use events::{
     AttestationClearedEvent, ChallengeCancelledEvent, ChallengeCompletedEvent, RenamedEvent,
     RotationCancelledEvent, RotationExecutedEvent, RotationRequestedEvent,
@@ -34,41 +33,37 @@ pub use events::{
     UpgradeAttestedEvent, UpgradedEvent, VerificationRevokedEvent, VerifiedEvent,
 };
 pub use storage::{
-    ChallengeRecord, ContributorRecord, ExportPage, HealthSnapshot, Role, Stats,
-    VerificationConfig, WasmAttestation, WasmProvenance, PauseReason,
+    ChallengeRecord, ContributorRecord, EntityType, ExportPage, HealthSnapshot,
+    PendingRotation, RecordProof, Role, RoleHolder, Stats, VerificationConfig, WasmAttestation,
+    WasmProvenance, PauseReason, MAX_FALLBACK_ADDRESSES,
 };
 pub use version::Version;
 
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Symbol, Vec};
 
 use crate::storage::{
-    add_to_index, add_to_org_index, add_to_team_index, get_admin, get_count, get_index,
-    get_record, get_stats as read_stats, get_verified_count, remove_from_index,
-    remove_from_org_index, remove_from_team_index, remove_record, require_initialized, set_count,
-    set_record, set_verified_count, team_key, ADMIN_KEY,
-    add_to_index, clear_pending_reverify, get_admin, get_audit_logs, get_audit_stats,
-    get_challenge, get_cooldown as storage_get_cooldown, get_count, get_index, get_last_upgrade,
-    get_record, get_registered_paginated_internal, get_role as storage_get_role,
-    bump_ever_verified_count, get_emergency_pause, get_emergency_pause_ts,
+    add_to_index, bump_ever_verified_count, build_record_proof, clear_pending_reverify,
+    get_admin, get_audit_logs, get_audit_stats, get_challenge, get_count,
+    get_cooldown as storage_get_cooldown, get_emergency_pause, get_emergency_pause_ts,
     get_ever_verified_count as storage_get_ever_verified_count, get_guardian as storage_get_guardian,
-    get_stats as read_stats, get_verification_config, get_verified_count as storage_get_verified_count,
-    is_attestation_required, is_guardian, remove_guardian as storage_remove_guardian,
-    set_emergency_pause, set_emergency_pause_ts, set_guardian_address,
+    get_index, get_last_upgrade, get_network_id as storage_get_network_id,
+    get_pending_rotation as storage_get_pending_rotation, get_record,
+    get_registered_paginated_internal, get_role as storage_get_role,
+    get_role_holder_count as storage_get_role_holder_count, get_role_holders_internal,
+    get_rotation_delay as storage_get_rotation_delay, get_stats as read_stats,
+    get_verification_config, get_verified_count as storage_get_verified_count,
     get_version as storage_get_version, get_wasm_attestation, get_wasm_provenance, has_challenge,
-    build_record_proof, get_pending_rotation as storage_get_pending_rotation,
-    get_rotation_delay as storage_get_rotation_delay, has_pending_rotation, has_record,
-    is_admin_caller, is_in_cooldown, is_paused as storage_is_paused, push_audit_entry,
-    remove_pending_rotation, set_pending_rotation, set_rotation_delay as storage_set_rotation_delay,
-    remove_challenge, remove_from_index, remove_record, remove_role as storage_remove_role,
-    remove_wasm_attestation, require_initialized, require_not_paused,
-    run_migration_steps, set_challenge, set_cooldown as storage_set_cooldown, set_count,
-    set_last_action, set_last_upgrade, set_paused as set_paused_state, set_pending_reverify,
-    set_ever_verified_count, set_record, set_role as storage_set_role, set_verified_count,
-    set_version,
-    set_wasm_attestation, set_wasm_provenance, DEFAULT_CHALLENGE_DELAY_SECS,
-    ADMIN_KEY,
-    get_guardian as storage_get_guardian,
-    remove_guardian as storage_remove_guardian,
+    has_pending_rotation, has_record, is_admin_caller, is_attestation_required, is_guardian,
+    is_in_cooldown, is_paused as storage_is_paused, push_audit_entry, remove_challenge,
+    remove_from_index, remove_guardian as storage_remove_guardian, remove_pending_rotation,
+    remove_record, remove_role as storage_remove_role, remove_wasm_attestation,
+    require_initialized, require_not_paused, run_migration_steps, set_challenge,
+    set_cooldown as storage_set_cooldown, set_count, set_emergency_pause, set_emergency_pause_ts,
+    set_ever_verified_count, set_guardian_address, set_last_action, set_last_upgrade,
+    set_network_id, set_paused as set_paused_state, set_pending_reverify, set_pending_rotation,
+    set_record, set_role as storage_set_role, set_rotation_delay as storage_set_rotation_delay,
+    set_verified_count, set_version, set_wasm_attestation, set_wasm_provenance,
+    DEFAULT_CHALLENGE_DELAY_SECS, ADMIN_KEY,
 };
 
 use crate::utils::{
@@ -172,17 +167,6 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Registers or updates a GitHub username → Stellar address mapping.
-    /// The caller must authenticate as `stellar_address`.
-    /// `entity_type`: 0 = Personal, 1 = Org, 2 = Team.
-    /// For teams, `org_name` must be provided.
-    pub fn register(
-        env: Env,
-        github_username: String,
-        stellar_address: Address,
-        entity_type: u32,
-        org_name: Option<String>,
-    ) -> Result<(), ContractError> {
     /// Pauses all state-mutating contract functions. Admin-only.
     ///
     /// While paused, any call to `register`, `remove`, `verify`, `revoke_verification`,
@@ -214,17 +198,6 @@ impl TrustBridgeContract {
         }
         let reason = PauseReason::from_code(reason_code).unwrap_or(PauseReason::Other);
 
-        let etype = match entity_type {
-            0 => EntityType::Personal,
-            1 => EntityType::Org,
-            2 => EntityType::Team,
-            _ => return Err(ContractError::InvalidEntityType),
-        };
-
-        if etype == EntityType::Team && org_name.is_none() {
-            return Err(ContractError::OrgNameRequired);
-        }
-
         set_paused_state(&env, true);
         crate::storage::set_pause_reason(&env, reason);
         let timestamp = env.ledger().timestamp();
@@ -236,39 +209,6 @@ impl TrustBridgeContract {
         }
         .publish(&env);
 
-        let record = ContributorRecord {
-            stellar_address: stellar_address.clone(),
-            registered_at: timestamp,
-            verified: existing
-                .as_ref()
-                .map(|r| r.stellar_address == stellar_address && r.verified)
-                .unwrap_or(false),
-            entity_type: etype,
-            org_name: org_name.clone(),
-        };
-
-        if existing.is_none() {
-            set_count(&env, get_count(&env).saturating_add(1));
-            add_to_index(&env, &github_username);
-            match etype {
-                EntityType::Org => {
-                    if let Some(ref oname) = org_name {
-                        add_to_org_index(&env, oname);
-                    }
-                }
-                EntityType::Team => {
-                    if let Some(ref oname) = org_name {
-                        let tk = team_key(&env, oname, &github_username);
-                        add_to_team_index(&env, &tk);
-                    }
-                }
-                _ => {}
-            }
-        } else if let Some(old) = existing {
-            if old.stellar_address != stellar_address && old.verified {
-                set_verified_count(&env, get_verified_count(&env).saturating_sub(1));
-            }
-        }
         push_audit_entry(
             &env,
             AuditLogEntry::new(AuditEventType::AdminAction, timestamp, Some(admin)),
@@ -423,23 +363,6 @@ impl TrustBridgeContract {
             return Err(ContractError::NotAuthorized);
         }
 
-        match record.entity_type {
-            EntityType::Org => {
-                if let Some(ref oname) = record.org_name {
-                    remove_from_org_index(&env, oname);
-                }
-            }
-            EntityType::Team => {
-                if let Some(ref oname) = record.org_name {
-                    let tk = team_key(&env, oname, &github_username);
-                    remove_from_team_index(&env, &tk);
-                }
-            }
-            _ => {}
-        }
-
-        if record.verified {
-            set_verified_count(&env, get_verified_count(&env).saturating_sub(1));
         // Idempotent: no-op if already emergency-paused.
         if get_emergency_pause(&env) {
             return Ok(());
@@ -722,68 +645,6 @@ impl TrustBridgeContract {
         storage_get_cooldown(&env)
     }
 
-    fn register_personal(env: &Env, contract_id: &soroban_sdk::Address, name: &str, addr: &Address) {
-        TrustBridgeContract::register(
-            env.clone(),
-            username(env, name),
-            addr.clone(),
-            0,
-            None,
-        )
-        .unwrap();
-    }
-
-    fn register_org(
-        env: &Env,
-        contract_id: &soroban_sdk::Address,
-        name: &str,
-        addr: &Address,
-        org: &str,
-    ) {
-        TrustBridgeContract::register(
-            env.clone(),
-            username(env, name),
-            addr.clone(),
-            1,
-            Some(username(env, org)),
-        )
-        .unwrap();
-    }
-
-    fn register_team(
-        env: &Env,
-        contract_id: &soroban_sdk::Address,
-        name: &str,
-        addr: &Address,
-        org: &str,
-    ) {
-        TrustBridgeContract::register(
-            env.clone(),
-            username(env, name),
-            addr.clone(),
-            2,
-            Some(username(env, org)),
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn test_register_and_get_address_roundtrip() {
-        let env = Env::default();
-        let (_admin, user, _other, contract_id) = setup(&env);
-
-        env.mock_all_auths();
-
-        env.as_contract(&contract_id, || {
-            register_personal(&env, &contract_id, "octocat", &user);
-
-            let record =
-                TrustBridgeContract::get_address(env.clone(), username(&env, "octocat")).unwrap();
-            assert_eq!(record.stellar_address, user);
-            assert!(!record.verified);
-            assert_eq!(record.entity_type, EntityType::Personal);
-        });
-    }
     /// Returns the stored contract schema version as `(major, minor, patch)`.
     ///
     /// Falls back to the compile-time [`CONTRACT_VERSION`] constant on instances
@@ -837,8 +698,6 @@ impl TrustBridgeContract {
             },
         );
 
-        env.as_contract(&contract_id, || {
-            register_personal(&env, &contract_id, "octocat", &user);
         UpgradeAttestedEvent {
             wasm_hash,
             expires_at,
@@ -864,8 +723,6 @@ impl TrustBridgeContract {
         let admin = get_admin(&env)?;
         admin.require_auth();
 
-        env.as_contract(&contract_id, || {
-            register_personal(&env, &contract_id, "octocat", &user);
         if let Some(attestation) = get_wasm_attestation(&env) {
             remove_wasm_attestation(&env);
             
@@ -1213,6 +1070,30 @@ impl TrustBridgeContract {
         eq_ignore_ascii_case(&a, &b)
     }
 
+    /// Computes the Merkle leaf hash for one `(github_username,
+    /// stellar_address, verified)` export entry (Issue #216).
+    ///
+    /// Every `ExportPage` returned by `get_registered_paginated` /
+    /// `get_public_paginated` carries a `merkle_root` over its `records` in
+    /// page order. This function exposes the exact leaf encoding that root
+    /// is built from, so off-chain tooling (a treasury, a dashboard) can
+    /// verify its own reimplementation matches before trusting inclusion
+    /// proofs it builds from an exported page. See `crate::merkle` for the
+    /// full leaf/node encoding and the odd-node promotion rule used above
+    /// the leaf layer.
+    ///
+    /// Read-only; no auth required — this is a pure function of its inputs
+    /// and reads no contract state.
+    #[must_use]
+    pub fn merkle_leaf_hash(
+        env: Env,
+        github_username: String,
+        stellar_address: Address,
+        verified: bool,
+    ) -> BytesN<32> {
+        crate::merkle::leaf_hash(&env, &github_username, &stellar_address, verified)
+    }
+
     /// Registers or updates a GitHub username → Stellar address mapping.
     ///
     /// The caller must authenticate as `stellar_address`. The username must be
@@ -1306,6 +1187,14 @@ impl TrustBridgeContract {
             }
         }
 
+        // Defaults to `stellar_address` for a first-time registration; a
+        // re-registration preserves whatever payout address was already on
+        // file rather than resetting it back to identity every time.
+        let resolved_payout = existing
+            .as_ref()
+            .map(|r| r.payout_address.clone())
+            .unwrap_or_else(|| stellar_address.clone());
+
         let record = ContributorRecord {
             stellar_address: stellar_address.clone(),
             payout_address: resolved_payout,
@@ -1393,8 +1282,14 @@ impl TrustBridgeContract {
             return Err(ContractError::CooldownActive);
         }
 
+        let resolved_payout = existing
+            .as_ref()
+            .map(|r| r.payout_address.clone())
+            .unwrap_or_else(|| stellar_address.clone());
+
         let record = ContributorRecord {
             stellar_address: stellar_address.clone(),
+            payout_address: resolved_payout,
             registered_at: timestamp as u32,
             verified: existing
                 .as_ref()
@@ -1780,14 +1675,26 @@ impl TrustBridgeContract {
         Ok(result)
     }
 
-    /// Exports a page of registry records using a cursor. Admin-only.
+    /// Exports a page of registry records using an opaque cursor. Admin-only.
     ///
-    /// `cursor` is the zero-based record index to start from; `limit` is the maximum
-    /// number of records to return (capped at `MAX_PAGE_LIMIT`). Returns an [`ExportPage`]
-    /// containing the records and a `next_cursor` for subsequent calls.
+    /// `cursor` is `None` to start from the beginning, or the exact
+    /// `next_cursor` value a previous call returned to continue — it is an
+    /// **opaque token** (Issue #215): never construct or decode one
+    /// yourself, and never persist one across a contract upgrade that
+    /// changes this encoding. `limit` is the maximum number of records to
+    /// return (capped at `MAX_PAGE_LIMIT`). Returns an [`ExportPage`]
+    /// containing the records, a `next_cursor` for the following call, and a
+    /// `merkle_root` over the page (Issue #216).
     ///
     /// Use this instead of `get_all_registered` for large registries — it avoids
     /// materializing the full index in one transaction.
+    ///
+    /// A cursor issued before a username was removed from the registry no
+    /// longer decodes: continuing to walk the registry with a stale offset
+    /// after a middle entry is removed would silently skip or duplicate
+    /// records for a consumer that isn't reconciling by upsert, so this
+    /// fails loudly instead. See `docs/DASHBOARD_SYNC.md` for the recommended
+    /// restart-from-`None` recovery.
     ///
     /// # Auth
     ///
@@ -1797,9 +1704,11 @@ impl TrustBridgeContract {
     ///
     /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
     /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
+    /// - [`ContractError::InvalidCursor`] if `cursor` is `Some` and no longer
+    ///   decodes against the current registry state.
     pub fn get_registered_paginated(
         env: Env,
-        cursor: u32,
+        cursor: Option<BytesN<8>>,
         limit: u32,
     ) -> Result<ExportPage, ContractError> {
         require_initialized(&env)?;
@@ -1811,9 +1720,15 @@ impl TrustBridgeContract {
 
     /// Public paginated read for indexers and dashboard consumers.
     ///
-    /// Same cursor/limit semantics as `get_registered_paginated` but requires no auth,
-    /// making it suitable for public dashboard sync and off-chain indexers. Returns an
-    /// [`ExportPage`] with records and a `next_cursor`.
+    /// Same opaque-cursor/limit semantics as `get_registered_paginated`
+    /// (Issue #215) but requires no auth, making it suitable for public
+    /// dashboard sync and off-chain indexers. Returns an [`ExportPage`] with
+    /// records, a `next_cursor`, and a `merkle_root` over the page.
+    ///
+    /// A cursor issued by `get_registered_paginated` may be passed here and
+    /// vice versa — both read the same underlying index and generation
+    /// counter, so cursors are interchangeable between the admin and public
+    /// variants.
     ///
     /// Blocked by the pause state — returns [`ContractError::Paused`] while the circuit
     /// breaker is active.
@@ -1822,9 +1737,11 @@ impl TrustBridgeContract {
     ///
     /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
     /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::InvalidCursor`] if `cursor` is `Some` and no longer
+    ///   decodes against the current registry state.
     pub fn get_public_paginated(
         env: Env,
-        cursor: u32,
+        cursor: Option<BytesN<8>>,
         limit: u32,
     ) -> Result<ExportPage, ContractError> {
         require_initialized(&env)?;
@@ -1876,6 +1793,7 @@ impl TrustBridgeContract {
                 admin: admin.clone(),
                 timestamp,
                 reason_code,
+                domain: event_domain(&env),
             }
             .publish(&env);
         } else {
@@ -1883,6 +1801,7 @@ impl TrustBridgeContract {
                 admin: admin.clone(),
                 timestamp,
                 reason_code,
+                domain: event_domain(&env),
             }
             .publish(&env);
         }
@@ -2276,8 +2195,10 @@ impl TrustBridgeContract {
 
         let moved = ContributorRecord {
             stellar_address: record.stellar_address.clone(),
+            payout_address: record.payout_address.clone(),
             registered_at: timestamp as u32,
             verified: false,
+            is_bot: record.is_bot,
         };
 
         // Write the new key and drop the old one in the same invocation: the
@@ -3015,6 +2936,13 @@ mod test {
 
     fn username(env: &Env, name: &str) -> String {
         String::from_str(env, name)
+    }
+
+    /// Registers `name` to `addr` with no fallback addresses. Must be called
+    /// from inside an `env.as_contract(&contract_id, || { .. })` closure.
+    fn register_personal(env: &Env, _contract_id: &Address, name: &str, addr: &Address) {
+        TrustBridgeContract::register(env.clone(), username(env, name), addr.clone(), Vec::new(env))
+            .unwrap();
     }
 
     /// Asserts `get_verified_count()` and `get_stats().verified` agree on

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -1,0 +1,264 @@
+//! Merkle root over an export page, for off-chain inclusion proofs (Issue #216).
+//!
+//! Treasuries and dashboards need to prove a specific `(username, record)`
+//! pair was present in a given `get_registered_paginated` /
+//! `get_public_paginated` page without republishing or re-fetching the whole
+//! registry. This module defines the leaf encoding and the binary tree
+//! construction behind `ExportPage::merkle_root`, so off-chain tooling can
+//! independently rebuild the same tree — and a Merkle proof against it —
+//! from the page's own `records`, in any language, without depending on this
+//! crate.
+//!
+//! ## Leaf encoding
+//!
+//! For a page entry `(github_username, record)`:
+//!
+//! ```text
+//! leaf = SHA256(LEAF_DOMAIN || username_bytes || 0x00 || address_strkey_bytes || verified_byte)
+//! ```
+//!
+//! - `username_bytes` — the raw bytes of `github_username` exactly as it
+//!   appears in the page (its canonical, lowercased storage-key form — see
+//!   Issue #194 — since that is what a page actually contains).
+//! - `0x00` — a fixed separator byte between the username and address
+//!   fields, so `("ab", "c...")` cannot be confused with `("a", "bc...")`
+//!   when the two byte strings are concatenated.
+//! - `address_strkey_bytes` — the raw bytes of `record.stellar_address`'s
+//!   Stellar strkey (`Address::to_string()`), not its internal binary
+//!   encoding, since the strkey is what's trivial for off-chain tooling in
+//!   any language to reproduce byte-for-byte from an exported record.
+//! - `verified_byte` — `0x01` if `record.verified`, else `0x00`. Carrying the
+//!   verified flag in the leaf means a proof attests to verification status
+//!   at export time, not just membership.
+//!
+//! `merkle_leaf_hash` is exposed as a read-only contract entry point so
+//! off-chain tooling can check its own reimplementation against the
+//! on-chain one for a single entry before trusting proofs built from it.
+//!
+//! ## Tree construction
+//!
+//! A standard bottom-up binary tree over the page's leaves, in page order:
+//!
+//! ```text
+//! node = SHA256(NODE_DOMAIN || left || right)
+//! ```
+//!
+//! When a level has an odd number of nodes, the last (rightmost) node is
+//! carried up to the next level **unchanged** — it is not duplicated or
+//! re-hashed with itself. This avoids the well-known second-preimage
+//! weakness of "duplicate the odd node" trees and keeps proof reconstruction
+//! simple: a promoted node's proof step is "this hash, no sibling, same
+//! side."
+//!
+//! An empty page's root is [`empty_root`], the all-zero `BytesN<32>` — a
+//! sentinel no real leaf or node hash can produce (finding a SHA-256 preimage
+//! of all zeros is computationally infeasible), and distinguishable at a
+//! glance from every real root. A single-leaf page's root **is** that leaf's
+//! hash: with one node at every level, each level "combines" by promotion
+//! until only the leaf remains.
+//!
+//! ## Domain separation
+//!
+//! Leaf and node hashes are prefixed with distinct, versioned ASCII domain
+//! strings (`LEAF_DOMAIN`, `NODE_DOMAIN`) so a leaf hash can never be
+//! mistaken for a node hash — or for a hash from an unrelated protocol —
+//! even though both are 32-byte SHA-256 outputs. Changing either string
+//! changes the tree shape and must ship as a new version suffix (`v2`, ...),
+//! never an in-place edit to `v1`.
+//!
+//! ## Scope
+//!
+//! This computes a root over a single page, not a historic accumulator over
+//! the whole registry's lifetime, and there is no zero-knowledge proof of
+//! membership — a verifier needs the leaf's plaintext fields (username,
+//! address, verified flag) and a sibling-hash path, exactly like any
+//! standard Merkle proof.
+
+use soroban_sdk::{Bytes, BytesN, Env, String, Vec};
+
+use crate::storage::ContributorRecord;
+
+const LEAF_DOMAIN: &[u8] = b"trustbridge/export-leaf/v1:";
+const NODE_DOMAIN: &[u8] = b"trustbridge/export-node/v1:";
+
+/// Separator byte between the username and address fields of a leaf, so
+/// `(a, bc)` and `(ab, c)` cannot hash to the same leaf.
+const FIELD_SEPARATOR: u8 = 0x00;
+
+/// The Merkle root of an empty page: the all-zero sentinel no real hash can
+/// produce.
+#[must_use]
+pub fn empty_root(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[0u8; 32])
+}
+
+/// Computes the leaf hash for one export entry. See the module docs for the
+/// exact byte layout.
+#[must_use]
+pub fn leaf_hash(
+    env: &Env,
+    username: &String,
+    stellar_address: &soroban_sdk::Address,
+    verified: bool,
+) -> BytesN<32> {
+    let mut buf = Bytes::from_slice(env, LEAF_DOMAIN);
+    buf.append(&username.to_bytes());
+    buf.push_back(FIELD_SEPARATOR);
+    buf.append(&stellar_address.to_string().to_bytes());
+    buf.push_back(u8::from(verified));
+    env.crypto().sha256(&buf).to_bytes()
+}
+
+fn node_hash(env: &Env, left: &BytesN<32>, right: &BytesN<32>) -> BytesN<32> {
+    let mut buf = Bytes::from_slice(env, NODE_DOMAIN);
+    buf.append(&Bytes::from(left.clone()));
+    buf.append(&Bytes::from(right.clone()));
+    env.crypto().sha256(&buf).to_bytes()
+}
+
+/// Computes the Merkle root over `leaves`, in order.
+///
+/// `leaves.len() == 0` returns [`empty_root`]. `leaves.len() == 1` returns
+/// that single leaf unchanged. See the module docs for the odd-node
+/// promotion rule applied at every level above the leaves.
+#[must_use]
+pub fn root_of(env: &Env, leaves: &Vec<BytesN<32>>) -> BytesN<32> {
+    if leaves.is_empty() {
+        return empty_root(env);
+    }
+
+    let mut level: Vec<BytesN<32>> = leaves.clone();
+    while level.len() > 1 {
+        let mut next: Vec<BytesN<32>> = Vec::new(env);
+        let mut i: u32 = 0;
+        while i + 1 < level.len() {
+            let left = level.get(i).unwrap();
+            let right = level.get(i + 1).unwrap();
+            next.push_back(node_hash(env, &left, &right));
+            i += 2;
+        }
+        if i < level.len() {
+            // Odd node out: promote unchanged rather than duplicate-hash it.
+            next.push_back(level.get(i).unwrap());
+        }
+        level = next;
+    }
+
+    level.get(0).unwrap()
+}
+
+/// Computes the Merkle root over one export page's records, in page order.
+#[must_use]
+pub fn root_of_records(env: &Env, records: &Vec<(String, ContributorRecord)>) -> BytesN<32> {
+    let mut leaves: Vec<BytesN<32>> = Vec::new(env);
+    for i in 0..records.len() {
+        let (username, record) = records.get(i).unwrap();
+        leaves.push_back(leaf_hash(env, &username, &record.stellar_address, record.verified));
+    }
+    root_of(env, &leaves)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::Address;
+
+    fn rec(env: &Env, addr: &Address, verified: bool) -> ContributorRecord {
+        ContributorRecord {
+            stellar_address: addr.clone(),
+            payout_address: addr.clone(),
+            registered_at: 0,
+            verified,
+            is_bot: false,
+        }
+    }
+
+    #[test]
+    fn test_empty_page_root_is_all_zero() {
+        let env = Env::default();
+        let leaves: Vec<BytesN<32>> = Vec::new(&env);
+        assert_eq!(root_of(&env, &leaves), empty_root(&env));
+    }
+
+    #[test]
+    fn test_single_leaf_page_root_equals_the_leaf() {
+        let env = Env::default();
+        let addr = Address::generate(&env);
+        let username = String::from_str(&env, "octocat");
+        let leaf = leaf_hash(&env, &username, &addr, false);
+
+        let mut leaves: Vec<BytesN<32>> = Vec::new(&env);
+        leaves.push_back(leaf.clone());
+
+        assert_eq!(root_of(&env, &leaves), leaf);
+    }
+
+    #[test]
+    fn test_root_changes_when_verified_flag_changes() {
+        let env = Env::default();
+        let addr = Address::generate(&env);
+        let username = String::from_str(&env, "octocat");
+
+        let leaf_unverified = leaf_hash(&env, &username, &addr, false);
+        let leaf_verified = leaf_hash(&env, &username, &addr, true);
+
+        assert_ne!(leaf_unverified, leaf_verified);
+    }
+
+    #[test]
+    fn test_root_of_records_matches_manual_leaf_hashes() {
+        let env = Env::default();
+        let a1 = Address::generate(&env);
+        let a2 = Address::generate(&env);
+        let u1 = String::from_str(&env, "alice");
+        let u2 = String::from_str(&env, "bob");
+
+        let mut records: Vec<(String, ContributorRecord)> = Vec::new(&env);
+        records.push_back((u1.clone(), rec(&env, &a1, true)));
+        records.push_back((u2.clone(), rec(&env, &a2, false)));
+
+        let mut leaves: Vec<BytesN<32>> = Vec::new(&env);
+        leaves.push_back(leaf_hash(&env, &u1, &a1, true));
+        leaves.push_back(leaf_hash(&env, &u2, &a2, false));
+
+        assert_eq!(root_of_records(&env, &records), root_of(&env, &leaves));
+    }
+
+    #[test]
+    fn test_odd_leaf_count_promotes_the_last_leaf_unchanged() {
+        let env = Env::default();
+        let addr = Address::generate(&env);
+        let l0 = leaf_hash(&env, &String::from_str(&env, "a"), &addr, false);
+        let l1 = leaf_hash(&env, &String::from_str(&env, "b"), &addr, false);
+        let l2 = leaf_hash(&env, &String::from_str(&env, "c"), &addr, false);
+
+        let mut leaves: Vec<BytesN<32>> = Vec::new(&env);
+        leaves.push_back(l0.clone());
+        leaves.push_back(l1.clone());
+        leaves.push_back(l2.clone());
+
+        // Level 1: [node_hash(l0, l1), l2 promoted unchanged]
+        // Root: node_hash(node_hash(l0, l1), l2)
+        let expected = node_hash(&env, &node_hash(&env, &l0, &l1), &l2);
+        assert_eq!(root_of(&env, &leaves), expected);
+    }
+
+    #[test]
+    fn test_leaf_order_matters() {
+        let env = Env::default();
+        let addr = Address::generate(&env);
+        let l0 = leaf_hash(&env, &String::from_str(&env, "a"), &addr, false);
+        let l1 = leaf_hash(&env, &String::from_str(&env, "b"), &addr, false);
+
+        let mut forward: Vec<BytesN<32>> = Vec::new(&env);
+        forward.push_back(l0.clone());
+        forward.push_back(l1.clone());
+
+        let mut reversed: Vec<BytesN<32>> = Vec::new(&env);
+        reversed.push_back(l1);
+        reversed.push_back(l0);
+
+        assert_ne!(root_of(&env, &forward), root_of(&env, &reversed));
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -6,6 +6,17 @@ use soroban_sdk::{symbol_short, Address, BytesN, Env, String, Symbol, Vec};
 
 use crate::ContractError;
 
+/// Canonical storage key for a GitHub username (Issue #194).
+///
+/// Every persistent key namespaced by a username — `reg`, `chllng`,
+/// `pend_rev`, `lastact`, `pendrot` — is built from this canonical form, so
+/// `Alice`, `ALICE`, and `alice` all resolve to the same underlying entry. See
+/// `docs/SECURITY.md#username-case-folding` for the fold rule (ASCII lower)
+/// and the squatting scenario this closes.
+fn canon(env: &Env, username: &String) -> String {
+    crate::utils::canonicalize_username(env, username)
+}
+
 pub const VER_CFG_KEY: Symbol = symbol_short!("vrfy_cfg");
 
 // ── Storage keys ────────────────────────────────────────────────────────────
@@ -78,6 +89,12 @@ pub const MAX_ROLE_PAGE_LIMIT: u32 = 50;
 /// Key prefix for chunked username index entries.
 pub const CHUNK_KEY: Symbol = symbol_short!("chunk");
 pub const CHUNK_CNT_KEY: Symbol = symbol_short!("chkcnt");
+/// Monotonic counter bumped every time the flat index's existing positions
+/// shift — i.e. on every removal (Issue #215). An opaque pagination cursor
+/// embeds the generation at issue time; `decode_cursor` rejects a cursor
+/// whose generation no longer matches, rather than silently resuming at a
+/// drifted offset.
+pub const INDEX_GEN_KEY: Symbol = symbol_short!("idx_gen");
 pub const LAST_ACT_KEY: Symbol = symbol_short!("lastact");
 /// Key for the WASM provenance record (Wave #24).
 pub const PROV_KEY: Symbol = symbol_short!("prov");
@@ -375,15 +392,28 @@ pub struct Stats {
 /// `next_cursor` is `None` when this is the last page. Pass it as `cursor` to
 /// the next call to advance the page. `has_more` mirrors `next_cursor.is_some()`
 /// for clients that prefer a boolean sentinel.
+///
+/// `next_cursor` is an **opaque** token (Issue #215): callers must not
+/// construct one themselves or interpret its bytes — pass back exactly what
+/// the contract returned. It embeds the index generation at issue time, so a
+/// cursor becomes invalid (`ContractError::InvalidCursor`) rather than
+/// silently skipping or duplicating records if a username was removed from
+/// the registry after the cursor was issued. See `docs/DASHBOARD_SYNC.md`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[soroban_sdk::contracttype]
 pub struct ExportPage {
     /// Records in this page: `(github_username, ContributorRecord)` pairs.
     pub records: Vec<(String, ContributorRecord)>,
-    /// Cursor to pass to the next call, or `None` if this is the last page.
-    pub next_cursor: Option<u32>,
+    /// Opaque cursor to pass to the next call, or `None` if this is the last
+    /// page. See the struct docs — never construct or decode this yourself.
+    pub next_cursor: Option<BytesN<8>>,
     /// Total number of records in the registry at query time.
     pub total: u32,
+    /// Merkle root over `records`, in page order (Issue #216). All-zero for
+    /// an empty page. See `crate::merkle` for the leaf encoding and tree
+    /// construction, so off-chain tooling can build an inclusion proof
+    /// against this root without re-fetching the whole registry.
+    pub merkle_root: BytesN<32>,
     /// `true` if there are more records after this page.
     pub has_more: bool,
 }
@@ -436,11 +466,11 @@ pub struct ChallengeRecord {
 pub fn get_challenge(env: &Env, github_username: &String) -> Option<ChallengeRecord> {
     env.storage()
         .persistent()
-        .get(&(CHALLENGE_KEY, github_username.clone()))
+        .get(&(CHALLENGE_KEY, canon(env, github_username)))
 }
 
 pub fn set_challenge(env: &Env, github_username: &String, record: &ChallengeRecord) {
-    let key = (CHALLENGE_KEY, github_username.clone());
+    let key = (CHALLENGE_KEY, canon(env, github_username));
     env.storage().persistent().set(&key, record);
     env.storage()
         .persistent()
@@ -450,13 +480,40 @@ pub fn set_challenge(env: &Env, github_username: &String, record: &ChallengeReco
 pub fn remove_challenge(env: &Env, github_username: &String) {
     env.storage()
         .persistent()
-        .remove(&(CHALLENGE_KEY, github_username.clone()));
+        .remove(&(CHALLENGE_KEY, canon(env, github_username)));
 }
 
 pub fn has_challenge(env: &Env, github_username: &String) -> bool {
     env.storage()
         .persistent()
-        .has(&(CHALLENGE_KEY, github_username.clone()))
+        .has(&(CHALLENGE_KEY, canon(env, github_username)))
+}
+
+/// Network id recorded at `initialize` (Issue #231), or `None` for an
+/// instance initialized before network tagging existed.
+pub fn get_network_id(env: &Env) -> Option<BytesN<32>> {
+    env.storage().instance().get(&NETWORK_KEY)
+}
+
+/// Records `network_id` as the instance's tag. Overwrites any existing value —
+/// callers are responsible for only calling this when that is intended
+/// (`initialize`, and `adopt_network_tag` for a previously-untagged instance).
+pub fn set_network_id(env: &Env, network_id: &BytesN<32>) {
+    env.storage().instance().set(&NETWORK_KEY, network_id);
+}
+
+/// Fails with [`ContractError::NetworkMismatch`] if a network id was recorded
+/// at `initialize` and it differs from the network this call is executing on.
+///
+/// An instance with no recorded tag (deployed before Issue #231) is treated as
+/// untagged and allowed through — there is nothing to compare against.
+pub fn require_matching_network(env: &Env) -> Result<(), ContractError> {
+    match get_network_id(env) {
+        Some(recorded) if recorded != env.ledger().network_id() => {
+            Err(ContractError::NetworkMismatch)
+        }
+        _ => Ok(()),
+    }
 }
 
 /// Fails unless the contract is initialized **and** running on the network it
@@ -488,7 +545,7 @@ pub fn get_admin(env: &Env) -> Result<Address, ContractError> {
 }
 
 pub fn get_record(env: &Env, github_username: &String) -> Option<ContributorRecord> {
-    let key = (REG_KEY, github_username.clone());
+    let key = (REG_KEY, canon(env, github_username));
     let record: Option<ContributorRecord> = env.storage().persistent().get(&key);
     if record.is_some() {
         env.storage()
@@ -499,7 +556,7 @@ pub fn get_record(env: &Env, github_username: &String) -> Option<ContributorReco
 }
 
 pub fn set_record(env: &Env, github_username: &String, record: &ContributorRecord) {
-    let key = (REG_KEY, github_username.clone());
+    let key = (REG_KEY, canon(env, github_username));
     env.storage().persistent().set(&key, record);
     env.storage()
         .persistent()
@@ -515,7 +572,7 @@ pub fn set_record(env: &Env, github_username: &String, record: &ContributorRecor
 /// Returns whether the entry existed. A missing entry is not an error: the
 /// keeper's list is built off-chain and can lag behind removals.
 pub fn extend_record_ttl(env: &Env, github_username: &String) -> bool {
-    let key = (REG_KEY, github_username.clone());
+    let key = (REG_KEY, canon(env, github_username));
     if !env.storage().persistent().has(&key) {
         return false;
     }
@@ -526,7 +583,7 @@ pub fn extend_record_ttl(env: &Env, github_username: &String) -> bool {
 }
 
 pub fn remove_record(env: &Env, github_username: &String) {
-    let key = (REG_KEY, github_username.clone());
+    let key = (REG_KEY, canon(env, github_username));
     env.storage().persistent().remove(&key);
 }
 
@@ -687,14 +744,14 @@ pub fn set_chunk(env: &Env, chunk_idx: u32, chunk: &Vec<String>) {
 pub fn add_to_index(env: &Env, github_username: &String) {
     // 1. Maintain legacy single-vec index
     let mut index = get_index(env);
-    index.push_back(github_username.clone());
+    index.push_back(canon(env, github_username));
     set_index(env, &index);
 
     // 2. Maintain chunked index
     let chunk_cnt = get_chunk_count(env);
     if chunk_cnt == 0 {
         let mut first_chunk = Vec::new(env);
-        first_chunk.push_back(github_username.clone());
+        first_chunk.push_back(canon(env, github_username));
         set_chunk(env, 0, &first_chunk);
         set_chunk_count(env, 1);
     } else {
@@ -702,11 +759,11 @@ pub fn add_to_index(env: &Env, github_username: &String) {
         let mut last_chunk = get_chunk(env, last_idx);
         if last_chunk.len() >= CHUNK_SIZE {
             let mut new_chunk = Vec::new(env);
-            new_chunk.push_back(github_username.clone());
+            new_chunk.push_back(canon(env, github_username));
             set_chunk(env, chunk_cnt, &new_chunk);
             set_chunk_count(env, chunk_cnt + 1);
         } else {
-            last_chunk.push_back(github_username.clone());
+            last_chunk.push_back(canon(env, github_username));
             set_chunk(env, last_idx, &last_chunk);
         }
     }
@@ -723,16 +780,27 @@ pub fn add_to_index(env: &Env, github_username: &String) {
 /// Covered by `test_remove_last_user_returns_registry_to_empty_state` in
 /// `src/lib.rs`.
 pub fn remove_from_index(env: &Env, github_username: &String) {
+    // The index stores the canonical form (see `add_to_index`), so the
+    // comparison below must fold the same way or a case-variant caller would
+    // silently fail to remove the entry it just looked up.
+    let target = canon(env, github_username);
+
     // 1. Legacy index update
     let index = get_index(env);
     let mut next = Vec::new(env);
     for i in 0..index.len() {
         let username = index.get(i).unwrap();
-        if username != *github_username {
+        if username != target {
             next.push_back(username);
         }
     }
     set_index(env, &next);
+
+    // Every position after the removed entry just shifted back by one, so
+    // any pagination cursor issued before this point is no longer safe to
+    // resume from (Issue #215) — bump the generation so `decode_cursor`
+    // rejects it instead of silently returning drifted results.
+    bump_index_generation(env);
 
     // 2. Chunked index update
     let chunk_cnt = get_chunk_count(env);
@@ -742,7 +810,7 @@ pub fn remove_from_index(env: &Env, github_username: &String) {
         let mut found = false;
         for i in 0..chunk.len() {
             let username = chunk.get(i).unwrap();
-            if username == *github_username {
+            if username == target {
                 found = true;
             } else {
                 new_chunk.push_back(username);
@@ -755,20 +823,87 @@ pub fn remove_from_index(env: &Env, github_username: &String) {
     }
 }
 
+// ── Opaque pagination cursors (Issue #215) ───────────────────────────────────
+
+/// Current index generation. Bumped by [`remove_from_index`] every time an
+/// existing entry's position could shift. Instance-scoped, defaulting to `0`
+/// for a fresh or pre-Issue-#215 instance.
+pub fn get_index_generation(env: &Env) -> u32 {
+    env.storage().instance().get(&INDEX_GEN_KEY).unwrap_or(0)
+}
+
+fn bump_index_generation(env: &Env) {
+    let next = get_index_generation(env).saturating_add(1);
+    env.storage().instance().set(&INDEX_GEN_KEY, &next);
+}
+
+/// Packs a flat-index offset together with the current index generation into
+/// an 8-byte opaque cursor: bytes `0..4` are the offset, bytes `4..8` are the
+/// generation, both big-endian. Callers must treat the result as opaque —
+/// this layout is an internal implementation detail, not a stabilized wire
+/// format.
+fn encode_cursor(env: &Env, offset: u32) -> BytesN<8> {
+    let generation = get_index_generation(env);
+    let mut bytes = [0u8; 8];
+    bytes[0..4].copy_from_slice(&offset.to_be_bytes());
+    bytes[4..8].copy_from_slice(&generation.to_be_bytes());
+    BytesN::from_array(env, &bytes)
+}
+
+/// Decodes and validates a cursor previously returned by this contract.
+///
+/// # Errors
+///
+/// - [`ContractError::InvalidCursor`] if the cursor's embedded generation no
+///   longer matches the current one — meaning a username was removed from
+///   the registry (shifting positions) since the cursor was issued — or if
+///   the embedded offset is past the current registry size. Either way, the
+///   safe recovery is to restart pagination from `cursor = None`; existing
+///   idempotent-upsert indexer logic (see `docs/DASHBOARD_SYNC.md`) makes a
+///   restart safe to replay.
+fn decode_cursor(env: &Env, cursor: &BytesN<8>) -> Result<u32, ContractError> {
+    let bytes = cursor.to_array();
+    let offset = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    let generation = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+
+    if generation != get_index_generation(env) {
+        return Err(ContractError::InvalidCursor);
+    }
+    if offset > get_count(env) {
+        return Err(ContractError::InvalidCursor);
+    }
+    Ok(offset)
+}
+
 // ── Paginated export (Issue #1 & #3) ─────────────────────────────────────────
 
 /// Returns a bounded page of `(username, record)` pairs starting at `cursor`.
+///
+/// `cursor` is `None` to start from the beginning, or a value previously
+/// returned as `ExportPage::next_cursor` to continue — see the opaque-cursor
+/// notes on [`ExportPage`] and [`decode_cursor`] (Issue #215).
 ///
 /// `limit == 0` falls back to `DEFAULT_PAGE_LIMIT`; anything above
 /// `MAX_PAGE_LIMIT` is clamped down to it rather than rejected — a caller
 /// asking for too much gets the largest page the contract allows instead of
 /// an error.
+///
+/// # Errors
+///
+/// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+/// - [`ContractError::InvalidCursor`] if `cursor` is `Some` and fails to
+///   decode against the current index generation or registry size.
 pub fn get_registered_paginated_internal(
     env: &Env,
-    cursor: u32,
+    cursor: Option<BytesN<8>>,
     limit: u32,
 ) -> Result<ExportPage, ContractError> {
     require_initialized(env)?;
+
+    let offset = match cursor {
+        Some(c) => decode_cursor(env, &c)?,
+        None => 0,
+    };
 
     let effective_limit = if limit == 0 {
         DEFAULT_PAGE_LIMIT
@@ -779,19 +914,20 @@ pub fn get_registered_paginated_internal(
     let total_count = get_count(env);
     let mut records = Vec::new(env);
 
-    if cursor >= total_count {
+    if offset >= total_count {
         return Ok(ExportPage {
             records,
             next_cursor: None,
             total: total_count,
             has_more: false,
+            merkle_root: crate::merkle::empty_root(env),
         });
     }
 
     let index = get_index(env);
-    let end = (cursor.saturating_add(effective_limit)).min(index.len());
+    let end = (offset.saturating_add(effective_limit)).min(index.len());
 
-    for i in cursor..end {
+    for i in offset..end {
         if let Some(username) = index.get(i) {
             if let Some(record) = get_record(env, &username) {
                 records.push_back((username, record));
@@ -799,14 +935,20 @@ pub fn get_registered_paginated_internal(
         }
     }
 
-    let next_cursor = if end < index.len() { Some(end) } else { None };
+    let next_cursor = if end < index.len() {
+        Some(encode_cursor(env, end))
+    } else {
+        None
+    };
     let has_more = next_cursor.is_some();
+    let merkle_root = crate::merkle::root_of_records(env, &records);
 
     Ok(ExportPage {
         records,
         next_cursor,
         total: total_count,
         has_more,
+        merkle_root,
     })
 }
 
@@ -909,12 +1051,6 @@ pub fn set_team_index(env: &Env, index: &Vec<String>) {
     env.storage().instance().set(&TEAM_INDEX_KEY, index);
 }
 
-pub fn team_key(env: &Env, org_name: &str, team_name: &str) -> String {
-    let prefix = String::from_str(env, org_name);
-    let suffix = String::from_str(env, team_name);
-    prefix.concat(&suffix.concat(&String::from_str(env, ":")))
-}
-
 pub fn add_to_team_index(env: &Env, key: &String) {
     let mut index = get_team_index(env);
     index.push_back(key.clone());
@@ -931,6 +1067,8 @@ pub fn remove_from_team_index(env: &Env, key: &String) {
         }
     }
     set_team_index(env, &next);
+}
+
 // ── Guardian (Issue #196) ─────────────────────────────────────────────────────
 
 /// Returns the designated guardian address, or `None` if none has been set.
@@ -984,17 +1122,17 @@ pub fn set_paused(env: &Env, paused: bool) {
 /// address, indicating a new off-chain GitHub identity check is needed.
 /// It is cleared when the record is successfully `verify`'d.
 pub fn get_pending_reverify(env: &Env, github_username: &String) -> bool {
-    let key = (PENDING_REVERIFY_KEY, github_username.clone());
+    let key = (PENDING_REVERIFY_KEY, canon(env, github_username));
     env.storage().persistent().get(&key).unwrap_or(false)
 }
 
 pub fn set_pending_reverify(env: &Env, github_username: &String, flag: bool) {
-    let key = (PENDING_REVERIFY_KEY, github_username.clone());
+    let key = (PENDING_REVERIFY_KEY, canon(env, github_username));
     env.storage().persistent().set(&key, &flag);
 }
 
 pub fn clear_pending_reverify(env: &Env, github_username: &String) {
-    let key = (PENDING_REVERIFY_KEY, github_username.clone());
+    let key = (PENDING_REVERIFY_KEY, canon(env, github_username));
     env.storage().persistent().remove(&key);
 }
 
@@ -1089,13 +1227,13 @@ pub fn set_attestation_required(env: &Env, required: bool) {
 pub fn get_last_action(env: &Env, github_username: &String) -> u64 {
     env.storage()
         .persistent()
-        .get(&(LAST_ACT_KEY, github_username.clone()))
+        .get(&(LAST_ACT_KEY, canon(env, github_username)))
         .unwrap_or(0)
 }
 
 /// Records the ledger timestamp of the last mutating action for `github_username`.
 pub fn set_last_action(env: &Env, github_username: &String, timestamp: u64) {
-    let key = (LAST_ACT_KEY, github_username.clone());
+    let key = (LAST_ACT_KEY, canon(env, github_username));
     env.storage().persistent().set(&key, &timestamp);
     env.storage()
         .persistent()
@@ -1529,7 +1667,7 @@ pub fn set_rotation_delay(env: &Env, seconds: u64) {
 }
 
 pub fn get_pending_rotation(env: &Env, github_username: &String) -> Option<PendingRotation> {
-    let key = (PENDING_ROT_KEY, github_username.clone());
+    let key = (PENDING_ROT_KEY, canon(env, github_username));
     let pending: Option<PendingRotation> = env.storage().persistent().get(&key);
     if pending.is_some() {
         env.storage()
@@ -1540,7 +1678,7 @@ pub fn get_pending_rotation(env: &Env, github_username: &String) -> Option<Pendi
 }
 
 pub fn set_pending_rotation(env: &Env, github_username: &String, rotation: &PendingRotation) {
-    let key = (PENDING_ROT_KEY, github_username.clone());
+    let key = (PENDING_ROT_KEY, canon(env, github_username));
     env.storage().persistent().set(&key, rotation);
     env.storage()
         .persistent()
@@ -1550,11 +1688,11 @@ pub fn set_pending_rotation(env: &Env, github_username: &String, rotation: &Pend
 pub fn remove_pending_rotation(env: &Env, github_username: &String) {
     env.storage()
         .persistent()
-        .remove(&(PENDING_ROT_KEY, github_username.clone()));
+        .remove(&(PENDING_ROT_KEY, canon(env, github_username)));
 }
 
 pub fn has_pending_rotation(env: &Env, github_username: &String) -> bool {
     env.storage()
         .persistent()
-        .has(&(PENDING_ROT_KEY, github_username.clone()))
+        .has(&(PENDING_ROT_KEY, canon(env, github_username)))
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -171,6 +171,46 @@ pub fn eq_ignore_ascii_case(a: &String, b: &String) -> bool {
         .all(|(x, y)| x.eq_ignore_ascii_case(y))
 }
 
+/// Folds a GitHub username to its canonical storage-key form.
+///
+/// GitHub logins are case-insensitive, so `Alice` and `alice` name the same
+/// account. Every persistent storage key keyed by a username is built from
+/// this canonical form (ASCII-lowercased), so a case variant of an existing
+/// login can never create a second, independent record — see
+/// `docs/SECURITY.md#username-case-folding`.
+///
+/// The fold is byte-wise ASCII-only: only bytes in `b'A'..=b'Z'` are lowered.
+/// Any byte `>= 0x80` (part of a multi-byte UTF-8 sequence) is left
+/// untouched, so this never changes the byte length of its input and never
+/// performs a Unicode-aware case fold — GitHub usernames are ASCII-only
+/// (`is_valid_github_username`), and this function does not attempt to
+/// canonicalize non-ASCII input beyond leaving it as-is. Homoglyph
+/// normalization is explicitly out of scope (tracked separately).
+///
+/// A username too long for the fixed stack buffer (longer than
+/// `MAX_USERNAME_LEN` could ever be, since registration already rejects
+/// those) is returned unchanged rather than folded, since it can never be a
+/// valid registration key anyway.
+#[must_use]
+pub fn canonicalize_username(env: &Env, s: &String) -> String {
+    let len = s.len() as usize;
+    if len == 0 || len > USERNAME_BUF {
+        return s.clone();
+    }
+
+    let mut buf = [0u8; USERNAME_BUF];
+    s.copy_into_slice(&mut buf[..len]);
+    buf[..len].make_ascii_lowercase();
+
+    match core::str::from_utf8(&buf[..len]) {
+        Ok(lowered) => String::from_str(env, lowered),
+        // Unreachable for any input that was valid UTF-8 going in: lowercasing
+        // ASCII bytes in place can never break UTF-8 validity. Kept as a safe
+        // fallback rather than a panic on the no_std validation path.
+        Err(_) => s.clone(),
+    }
+}
+
 /// Calculate the percentage of verified contributors out of total.
 pub fn calculate_verification_percentage(verified: u32, total: u32) -> u32 {
     if total == 0 {
@@ -504,6 +544,77 @@ mod tests {
         assert!(eq_ignore_ascii_case(&s(&env, "BOB-1"), &s(&env, "bob-1")));
         assert!(!eq_ignore_ascii_case(&s(&env, "alice"), &s(&env, "bob")));
         assert!(!eq_ignore_ascii_case(&s(&env, "alice"), &s(&env, "alice1")));
+    }
+
+    // ── Username case-folding (Issue #194) ────────────────────────────────────
+
+    #[test]
+    fn test_canonicalize_username_lowercases() {
+        let env = Env::default();
+        assert_eq!(
+            canonicalize_username(&env, &s(&env, "Alice")),
+            s(&env, "alice")
+        );
+        assert_eq!(
+            canonicalize_username(&env, &s(&env, "OCTOCAT")),
+            s(&env, "octocat")
+        );
+        assert_eq!(
+            canonicalize_username(&env, &s(&env, "Bob-Smith_42")),
+            s(&env, "bob-smith_42")
+        );
+    }
+
+    #[test]
+    fn test_canonicalize_username_already_lower_is_unchanged() {
+        let env = Env::default();
+        assert_eq!(
+            canonicalize_username(&env, &s(&env, "octocat")),
+            s(&env, "octocat")
+        );
+    }
+
+    #[test]
+    fn test_canonicalize_username_idempotent() {
+        let env = Env::default();
+        let once = canonicalize_username(&env, &s(&env, "MixedCase"));
+        let twice = canonicalize_username(&env, &once);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn test_canonicalize_username_case_variants_collide() {
+        let env = Env::default();
+        let variants = ["alice", "Alice", "ALICE", "aLiCe"];
+        let canonical = canonicalize_username(&env, &s(&env, variants[0]));
+        for v in &variants {
+            assert_eq!(
+                canonicalize_username(&env, &s(&env, v)),
+                canonical,
+                "{v} must fold to the same canonical key as {}",
+                variants[0]
+            );
+        }
+    }
+
+    #[test]
+    fn test_canonicalize_username_never_changes_byte_length() {
+        let env = Env::default();
+        for name in ["a", "Z", "MixedCase123", "foo-BAR_baz", "OCTOCAT"] {
+            let original = s(&env, name);
+            let folded = canonicalize_username(&env, &original);
+            assert_eq!(
+                folded.len(),
+                original.len(),
+                "ASCII case-folding must never change byte length ({name})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_canonicalize_username_empty_is_unchanged() {
+        let env = Env::default();
+        assert_eq!(canonicalize_username(&env, &s(&env, "")), s(&env, ""));
     }
 
     // ── Percentage helper ─────────────────────────────────────────────────────

--- a/tests/cursor_pagination.rs
+++ b/tests/cursor_pagination.rs
@@ -1,0 +1,224 @@
+//! Standalone verification for Issue #215 (opaque cursor tokens for
+//! `get_registered_paginated` / `get_public_paginated`).
+//!
+//! Kept as its own integration test file, independent of `tests/integration.rs`,
+//! so it can be built and run on its own via
+//! `cargo test --test cursor_pagination` regardless of the state of that
+//! other file.
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+
+use trustbridge_contract::{ContractError, TrustBridgeContract};
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TrustBridgeContract, ());
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::initialize(env.clone(), admin.clone()).unwrap();
+    });
+    (env, admin, contract_id)
+}
+
+fn s(env: &Env, text: &str) -> String {
+    String::from_str(env, text)
+}
+
+/// Registers `n` freshly-generated users named `user{start}..user{start+n}`,
+/// so repeated calls in one test (with increasing `start`) grow the registry
+/// without re-registering (and thus not actually adding) an earlier name.
+fn register_range(env: &Env, start: u32, n: u32) -> Vec<(String, Address)> {
+    let mut out = Vec::new(env);
+    for i in start..start + n {
+        let addr = Address::generate(env);
+        let name = s(env, &alloc::format!("user{i:03}"));
+        TrustBridgeContract::register(env.clone(), name.clone(), addr.clone(), Vec::new(env))
+            .unwrap();
+        out.push_back((name, addr));
+    }
+    out
+}
+
+fn register_n(env: &Env, n: u32) -> Vec<(String, Address)> {
+    register_range(env, 0, n)
+}
+
+extern crate alloc;
+
+#[test]
+fn test_full_walk_with_cursor_none_start_visits_every_record_once() {
+    let (env, _admin, contract_id) = setup();
+
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        register_n(&env, 25);
+
+        let mut seen: alloc::vec::Vec<String> = alloc::vec::Vec::new();
+        let mut cursor = None;
+        loop {
+            let page = TrustBridgeContract::get_registered_paginated(env.clone(), cursor, 10)
+                .unwrap();
+            for i in 0..page.records.len() {
+                let (username, _) = page.records.get(i).unwrap();
+                seen.push(username);
+            }
+            if !page.has_more {
+                assert!(page.next_cursor.is_none());
+                break;
+            }
+            cursor = page.next_cursor;
+        }
+
+        assert_eq!(seen.len(), 25);
+    });
+}
+
+#[test]
+fn test_empty_registry_page_has_no_next_cursor() {
+    let (env, _admin, contract_id) = setup();
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        let page = TrustBridgeContract::get_registered_paginated(env.clone(), None, 10).unwrap();
+        assert_eq!(page.records.len(), 0);
+        assert!(page.next_cursor.is_none());
+        assert!(!page.has_more);
+    });
+}
+
+#[test]
+fn test_last_page_has_no_next_cursor() {
+    let (env, _admin, contract_id) = setup();
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        register_n(&env, 5);
+        let page = TrustBridgeContract::get_registered_paginated(env.clone(), None, 10).unwrap();
+        assert_eq!(page.records.len(), 5);
+        assert!(page.next_cursor.is_none());
+        assert!(!page.has_more);
+    });
+}
+
+/// The core Issue #215 scenario: a cursor issued before a removal must not
+/// be usable to silently continue past drifted positions — it must fail
+/// loudly instead.
+#[test]
+fn test_removing_a_record_after_a_cursor_is_issued_invalidates_it() {
+    let (env, admin, contract_id) = setup();
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        register_n(&env, 10);
+
+        // First page of 4; there is more after it.
+        let page1 =
+            TrustBridgeContract::get_registered_paginated(env.clone(), None, 4).unwrap();
+        assert_eq!(page1.records.len(), 4);
+        assert!(page1.has_more);
+        let stale_cursor = page1.next_cursor.clone().unwrap();
+
+        // Remove a record that sits *before* the stale cursor's offset,
+        // shifting every later position back by one.
+        TrustBridgeContract::remove(env.clone(), admin.clone(), s(&env, "user000")).unwrap();
+
+        // Continuing with the pre-removal cursor must fail loudly rather
+        // than silently return a drifted page.
+        let result =
+            TrustBridgeContract::get_registered_paginated(env.clone(), Some(stale_cursor), 4);
+        assert_eq!(result, Err(ContractError::InvalidCursor));
+
+        // The documented recovery — restart from `cursor = None` — must
+        // succeed and eventually visit every remaining record exactly once.
+        let mut seen: alloc::vec::Vec<String> = alloc::vec::Vec::new();
+        let mut cursor = None;
+        loop {
+            let page =
+                TrustBridgeContract::get_registered_paginated(env.clone(), cursor, 4).unwrap();
+            for i in 0..page.records.len() {
+                let (username, _) = page.records.get(i).unwrap();
+                seen.push(username);
+            }
+            if !page.has_more {
+                break;
+            }
+            cursor = page.next_cursor;
+        }
+        assert_eq!(seen.len(), 9);
+        assert!(!seen.iter().any(|u| *u == s(&env, "user000")));
+    });
+}
+
+/// A removal that happens *after* the position a cursor already passed
+/// still invalidates it under this contract's coarse (whole-index)
+/// generation bump — documented behavior, not a bug: any removal shifts the
+/// global offset space, so the safe rule is "any removal invalidates every
+/// outstanding cursor," not just ones downstream of the removed entry.
+#[test]
+fn test_removal_anywhere_invalidates_outstanding_cursors_even_if_already_passed() {
+    let (env, admin, contract_id) = setup();
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        register_n(&env, 10);
+
+        let page1 =
+            TrustBridgeContract::get_registered_paginated(env.clone(), None, 4).unwrap();
+        let stale_cursor = page1.next_cursor.clone().unwrap();
+
+        // Remove a record *after* the cursor's offset this time.
+        TrustBridgeContract::remove(env.clone(), admin.clone(), s(&env, "user009")).unwrap();
+
+        let result =
+            TrustBridgeContract::get_registered_paginated(env.clone(), Some(stale_cursor), 4);
+        assert_eq!(result, Err(ContractError::InvalidCursor));
+    });
+}
+
+#[test]
+fn test_cursor_is_interchangeable_between_admin_and_public_paginated() {
+    let (env, _admin, contract_id) = setup();
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        register_n(&env, 6);
+
+        let page1 = TrustBridgeContract::get_public_paginated(env.clone(), None, 3).unwrap();
+        assert!(page1.has_more);
+        let cursor = page1.next_cursor;
+
+        // Resume with the admin-gated variant using the cursor the public
+        // variant issued.
+        let page2 =
+            TrustBridgeContract::get_registered_paginated(env.clone(), cursor, 3).unwrap();
+        assert_eq!(page2.records.len(), 3);
+        assert!(!page2.has_more);
+    });
+}
+
+/// A cursor is opaque by design (Issue #215): this crate deliberately does
+/// not expose a way to construct one outside of a contract call, so an
+/// "out of range offset with an otherwise-valid generation" case is not
+/// independently reachable from outside the contract — any removal that
+/// would shrink the registry below a previously-issued offset also bumps
+/// the generation, so `test_removing_a_record_after_a_cursor_is_issued_invalidates_it`
+/// and `test_removal_anywhere_invalidates_outstanding_cursors_even_if_already_passed`
+/// above already exercise the only way a stale cursor can actually arise.
+#[test]
+fn test_registering_more_after_a_cursor_is_issued_does_not_invalidate_it() {
+    let (env, _admin, contract_id) = setup();
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        register_n(&env, 3);
+
+        let page1 = TrustBridgeContract::get_registered_paginated(env.clone(), None, 2).unwrap();
+        assert!(page1.has_more);
+        let cursor = page1.next_cursor;
+
+        // Appending new registrations only grows the index past the cursor's
+        // offset; it never shifts an existing position, so the cursor from
+        // before this registration must still be valid.
+        register_range(&env, 3, 2);
+
+        let page2 =
+            TrustBridgeContract::get_registered_paginated(env.clone(), cursor, 10).unwrap();
+        assert!(page2.records.len() >= 1);
+    });
+}

--- a/tests/merkle_export.rs
+++ b/tests/merkle_export.rs
@@ -1,0 +1,274 @@
+//! Standalone verification for Issue #216 (Merkle root over an export page).
+//!
+//! Kept as its own integration test file, independent of `tests/integration.rs`,
+//! so it can be built and run on its own via `cargo test --test merkle_export`
+//! regardless of the state of that other file.
+//!
+//! The proof builder/verifier below is a deliberately independent
+//! reimplementation of the tree rules documented in `src/merkle.rs` and
+//! `docs/ABI.md` — it does not call into the contract's internal tree code —
+//! because the point of this test is to prove that off-chain tooling, given
+//! only the exported page and the documented spec, can build proofs that
+//! verify against the on-chain root.
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Bytes, BytesN, Env, String};
+use soroban_sdk::Vec as SVec;
+
+use trustbridge_contract::TrustBridgeContract;
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TrustBridgeContract, ());
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::initialize(env.clone(), admin.clone()).unwrap();
+    });
+    (env, admin, contract_id)
+}
+
+fn s(env: &Env, text: &str) -> String {
+    String::from_str(env, text)
+}
+
+// ── Independent off-chain-style Merkle implementation, per docs/ABI.md ─────
+//
+// This does not call `trustbridge_contract`'s internal tree code — it is a
+// from-scratch reimplementation of the documented spec, exactly like an
+// off-chain treasury or dashboard would write.
+
+const LEAF_DOMAIN: &[u8] = b"trustbridge/export-leaf/v1:";
+const NODE_DOMAIN: &[u8] = b"trustbridge/export-node/v1:";
+
+fn leaf_hash(env: &Env, username: &String, addr: &Address, verified: bool) -> BytesN<32> {
+    let mut buf = Bytes::from_slice(env, LEAF_DOMAIN);
+    buf.append(&username.to_bytes());
+    buf.push_back(0u8);
+    buf.append(&addr.to_string().to_bytes());
+    buf.push_back(u8::from(verified));
+    env.crypto().sha256(&buf).to_bytes()
+}
+
+fn node_hash(env: &Env, left: &BytesN<32>, right: &BytesN<32>) -> BytesN<32> {
+    let mut buf = Bytes::from_slice(env, NODE_DOMAIN);
+    buf.append(&Bytes::from(left.clone()));
+    buf.append(&Bytes::from(right.clone()));
+    env.crypto().sha256(&buf).to_bytes()
+}
+
+/// One step of an inclusion proof: the sibling hash to combine with and
+/// which side it sits on, or `Promoted` for a level where the current node
+/// had no sibling and was carried up unchanged.
+#[derive(Clone)]
+enum Step {
+    Pair { sibling: BytesN<32>, sibling_is_left: bool },
+    Promoted,
+}
+
+/// Builds an inclusion proof for `leaves[index]` by replaying the same
+/// level-by-level tree construction `src/merkle.rs` documents, recording the
+/// sibling at each level instead of discarding it.
+fn build_proof(env: &Env, leaves: &SVec<BytesN<32>>, index: u32) -> Vec<Step> {
+    let mut steps: Vec<Step> = Vec::new();
+    let mut level: SVec<BytesN<32>> = leaves.clone();
+    let mut idx = index;
+
+    while level.len() > 1 {
+        let mut next: SVec<BytesN<32>> = SVec::new(env);
+        let mut i: u32 = 0;
+        while i + 1 < level.len() {
+            let left = level.get(i).unwrap();
+            let right = level.get(i + 1).unwrap();
+            if idx == i {
+                steps.push(Step::Pair {
+                    sibling: right.clone(),
+                    sibling_is_left: false,
+                });
+                idx = next.len();
+            } else if idx == i + 1 {
+                steps.push(Step::Pair {
+                    sibling: left.clone(),
+                    sibling_is_left: true,
+                });
+                idx = next.len();
+            }
+            next.push_back(node_hash(env, &left, &right));
+            i += 2;
+        }
+        if i < level.len() {
+            if idx == i {
+                steps.push(Step::Promoted);
+                idx = next.len();
+            }
+            next.push_back(level.get(i).unwrap());
+        }
+        level = next;
+    }
+
+    steps
+}
+
+/// Recomputes the root from `leaf` and `steps`, exactly as a verifier with no
+/// access to the rest of the tree would.
+fn verify_proof(env: &Env, leaf: &BytesN<32>, steps: &[Step], root: &BytesN<32>) -> bool {
+    let mut acc = leaf.clone();
+    for step in steps {
+        acc = match step {
+            Step::Pair { sibling, sibling_is_left } => {
+                if *sibling_is_left {
+                    node_hash(env, sibling, &acc)
+                } else {
+                    node_hash(env, &acc, sibling)
+                }
+            }
+            Step::Promoted => acc,
+        };
+    }
+    acc == *root
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_merkle_root_present_on_export_page() {
+    let (env, admin, contract_id) = setup();
+    let a1 = Address::generate(&env);
+    let a2 = Address::generate(&env);
+    let a3 = Address::generate(&env);
+
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        for (name, addr) in [("alice", &a1), ("bob", &a2), ("carol", &a3)] {
+            TrustBridgeContract::register(
+                env.clone(),
+                s(&env, name),
+                addr.clone(),
+                SVec::new(&env),
+            )
+            .unwrap();
+        }
+        TrustBridgeContract::verify(env.clone(), admin.clone(), s(&env, "alice")).unwrap();
+
+        let page = TrustBridgeContract::get_registered_paginated(env.clone(), 0, 10).unwrap();
+        assert_eq!(page.records.len(), 3);
+        assert_ne!(page.merkle_root, BytesN::from_array(&env, &[0u8; 32]));
+    });
+}
+
+#[test]
+fn test_empty_registry_export_has_all_zero_root() {
+    let (env, _admin, contract_id) = setup();
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        let page = TrustBridgeContract::get_registered_paginated(env.clone(), 0, 10).unwrap();
+        assert_eq!(page.records.len(), 0);
+        assert_eq!(page.merkle_root, BytesN::from_array(&env, &[0u8; 32]));
+    });
+}
+
+#[test]
+fn test_leaf_hash_matches_contract_helper() {
+    let (env, _admin, contract_id) = setup();
+    let addr = Address::generate(&env);
+
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::register(
+            env.clone(),
+            s(&env, "octocat"),
+            addr.clone(),
+            SVec::new(&env),
+        )
+        .unwrap();
+
+        let via_contract = TrustBridgeContract::merkle_leaf_hash(
+            env.clone(),
+            s(&env, "octocat"),
+            addr.clone(),
+            false,
+        );
+        let via_reimpl = leaf_hash(&env, &s(&env, "octocat"), &addr, false);
+        assert_eq!(via_contract, via_reimpl);
+    });
+}
+
+#[test]
+fn test_included_member_proves_inclusion_and_non_member_fails() {
+    let (env, admin, contract_id) = setup();
+    let names = ["alice", "bob", "carol", "dave", "erin"];
+    let addrs: Vec<Address> = names.iter().map(|_| Address::generate(&env)).collect();
+
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        for (name, addr) in names.iter().zip(addrs.iter()) {
+            TrustBridgeContract::register(env.clone(), s(&env, name), addr.clone(), SVec::new(&env))
+                .unwrap();
+        }
+        TrustBridgeContract::verify(env.clone(), admin.clone(), s(&env, "carol")).unwrap();
+
+        let page = TrustBridgeContract::get_registered_paginated(env.clone(), 0, 10).unwrap();
+        assert_eq!(page.records.len(), 5);
+
+        // Rebuild the leaf set exactly as documented, independent of the
+        // contract's internal tree code.
+        let mut leaves: SVec<BytesN<32>> = SVec::new(&env);
+        for i in 0..page.records.len() {
+            let (username, record) = page.records.get(i).unwrap();
+            leaves.push_back(leaf_hash(&env, &username, &record.stellar_address, record.verified));
+        }
+
+        // "carol" (index 2) is verified; her leaf must reflect that and her
+        // proof must verify against the page's published root.
+        let carol_index = 2u32;
+        let (carol_username, carol_record) = page.records.get(carol_index).unwrap();
+        assert_eq!(carol_username, s(&env, "carol"));
+        assert!(carol_record.verified);
+
+        let carol_leaf = leaves.get(carol_index).unwrap();
+        let proof = build_proof(&env, &leaves, carol_index);
+        assert!(
+            verify_proof(&env, &carol_leaf, &proof, &page.merkle_root),
+            "carol's proof must verify against the page's merkle_root"
+        );
+
+        // A non-member (never registered) must not verify against this root
+        // using carol's proof path — there is no leaf for them in this tree.
+        let outsider = Address::generate(&env);
+        let outsider_leaf = leaf_hash(&env, &s(&env, "mallory"), &outsider, false);
+        assert!(
+            !verify_proof(&env, &outsider_leaf, &proof, &page.merkle_root),
+            "a non-member must not verify against the page's merkle_root"
+        );
+
+        // Tampering with carol's verified flag must also invalidate the leaf
+        // against the same proof path, since the flag is part of the leaf.
+        let tampered_leaf = leaf_hash(&env, &carol_username, &carol_record.stellar_address, false);
+        assert!(
+            !verify_proof(&env, &tampered_leaf, &proof, &page.merkle_root),
+            "a tampered verified flag must change the leaf and break the proof"
+        );
+    });
+}
+
+#[test]
+fn test_single_record_page_root_equals_its_own_leaf() {
+    let (env, _admin, contract_id) = setup();
+    let addr = Address::generate(&env);
+
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::register(
+            env.clone(),
+            s(&env, "octocat"),
+            addr.clone(),
+            SVec::new(&env),
+        )
+        .unwrap();
+
+        let page = TrustBridgeContract::get_registered_paginated(env.clone(), 0, 10).unwrap();
+        assert_eq!(page.records.len(), 1);
+        let expected = leaf_hash(&env, &s(&env, "octocat"), &addr, false);
+        assert_eq!(page.merkle_root, expected);
+    });
+}

--- a/tests/username_case_fold.rs
+++ b/tests/username_case_fold.rs
@@ -1,0 +1,131 @@
+//! Standalone verification for Issue #194 (case-fold GitHub usernames at the
+//! storage-key layer).
+//!
+//! Kept as its own integration test file, independent of `tests/integration.rs`,
+//! so it can be built and run on its own via
+//! `cargo test --test username_case_fold` regardless of the state of that
+//! other file.
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+
+use trustbridge_contract::TrustBridgeContract;
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TrustBridgeContract, ());
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::initialize(env.clone(), admin.clone()).unwrap();
+    });
+    (env, admin, contract_id)
+}
+
+fn s(env: &Env, text: &str) -> String {
+    String::from_str(env, text)
+}
+
+#[test]
+fn test_username_case_variant_looks_up_the_same_record() {
+    let (env, _admin, contract_id) = setup();
+    let alice = Address::generate(&env);
+
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::register(env.clone(), s(&env, "Alice"), alice.clone(), Vec::new(&env))
+            .unwrap();
+
+        // A case variant lookup must hit the exact same record.
+        let via_lower = TrustBridgeContract::get_address(env.clone(), s(&env, "alice")).unwrap();
+        let via_upper = TrustBridgeContract::get_address(env.clone(), s(&env, "ALICE")).unwrap();
+        let via_mixed = TrustBridgeContract::get_address(env.clone(), s(&env, "aLiCe")).unwrap();
+
+        assert_eq!(via_lower.stellar_address, alice);
+        assert_eq!(via_upper.stellar_address, alice);
+        assert_eq!(via_mixed.stellar_address, alice);
+
+        // Only one registration exists, not one per case variant.
+        let stats = TrustBridgeContract::get_stats(env.clone());
+        assert_eq!(stats.total, 1);
+
+        assert!(TrustBridgeContract::has_record(env.clone(), s(&env, "alice")));
+        assert!(TrustBridgeContract::has_record(env.clone(), s(&env, "ALICE")));
+    });
+}
+
+#[test]
+fn test_registering_a_case_variant_updates_the_existing_record_not_a_new_one() {
+    let (env, _admin, contract_id) = setup();
+    let alice = Address::generate(&env);
+
+    // `mock_all_auths` authorizes every signature the invocation asks for,
+    // including the existing owner's — this test's job is to prove the
+    // second call lands on the *same* storage key (so a real deployment's
+    // `old.stellar_address.require_auth()` guard is even reached) rather than
+    // silently creating a second, independent registration for the same
+    // GitHub login. The auth-rejection path itself is exercised by the
+    // broader `remove`/`register` negative-auth suite.
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), alice.clone(), Vec::new(&env))
+            .unwrap();
+    });
+
+    let new_owner = Address::generate(&env);
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::register(
+            env.clone(),
+            s(&env, "ALICE"),
+            new_owner.clone(),
+            Vec::new(&env),
+        )
+        .unwrap();
+
+        // Still one registration overall: the case variant updated the
+        // existing entry rather than creating a second one.
+        let stats = TrustBridgeContract::get_stats(env.clone());
+        assert_eq!(stats.total, 1);
+
+        let record = TrustBridgeContract::get_address(env.clone(), s(&env, "alice")).unwrap();
+        assert_eq!(record.stellar_address, new_owner);
+    });
+}
+
+#[test]
+fn test_export_and_index_show_canonical_username_form() {
+    let (env, _admin, contract_id) = setup();
+    let alice = Address::generate(&env);
+
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::register(env.clone(), s(&env, "Alice"), alice.clone(), Vec::new(&env))
+            .unwrap();
+
+        let page = TrustBridgeContract::get_registered_paginated(env.clone(), 0, 10).unwrap();
+        assert_eq!(page.records.len(), 1);
+        let (stored_username, _) = page.records.get(0).unwrap();
+        assert_eq!(stored_username, s(&env, "alice"));
+    });
+}
+
+#[test]
+fn test_remove_by_case_variant_removes_the_canonical_record() {
+    let (env, admin, contract_id) = setup();
+    let alice = Address::generate(&env);
+
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), alice.clone(), Vec::new(&env))
+            .unwrap();
+
+        // Remove using a different case than the one used to register.
+        TrustBridgeContract::remove(env.clone(), admin.clone(), s(&env, "ALICE")).unwrap();
+
+        assert!(!TrustBridgeContract::has_record(env.clone(), s(&env, "alice")));
+        assert!(!TrustBridgeContract::has_record(env.clone(), s(&env, "Alice")));
+        let stats = TrustBridgeContract::get_stats(env.clone());
+        assert_eq!(stats.total, 0);
+    });
+}


### PR DESCRIPTION
…t roots

Case-fold GitHub usernames at the storage-key layer Fixes #194

Opaque cursor tokens for `get_registered_paginated` Fixes #215

Merkle root over an export page for off-chain inclusion proofs Fixes #216

Store GitHub attestation hash alongside the verified flag Fixes #217