### PR TITLE
feat: role/verification expiry, export attestation, dual-control batc…

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -79,6 +79,22 @@ enum Role {
 | Revoker | ❌ | ✅ | ❌ | ❌ |
 | Upgrader | ❌ | ❌ | ✅ | ❌ |
 
+**Optional expiry (Issue #221):** `set_role` grants a role with no expiry.
+`set_role_with_expiry(target, role, expires_at: Option<u64>)` grants the same
+role but, once `env.ledger().timestamp() >= expires_at`, `get_role` and every
+check built on it (`verify`, `revoke_verification`, `batch_verify`,
+`get_role_holders`, `execute_batch_remove`'s second-signer check) treat
+`target` as holding no role at all — no expiry never happens unless a caller
+opts in via `set_role_with_expiry`. Expiry is **lazy**: the underlying
+storage entry is left in place until `remove_role` deletes it; `get_role`
+just stops reporting it. `get_role_expiry(address)` returns the raw
+(possibly-already-past) timestamp, or `None` for a no-expiry grant or no
+grant at all. `has_role(address, role)` is a convenience boolean for
+`get_role(address) == Some(role)`. The contract admin's own identity
+(`ADMIN_KEY`, checked by `has_admin_role`) is a separate storage slot never
+touched by this — only the RBAC-style `Role::Admin` grant can expire, and
+only if explicitly granted with an expiry.
+
 ### HealthSnapshot
 
 Returned by `get_health` (Issue #210).
@@ -146,6 +162,9 @@ struct ChallengeRecord {
 | 19 | `ChallengeNotResolvable` | `complete_challenge` called before the delay has elapsed |
 | 20 | `ChallengeActive` | `register` attempted while a challenge is active on the username |
 | 21 | `NetworkMismatch` | Instance state was initialized on a different network than the one executing (Issue #231) |
+| 30 | `DualControlRequired` | `batch_remove` batch size exceeds the dual-control threshold; use `propose_batch_remove` / `execute_batch_remove` (Issue #219) |
+| 31 | `BatchRemoveProposalPending` | `propose_batch_remove` called while a proposal is already pending (Issue #219) |
+| 32 | `NoPendingBatchRemove` | `execute_batch_remove` / `cancel_batch_remove` called with no pending (or an expired) proposal (Issue #219) |
 
 `ContractError::from_code(u32)` maps every code in this table back to the typed
 variant and returns `None` for any unrecognized code. Every code round-trips
@@ -160,6 +179,45 @@ tests in `src/lib.rs` (`test_error_from_code_is_inverse_of_code`).
 |-------|------|-------|
 | `address` | `Address` | Address holding the role |
 | `role` | `Role` | Role held, as the `Role` discriminant |
+
+### ExportAttestation (Issue #223)
+
+Returned by `export_attestation`. Binds one `ExportPage` to a digest, the
+contract's schema version, and the ledger it was read at, so an auditor
+holding only this struct and the exported JSON page can confirm the export
+matches what the contract held — without reconnecting to the network. See
+[ADMIN_RUNBOOK.md](./ADMIN_RUNBOOK.md#signed-export-attestation-issue-223).
+
+```rust
+struct ExportAttestation {
+    page: ExportPage,      // identical to get_registered_paginated's return for the same cursor/limit
+    digest: BytesN<32>,    // SHA-256 over page's XDR encoding — treat as opaque, compare byte for byte
+    version: Vec<u32>,     // [major, minor, patch] at export time
+    ledger: u32,           // ledger sequence the page and digest were computed at
+}
+```
+
+The digest is deterministic: unchanged state and the same `cursor`/`limit`
+always produce the same bytes; any change to a record, the total, or the
+pagination cursor changes it. It is **not** a threshold signature and **not**
+a Merkle proof over the whole registry — those are explicitly out of scope
+for this issue (a Merkle root over the full registry can complement this per
+Issue #27).
+
+### PendingBatchRemove (Issue #219)
+
+Returned by `get_pending_batch_remove`. Represents a large `batch_remove`
+awaiting a second, distinct admin-equivalent signature. See
+[ADMIN_RUNBOOK.md](./ADMIN_RUNBOOK.md#dual-control-batch_remove-issue-219).
+
+```rust
+struct PendingBatchRemove {
+    usernames: Vec<String>,  // the exact batch that will be removed on execute
+    proposed_by: Address,    // execute_batch_remove rejects this exact caller
+    proposed_at: u64,        // ledger timestamp of propose_batch_remove; proposal
+                              // expires BATCH_REMOVE_PROPOSAL_TTL_SECS (24h) after this
+}
+```
 
 ### EventDomain (Issue #226)
 
@@ -1832,3 +1890,129 @@ read or write.
 An instance with no recorded tag is allowed through, so contracts deployed
 before this change keep working. Once a tag is present it is compared on every
 call and never rewritten.
+
+## New Functions (Issues #218, #219, #221, #223)
+
+### Role expiry (Issue #221)
+
+#### `set_role_with_expiry(target: Address, role: Role, expires_at: Option<u64>) -> Result<(), ContractError>`
+
+Admin-only. Identical to `set_role`, except the grant lapses once
+`env.ledger().timestamp() >= expires_at`. `None` behaves exactly like
+`set_role` (no expiry). See the **Optional expiry** note under the `Role`
+type above for the full semantics, including that expiry is lazy and never
+affects the contract admin's own identity.
+
+Emits `RoleGrantedEvent` (unchanged shape — expiry is not carried on the
+event; read it back with `get_role_expiry`).
+
+#### `get_role_expiry(address: Address) -> Option<u64>`
+
+Read-only; no auth. The raw expiry timestamp for `address`'s current role
+grant — `None` for a no-expiry grant or no role at all. Unlike `get_role`,
+this does not hide an already-past timestamp, so an operator can distinguish
+"never expires" from "expired at T" without waiting for `remove_role`.
+
+#### `has_role(address: Address, role: Role) -> bool`
+
+Read-only; no auth. `true` iff `get_role(address) == Some(role)`.
+
+### Time-bounded verification (Issue #218)
+
+`config_verification`'s `expires_in` (seconds) is now enforced. `verify` and
+`batch_verify` record a verification timestamp; expiry is checked against it.
+
+#### `is_verification_active(github_username: String) -> bool`
+
+Read-only; no auth; works while paused. The effective, expiry-aware status:
+`true` only if the username is registered, `verified`, and — when
+verification was configured with a non-zero `expires_in` — that window has
+not lapsed. This differs from `get_address(..).verified` exactly when a
+verification is raw-`true` but expired: the raw flag stays `true` (expiry is
+lazy — see below), this reads `false`.
+
+#### `get_verification_expiry(github_username: String) -> Option<u64>`
+
+Read-only; no auth. The ledger timestamp the username's current verification
+will expire at, or `None` if it cannot expire (never verified, verification
+not configured, `expires_in == 0`, or revoked).
+
+**Lazy expiry, and what it means for `verify` / `revoke_verification` /
+`get_stats`:**
+
+- `ContributorRecord.verified` is **not** flipped back to `false` in storage
+  when the window lapses — only `revoke_verification` does that. Reads that
+  need the effective status call `is_verification_active`, not the raw flag.
+- `verify` on an expired-but-not-revoked username **renews** it (fresh
+  timestamp) instead of returning `AlreadyVerified` — a verification that is
+  still active is unaffected and still rejects a duplicate call.
+- `revoke_verification` is unaffected by expiry: it acts on the raw
+  `verified` flag regardless of whether it has also expired, and clears the
+  verification timestamp either way.
+- **Stats definition:** `get_stats().verified` / `get_verified_count()` count
+  the raw `verified` flag, the same as before this issue — they do **not**
+  subtract expired-but-unrevoked verifications. This keeps the counter an
+  O(1) read instead of a full-registry scan on every call. Use
+  `is_verification_active` for the per-record effective answer; there is no
+  aggregate "currently active" counter.
+
+### Signed export attestation (Issue #223)
+
+#### `export_attestation(cursor: u32, limit: u32) -> Result<ExportAttestation, ContractError>`
+
+Admin-only; unaffected by the normal pause flag (same as
+`get_registered_paginated` / `get_all_registered` — admin export tooling
+stays available during maintenance). Wraps the same page
+`get_registered_paginated(cursor, limit)` would return with a SHA-256 digest,
+the contract's schema version, and the ledger sequence — see the
+`ExportAttestation` type above and
+[ADMIN_RUNBOOK.md](./ADMIN_RUNBOOK.md#signed-export-attestation-issue-223)
+for the offline verification workflow. An empty registry produces an empty
+page and a real (deterministic) digest over it, not an error.
+
+### Dual-control `batch_remove` (Issue #219)
+
+#### `set_batch_remove_threshold(threshold: u32) -> Result<(), ContractError>`
+
+Admin-only. `0` (default) disables dual control — `batch_remove` always
+executes directly, exactly as before this issue. A non-zero value requires
+any batch **larger** than it (strictly greater — a batch exactly at the
+threshold is unaffected) to go through `propose_batch_remove` /
+`execute_batch_remove` instead.
+
+#### `get_batch_remove_threshold() -> u32`
+
+Read-only; no auth.
+
+#### `propose_batch_remove(caller: Address, usernames: Vec<String>) -> Result<(), ContractError>`
+
+Admin-only. Records the batch and proposer for later execution by a
+*different* admin-equivalent address. Only one proposal may be pending;
+returns `BatchRemoveProposalPending` if one already is (unless it has
+expired — see below). Emits `BatchRemoveProposedEvent`.
+
+#### `execute_batch_remove(caller: Address) -> Result<BatchSummary, ContractError>`
+
+`caller` must be the contract admin or hold `Role::Admin`, **and** must not
+be the address that proposed the batch — this is what makes it dual
+control. Performs the removals with the same partial-success semantics as
+`batch_remove`. A proposal older than `BATCH_REMOVE_PROPOSAL_TTL_SECS`
+(24h) is treated as gone (`NoPendingBatchRemove`) rather than executed.
+Emits `BatchRemoveExecutedEvent` plus one `RemovedEvent` per removed
+username.
+
+#### `cancel_batch_remove(caller: Address) -> Result<(), ContractError>`
+
+Admin-only. Discards the pending proposal without executing it. Available
+even while paused — see
+[SECURITY.md](./SECURITY.md#dual-control-batch_remove-issue-219). Emits
+`BatchRemoveCancelledEvent`.
+
+#### `get_pending_batch_remove() -> Option<PendingBatchRemove>`
+
+Read-only; no auth; works while paused.
+
+**batch_remove itself:** now returns `DualControlRequired` (code 30) if
+`usernames.len()` exceeds the configured threshold, instead of executing —
+below the threshold, or with the default threshold of `0`, `batch_remove`'s
+behavior is completely unchanged.

--- a/docs/ADMIN_RUNBOOK.md
+++ b/docs/ADMIN_RUNBOOK.md
@@ -200,3 +200,198 @@ Use this when freezing writes during an active Wave.
 	or `get_address`) to confirm normal behavior is restored.
 8. Post-incident note: include window duration, impacted functions, and
 	follow-up actions.
+
+---
+
+## Role Expiry (Issue #221)
+
+Off-boarded contractor and bot keys should not linger as live `Verifier` /
+`Revoker` holders forever. `set_role` still grants a role with no expiry
+(unchanged); `set_role_with_expiry` grants a time-bounded one.
+
+```bash
+# Grant a contractor Verifier access that lapses in 30 days
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source-account admin-identity \
+  --network testnet \
+  --send=yes \
+  -- set_role_with_expiry --target $CONTRACTOR --role 3 --expires_at $(($(date +%s) + 2592000))
+```
+
+- Check what is set: `get_role_expiry --address $CONTRACTOR` — `None` means
+  no expiry (or no role at all); `Some(T)` may already be in the past.
+- Expiry is **lazy**. The role entry is not deleted when the clock passes
+  `expires_at` — `get_role` (and every check built on it) just stops
+  reporting it. Run `remove_role` afterward if you want the storage entry
+  itself gone and the address dropped from `get_role_holders`.
+- The contract admin's own identity is never affected by this. Only the
+  RBAC-style `Role::Admin` grant (the one `initialize` sets alongside
+  `ADMIN_KEY`) can expire, and only if you explicitly grant it with
+  `set_role_with_expiry` — routine admin auth (`has_admin_role`,
+  `get_admin`) reads a separate, immutable storage slot.
+- Operational habit: when off-boarding a contractor or rotating a bot key,
+  prefer `set_role_with_expiry` with a known end date over remembering to
+  call `remove_role` manually later.
+
+---
+
+## Time-Bounded Verification (Issue #218)
+
+A stolen or transferred GitHub account should not stay `verified` forever.
+`config_verification`'s `expires_in` (seconds, one-time set) now drives an
+actual expiry, checked against each username's last `verify()` timestamp.
+
+- **Check effective status**: `is_verification_active --github-username
+  octocat` — this is expiry-aware. `get_address --github-username octocat`
+  returns the raw `ContributorRecord.verified` flag, which stays `true`
+  after expiry until someone calls `revoke_verification` (lazy expiry — see
+  [ABI.md](./ABI.md#time-bounded-verification-issue-218)). Payout and
+  dashboard integrations should call `is_verification_active`, not read the
+  raw flag, if `config_verification` has been used.
+- **Renewal is automatic on re-verify**: calling `verify` again on a
+  username whose prior verification has expired succeeds and refreshes the
+  timestamp — it does not require an explicit `revoke_verification` first.
+  A still-active verification is unaffected and still rejects a duplicate
+  `verify` call with `AlreadyVerified`.
+- **`get_stats` / `get_verified_count` are not expiry-aware** by design —
+  they count the raw `verified` flag, not `is_verification_active`, so they
+  stay an O(1) read. An operator watching for stale-but-unrevoked
+  verifications should page through the registry and call
+  `is_verification_active` per record, or track `get_verification_expiry`
+  off-chain.
+- If `config_verification` was never called, or was called with
+  `expires_in = 0`, nothing in this section applies — verification behaves
+  exactly as before this issue.
+
+---
+
+## Signed Export Attestation (Issue #223)
+
+`export_registry.sh` produces a JSON page with no on-chain binding — a
+compromised or careless export step could hand an auditor stale or edited
+data with no way to detect it. `export_attestation(cursor, limit)` is the
+admin-only companion read that binds the same page to a digest.
+
+### Workflow for an air-gapped audit
+
+1. **Online, admin-authenticated machine:** call `export_attestation` for
+   each page (same `cursor`/`limit` loop as `export_registry.sh` already
+   does against `get_registered_paginated`) and save both the page JSON and
+   the returned `digest` / `version` / `ledger`.
+
+   ```bash
+   stellar contract invoke \
+     --id $CONTRACT_ID \
+     --source-account admin-identity \
+     --network testnet \
+     -- export_attestation --cursor 0 --limit 100
+   ```
+
+2. **Transfer** the saved output to the air-gapped machine by any channel —
+   USB, printed QR, whatever the audit's threat model requires. There is
+   nothing further to fetch from the network.
+
+3. **Offline, on the air-gapped machine:** recompute the SHA-256 digest over
+   the page's XDR encoding exactly as `export_attestation` does (see
+   `storage::build_export_digest` in `src/storage.rs` for the reference
+   implementation) and compare byte for byte against the saved `digest`. A
+   mismatch means the JSON the auditor is holding does not match what the
+   contract actually returned for that `cursor`/`limit` at `ledger`.
+
+### What this is not
+
+- **Not a threshold signature.** The digest is bound to the admin's
+  authenticated read, not counter-signed by a quorum. Out of scope for
+  Issue #223 by design.
+- **Not a Merkle proof over the whole registry.** Each attestation covers
+  one page; there is no root committing to every page at once. A
+  registry-wide Merkle root can complement this later (Issue #27) without
+  changing this function's shape.
+- **Does not weaken the existing admin gate.** `export_attestation`,
+  `get_registered_paginated`, and `get_all_registered` all still require
+  admin auth — this issue only adds a binding on top of that export, it
+  does not add a new unauthenticated way to read the registry.
+- **An empty registry is not an error.** `page.records` is empty and
+  `digest` is still a real, deterministic hash over that empty page —
+  useful as a baseline attestation for a freshly deployed instance.
+
+---
+
+## Dual-Control `batch_remove` (Issue #219)
+
+A single admin signature could previously delete up to `MAX_WRITE_BATCH`
+(25) registrations in one call. Above a configurable size threshold, that is
+no longer enough — the batch must be proposed by one admin-equivalent
+address and executed by a **different** one.
+
+### 1. Configure the threshold
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source-account admin-identity \
+  --network testnet \
+  --send=yes \
+  -- set_batch_remove_threshold --threshold 10
+```
+
+`0` (the default) disables dual control entirely — every `batch_remove` call
+executes directly regardless of size, identical to pre-#219 behavior. With a
+threshold set, any batch **larger** than it (strictly greater; a batch
+exactly at the threshold is unaffected) is rejected by `batch_remove` itself
+with `DualControlRequired` and must go through the propose/execute flow
+below.
+
+### 2. Provision a second key *before* you need it
+
+`execute_batch_remove` requires a caller that is the contract admin or holds
+`Role::Admin`, and is a **different** address than whoever proposed the
+batch. If the only admin-equivalent address is the contract admin itself,
+a large batch can be proposed but never executed — grant `Role::Admin` to a
+second, independently held key ahead of time:
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source-account admin-identity \
+  --network testnet \
+  --send=yes \
+  -- set_role --target $SECOND_KEY --role 1
+```
+
+This is a deliberate design choice, not a bug: dual control that degraded
+back to single-key execution whenever the second key was missing would not
+be dual control. `cancel_batch_remove` remains available to abort a stuck
+proposal — see [SECURITY.md](./SECURITY.md#dual-control-batch_remove-issue-219)
+for the full threat-model note.
+
+### 3. Propose, then execute from a different key
+
+```bash
+# Admin proposes
+stellar contract invoke \
+  --id $CONTRACT_ID --source-account admin-identity --network testnet --send=yes \
+  -- propose_batch_remove --caller $ADMIN --usernames '["squatter1","squatter2", ...]'
+
+# A DIFFERENT Role::Admin holder executes
+stellar contract invoke \
+  --id $CONTRACT_ID --source-account second-key-identity --network testnet --send=yes \
+  -- execute_batch_remove --caller $SECOND_KEY
+```
+
+`get_pending_batch_remove` shows what is queued (works while paused). A
+proposal not executed within 24 hours (`BATCH_REMOVE_PROPOSAL_TTL_SECS`) is
+treated as gone the next time anyone calls `execute_batch_remove` — propose
+again if you still need it removed.
+
+### 4. Abort instead
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID --source-account admin-identity --network testnet --send=yes \
+  -- cancel_batch_remove --caller $ADMIN
+```
+
+Available even while paused, so a stuck or mistaken proposal is never
+trapped behind the same freeze that might be the reason to cancel it.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -26,6 +26,10 @@ Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [DEPL
 | Compromised or unpinned RPC client dependency | Crate validation checklist below |
 | Compromised Verifier key silently revoking payout eligibility | `Role::Verifier` and `Role::Revoker` are distinct — Issue #212 |
 | Admin force-removing a name without a grace period | Challenge flow enforces on-chain `resolve_after` delay — Issue #214 |
+| Off-boarded contractor or bot key lingering as a live `Verifier`/`Revoker` forever | Optional per-grant expiry via `set_role_with_expiry`, checked lazily by `get_role` — see [Role Expiry](#role-expiry-issue-221) |
+| Stolen or transferred GitHub account staying `verified` (and payout-eligible) indefinitely | `config_verification`'s `expires_in` now drives an actual expiry, checked via `is_verification_active` — see [Time-Bounded Verification](#time-bounded-verification-issue-218) |
+| Single compromised admin key wiping a large slice of the registry in one `batch_remove` call | Above a configurable size threshold, `batch_remove` requires a second, distinct admin-equivalent signature — see [Dual-Control batch_remove](#dual-control-batch_remove-issue-219) |
+| Auditor trusting an unbound, unsigned `export_registry.sh` JSON dump | `export_attestation` binds a page to a SHA-256 digest, version, and ledger for offline comparison — see [Signed Export Attestation](#signed-export-attestation-issue-223) |
 
 ### Out of Scope (handled off-chain)
 
@@ -559,6 +563,193 @@ The `verify` function additionally guards against illegal state transitions:
 The `revoke_verification` function guards:
 - Revoking from an unregistered username → `NotRegistered` (code 4)
 - Revoking from a username that was never verified → `NotVerified` (code 6)
+
+---
+
+## Role Expiry (Issue #221)
+
+Contractors and bots that held `Role::Verifier` or `Role::Revoker` used to
+keep that access forever unless someone remembered to call `remove_role`. An
+off-boarded key that nobody thought to revoke could go on verifying (or
+revoking) payout eligibility indefinitely.
+
+`set_role_with_expiry(target, role, expires_at: Option<u64>)` grants a
+role that lapses once `env.ledger().timestamp() >= expires_at`. `set_role`
+is unchanged and still grants a role with no expiry — expiry is strictly
+opt-in.
+
+**Lazy expiry.** The `(role, expires_at)` entries are not deleted when the
+clock passes `expires_at`. Every role check in the contract —
+`get_role`, and therefore `verify`, `revoke_verification`, `batch_verify`,
+`get_role_holders`, `has_role_or_admin`, and `execute_batch_remove`'s
+second-signer check — reads through a single function
+(`storage::get_role`) that treats an expired grant as absent. This means a
+lapsed grant behaves as "no role" everywhere with no per-call-site change
+required, but the storage entry itself (and the address's slot in the
+enumeration index) persists until an explicit `remove_role`. Operators who
+want the entry actually deleted, not just ignored, still need to call
+`remove_role` — expiry answers "can this address still act as this role
+right now", not "has this contract forgotten this address ever held one."
+
+**Boundary:** `expires_at` is checked with `>=`, so a grant expires exactly
+at its timestamp, not one ledger after. `set_role_with_expiry` accepts an
+`expires_at` in the past or exactly equal to "now" — the grant is recorded
+but reads as already expired the instant the call returns. This is a
+deliberate simplification: no separate validation error, and no special
+case for a boundary an operator is unlikely to construct on purpose.
+
+**The admin identity is never affected.** `is_admin_caller` / `get_admin`
+read `ADMIN_KEY`, a separate, immutable storage slot set once by
+`initialize` and never touched by `set_role_with_expiry`. Only the
+RBAC-style `Role::Admin` grant — the one `initialize` sets alongside
+`ADMIN_KEY` through the same `set_role` path everyone else's roles go
+through — can be given an expiry, and only if a caller explicitly does so
+with `set_role_with_expiry`. This satisfies the constraint that this
+feature must not be able to expire the admin's authority "by accident."
+
+---
+
+## Time-Bounded Verification (Issue #218)
+
+A `verified` flag that stays true forever is a standing liability: a GitHub
+account can be phished or transferred after the contract already marked its
+Stellar address as verified, and nothing on-chain would notice.
+`config_verification`'s `expires_in` parameter existed before this issue but
+was stored and never read — this wires it into an actual check.
+
+**Clock:** the ledger timestamp (`env.ledger().timestamp()`), the same clock
+every other time-based policy in this contract uses (cooldowns, challenge
+delays, admin-transfer delay, role expiry above).
+
+**Lazy expiry, mirroring Role Expiry above.** `verify` records a
+verification timestamp; `ContributorRecord.verified` itself is **not**
+flipped back to `false` when the configured window lapses — only
+`revoke_verification` does that. `is_verification_active(github_username)`
+is the effective, expiry-aware read; `get_address(..).verified` remains the
+raw flag and stays `true` past expiry until revoked. Off-chain consumers
+that gate payouts on verification status **must** call
+`is_verification_active`, not read the raw flag, once `config_verification`
+has been used with a non-zero `expires_in`.
+
+**Expired, but not revoked, is an explicit and supported state.** A record
+can sit with `verified == true` (raw) and `is_verification_active == false`
+(effective) indefinitely if nobody calls `verify` or `revoke_verification`
+on it. This is intentional — lazy expiry means the contract does not spend
+gas eagerly walking the registry to flip flags nobody asked about, and any
+reader that cares checks `is_verification_active` directly.
+
+**`verify` renews instead of rejecting.** Calling `verify` on a username
+whose prior verification has expired succeeds and records a fresh
+timestamp, rather than returning `AlreadyVerified`. A verification that is
+still active is unaffected: a duplicate `verify` call against it still
+returns `AlreadyVerified`, exactly as before this issue.
+
+**Stats definition (`get_stats` / `get_verified_count`):** both count the
+raw `ContributorRecord.verified` flag, unchanged from before this issue.
+They are **not** expiry-aware and do not decrement when a verification
+expires without being revoked — only `revoke_verification` moves them. This
+is a deliberate O(1)-counter tradeoff: making the aggregate count
+expiry-aware would require scanning every record on every `get_stats` call.
+Callers needing the effective count must page the registry and check
+`is_verification_active` per record.
+
+---
+
+## Dual-Control `batch_remove` (Issue #219)
+
+`batch_remove` is a single admin signature that can delete up to
+`MAX_WRITE_BATCH` (25) registrations in one invocation — a wave treasury or
+large cleanup operation is one compromised or careless admin key away from a
+significant, instant loss of registry state. Above a configurable size
+threshold, a second, independently held key is now required.
+
+**Threshold semantics.** `set_batch_remove_threshold(n)` (admin-only). `n =
+0` (the default) disables dual control entirely: `batch_remove` behaves
+exactly as it did before this issue, for any batch size up to
+`MAX_WRITE_BATCH`. With `n > 0`, a batch with `usernames.len() > n` (strictly
+greater — a batch exactly at the threshold is unaffected) is rejected by
+`batch_remove` itself with `DualControlRequired`; it must go through
+`propose_batch_remove` → `execute_batch_remove`.
+
+**The two keys must be different.** `propose_batch_remove(caller, ...)`
+requires `caller == admin`, same as `batch_remove` today.
+`execute_batch_remove(caller)` requires `caller` to be the admin or hold
+`Role::Admin`, **and** requires `caller != proposal.proposed_by`. Neither
+signature alone can remove a large batch — one proposes, a distinct one
+executes.
+
+**"Do not deadlock if the second key is the same as the first" — addressed
+by documentation, not by code that silently falls back to single-key
+execution.** If an operator sets a non-zero threshold without first
+provisioning a second `Role::Admin` holder distinct from the contract
+admin, a large batch can be *proposed* but never *executed* — that is
+correct dual-control behavior, not a bug, and relaxing it (e.g. letting the
+proposer also execute when no second key exists) would defeat the point of
+this issue. The documented mitigation:
+
+- Provision a second `Role::Admin` address **before** relying on this — see
+  [ADMIN_RUNBOOK.md](./ADMIN_RUNBOOK.md#dual-control-batch_remove-issue-219).
+- `cancel_batch_remove` is always available (including while paused) to
+  discard a proposal that cannot currently be executed, so an operator is
+  never permanently stuck with an un-cancellable pending removal.
+- Alternatively, lower or zero the threshold (`set_batch_remove_threshold`)
+  to fall back to direct single-admin `batch_remove` for smaller cleanups.
+
+**Proposal expiry.** A pending proposal older than
+`BATCH_REMOVE_PROPOSAL_TTL_SECS` (24 hours) is treated as gone the next time
+`execute_batch_remove` is called — the storage slot is cleared and the call
+returns `NoPendingBatchRemove`. This bounds how long a stale username list
+remains executable; the operational context that justified it (e.g. a
+specific dispute list) may no longer hold weeks later.
+
+**Partial-success semantics are unchanged.** `execute_batch_remove` shares
+the exact same per-entry removal logic as `batch_remove` — one bad entry
+(already removed, never registered) does not block the rest, and the
+returned `BatchSummary` reports the real outcome.
+
+---
+
+## Signed Export Attestation (Issue #223)
+
+`export_registry.sh` produces a JSON page with no on-chain binding: an
+auditor working from a copy of that file has to trust that nobody tampered
+with it between export and review, with nothing to check that trust
+against. `export_attestation(cursor, limit)` gives an auditor a value bound
+to a specific ledger and contract version that they can verify offline.
+
+**What it does.** Returns the same `ExportPage` `get_registered_paginated`
+would for identical `cursor`/`limit`, plus a SHA-256 digest computed over
+that page's XDR encoding, the contract's schema version, and the ledger
+sequence the read happened at. XDR encoding of a fixed value is
+deterministic, so unchanged state reproduces the same digest on every call,
+and any change to a record, the total, or the pagination cursor changes it
+— this is what "digest stability" means for this feature and is what the
+unit tests in `src/lib.rs` (search `export_attestation`) assert directly,
+rather than pinning a specific hash value.
+
+**Auth is unchanged, not weakened.** `export_attestation` requires admin
+auth via `admin.require_auth()`, exactly like `get_registered_paginated` and
+`get_all_registered`. This issue adds a binding on top of an existing
+admin-gated export; it does not introduce a new, more permissive way to
+read the registry.
+
+**Paused behavior matches the existing admin-export pattern.**
+`export_attestation` does not call `require_not_paused` — like
+`get_registered_paginated` / `get_all_registered`, it stays available to
+the admin during a maintenance window so audit and export tooling is not
+blocked by the same pause that might be the reason for the audit.
+
+**Empty registry.** A fresh or fully-emptied instance is not a special
+case: `page.records` is empty, `page.total` is `0`, and `digest` is still a
+real, deterministic hash over that empty page — usable as a baseline
+attestation, e.g. immediately after deployment.
+
+**Explicitly out of scope for this issue** (see the issue's own Scope
+section): threshold/multi-party signatures over the digest, and a Merkle
+root committing to the *entire* registry across all pages. Both are
+possible future work — a registry-wide Merkle root in particular could
+complement this per Issue #27 — but neither is part of this attestation
+struct.
 
 ---
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,6 +96,16 @@ pub enum ContractError {
     NoPendingAdminTransfer = 28,
     /// `upgrade` was called without a required attestation (attestation-required mode is on).
     AttestationRequired = 29,
+    /// `batch_remove` was called with a batch larger than the configured
+    /// dual-control threshold; use `propose_batch_remove` /
+    /// `execute_batch_remove` instead (Issue #219).
+    DualControlRequired = 30,
+    /// `propose_batch_remove` was called while a proposal is already pending.
+    /// Cancel it with `cancel_batch_remove` first (Issue #219).
+    BatchRemoveProposalPending = 31,
+    /// `execute_batch_remove` or `cancel_batch_remove` was called with no
+    /// pending proposal (or a proposal that has expired) (Issue #219).
+    NoPendingBatchRemove = 32,
 }
 
 impl ContractError {
@@ -140,6 +150,9 @@ impl ContractError {
             27 => Some(ContractError::AdminTransferDelayActive),
             28 => Some(ContractError::NoPendingAdminTransfer),
             29 => Some(ContractError::AttestationRequired),
+            30 => Some(ContractError::DualControlRequired),
+            31 => Some(ContractError::BatchRemoveProposalPending),
+            32 => Some(ContractError::NoPendingBatchRemove),
             _ => None,
         }
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -123,6 +123,54 @@ pub struct RoleRevokedEvent {
     pub domain: EventDomain,
 }
 
+/// Emitted when a large `batch_remove` is proposed for dual-control execution
+/// (Issue #219).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatchRemoveProposedEvent {
+    #[topic]
+    pub proposed_by: Address,
+    /// Number of usernames in the proposed batch.
+    pub count: u32,
+    pub timestamp: u64,
+    /// Deployment that emitted this event — contract id, network, and
+    /// contract version. See [`EventDomain`] for why indexers need it.
+    pub domain: EventDomain,
+}
+
+/// Emitted when a pending large `batch_remove` proposal is executed by a
+/// second, distinct address (Issue #219).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatchRemoveExecutedEvent {
+    #[topic]
+    pub executed_by: Address,
+    pub proposed_by: Address,
+    /// Number of usernames in the executed batch.
+    pub count: u32,
+    /// Number of usernames actually removed (partial-success semantics
+    /// match `batch_remove`'s own `BatchSummary`).
+    pub successful: u32,
+    pub timestamp: u64,
+    /// Deployment that emitted this event — contract id, network, and
+    /// contract version. See [`EventDomain`] for why indexers need it.
+    pub domain: EventDomain,
+}
+
+/// Emitted when a pending large `batch_remove` proposal is cancelled without
+/// executing (Issue #219).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatchRemoveCancelledEvent {
+    #[topic]
+    pub cancelled_by: Address,
+    pub proposed_by: Address,
+    pub timestamp: u64,
+    /// Deployment that emitted this event — contract id, network, and
+    /// contract version. See [`EventDomain`] for why indexers need it.
+    pub domain: EventDomain,
+}
+
 /// Emitted when an admin starts a challenge on a squatted username (Issue #214).
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,15 +27,17 @@ pub use error::ContractError;
 pub use events::{RegisteredEvent, RemovedEvent, VerifiedEvent};
 pub use storage::{ContributorRecord, EntityType, Stats};
 pub use events::{
-    AttestationClearedEvent, ChallengeCancelledEvent, ChallengeCompletedEvent, RenamedEvent,
+    AttestationClearedEvent, BatchRemoveCancelledEvent, BatchRemoveExecutedEvent,
+    BatchRemoveProposedEvent, ChallengeCancelledEvent, ChallengeCompletedEvent, RenamedEvent,
     RotationCancelledEvent, RotationExecutedEvent, RotationRequestedEvent,
     ChallengeStartedEvent, EmergencyClearedEvent, EmergencyPausedEvent, PausedEvent,
     RegisteredEvent, RemovedEvent, RoleGrantedEvent, RoleRevokedEvent, UnpausedEvent,
     UpgradeAttestedEvent, UpgradedEvent, VerificationRevokedEvent, VerifiedEvent,
 };
 pub use storage::{
-    ChallengeRecord, ContributorRecord, ExportPage, HealthSnapshot, Role, Stats,
-    VerificationConfig, WasmAttestation, WasmProvenance, PauseReason,
+    ChallengeRecord, ContributorRecord, ExportAttestation, ExportPage, HealthSnapshot,
+    PendingBatchRemove, Role, Stats, VerificationConfig, WasmAttestation, WasmProvenance,
+    PauseReason,
 };
 pub use version::Version;
 
@@ -509,7 +511,7 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Assigns a role to `target`. Admin-only.
+    /// Assigns a role to `target` with no expiry. Admin-only.
     ///
     /// Roles gate access to privileged operations:
     ///
@@ -518,6 +520,11 @@ impl TrustBridgeContract {
     /// | `Admin` | Everything |
     /// | `Upgrader` | Call `upgrade` |
     /// | `Verifier` | Call `verify` and `revoke_verification` |
+    ///
+    /// A grant made here never lapses on its own — see `set_role_with_expiry`
+    /// (Issue #221) for a time-bounded grant, e.g. for a contractor or bot
+    /// key that should stop verifying after a known off-boarding date without
+    /// requiring anyone to remember to call `remove_role`.
     ///
     /// Emits [`RoleGrantedEvent`].
     ///
@@ -555,7 +562,10 @@ impl TrustBridgeContract {
     ///
     /// After this call `get_role(target)` returns `None`. Does not affect the
     /// admin's own role — the admin address is stored separately and cannot be
-    /// stripped via `remove_role`.
+    /// stripped via `remove_role`. Also clears any expiry timestamp set via
+    /// `set_role_with_expiry` (Issue #221) — this is the only way to actually
+    /// delete a role's storage entries; letting a time-bounded grant simply
+    /// lapse leaves it in storage, just no longer reported by `get_role`.
     ///
     /// Emits [`RoleRevokedEvent`].
     ///
@@ -588,13 +598,102 @@ impl TrustBridgeContract {
         Ok(())
     }
 
-    /// Returns the role assigned to `address`, or `None` if no role is assigned.
+    /// Returns the role currently assigned to `address`, or `None` if no role
+    /// is assigned **or its grant has expired** (Issue #221).
     ///
-    /// Read-only; no auth required. Returns `None` for any address that has never
-    /// been granted a role (including the admin address, which is stored separately).
+    /// Read-only; no auth required. Returns `None` for any address that has
+    /// never been granted a role (including the admin address, which is
+    /// stored separately). Expiry is lazy: an expired grant's storage entry
+    /// is left in place — `get_role` just stops reporting it as held. Use
+    /// `get_role_expiry` to see the raw expiry timestamp, including for an
+    /// address whose grant has already lapsed.
     #[must_use]
     pub fn get_role(env: Env, address: Address) -> Option<Role> {
         storage_get_role(&env, &address)
+    }
+
+    /// Returns `true` if `address` currently holds `role` — i.e. `get_role`
+    /// would return `Some(role)` (Issue #221). Expired grants read as not
+    /// held, the same as if `address` had never been granted a role.
+    ///
+    /// Read-only; no auth required.
+    #[must_use]
+    pub fn has_role(env: Env, address: Address, role: Role) -> bool {
+        storage_get_role(&env, &address) == Some(role)
+    }
+
+    /// The expiry timestamp for `address`'s current role grant, or `None` if
+    /// it was granted with no expiry, or if `address` holds no `ROLE_KEY`
+    /// entry at all (Issue #221).
+    ///
+    /// Unlike `get_role`, this does **not** hide an already-lapsed expiry —
+    /// it is the raw stored timestamp, so an operator auditing off-boarded
+    /// keys can distinguish "never expires" (`None`) from "expired at T"
+    /// (`Some(T)` where `T` is in the past) without waiting for `remove_role`
+    /// to run.
+    ///
+    /// Read-only; no auth required.
+    #[must_use]
+    pub fn get_role_expiry(env: Env, address: Address) -> Option<u64> {
+        crate::storage::get_role_expiry(&env, &address)
+    }
+
+    /// Assigns a role to `target` with an optional expiry timestamp
+    /// (Issue #221). Admin-only.
+    ///
+    /// Identical to `set_role`, except the grant can be time-bounded: once
+    /// `env.ledger().timestamp() >= expires_at`, `get_role(target)` returns
+    /// `None` — and every role check built on it (`verify`,
+    /// `revoke_verification`, `batch_verify`, `get_role_holders`,
+    /// `has_role_or_admin`) treats `target` as holding no role at all, with
+    /// no further changes needed at those call sites. `set_role(target,
+    /// role)` remains available and is exactly `set_role_with_expiry(target,
+    /// role, None)` — a grant that never expires.
+    ///
+    /// This is intentionally the **only** path that can expire a role
+    /// assignment. It never touches `ADMIN_KEY`: the contract admin's
+    /// identity (`has_admin_role`, `get_admin`) is a separate, immutable
+    /// storage slot, so granting `Role::Admin` here with an expiry only
+    /// affects RBAC-style role checks, never who the admin is.
+    ///
+    /// Expiry is lazy — see `get_role` and `docs/SECURITY.md` for what that
+    /// means for `get_role_holders` and storage cleanup.
+    ///
+    /// Emits [`RoleGrantedEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
+    pub fn set_role_with_expiry(
+        env: Env,
+        target: Address,
+        role: Role,
+        expires_at: Option<u64>,
+    ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        crate::storage::set_role_with_expiry(&env, &target, &role, expires_at);
+        let timestamp = env.ledger().timestamp();
+        RoleGrantedEvent {
+            address: target,
+            role: role as u32,
+            admin,
+            timestamp,
+            domain: event_domain(&env),
+        }
+        .publish(&env);
+
+        Ok(())
     }
 
     /// Lists addresses that currently hold a role, as `(address, role)` pairs
@@ -1099,6 +1198,56 @@ impl TrustBridgeContract {
         get_verification_config(&env)
     }
 
+    /// Returns `true` if `github_username` is verified **and that
+    /// verification has not expired** (Issue #218).
+    ///
+    /// This is the effective, expiry-aware status — the read to use when
+    /// deciding payout eligibility. It differs from
+    /// `get_address(github_username).map(|r| r.verified)` in one case: a
+    /// record whose `verified` flag is still raw-`true` but whose
+    /// `config_verification`-configured window has lapsed. That case reads
+    /// `true` from the raw flag but `false` here.
+    ///
+    /// `false` for an unregistered username, a never-verified one, or one
+    /// whose verification has expired. `true` for a verified username when
+    /// verification was never configured, or configured with
+    /// `expires_in == 0` (no expiry) — expiry only ever narrows `verified`,
+    /// it never widens it.
+    ///
+    /// Read-only; no auth required; works while paused.
+    #[must_use]
+    pub fn is_verification_active(env: Env, github_username: String) -> bool {
+        match get_record(&env, &github_username) {
+            Some(record) if record.verified => {
+                !crate::storage::is_verification_expired(&env, &github_username)
+            }
+            _ => false,
+        }
+    }
+
+    /// Returns the ledger timestamp at which `github_username`'s **current**
+    /// verification will expire, or `None` if it cannot expire — never
+    /// verified, verification not configured, configured with
+    /// `expires_in == 0`, or already revoked (Issue #218).
+    ///
+    /// Does not check whether that timestamp is already in the past — pair
+    /// this with `is_verification_active` for the effective yes/no answer.
+    ///
+    /// Read-only; no auth required.
+    #[must_use]
+    pub fn get_verification_expiry(env: Env, github_username: String) -> Option<u64> {
+        let record = get_record(&env, &github_username)?;
+        if !record.verified {
+            return None;
+        }
+        let config = get_verification_config(&env)?;
+        if config.expires_in == 0 {
+            return None;
+        }
+        let verified_at = crate::storage::get_verified_at(&env, &github_username)?;
+        Some(verified_at.saturating_add(config.expires_in))
+    }
+
     /// Returns stored audit log entries for operator compliance and inspection.
     #[must_use]
     pub fn get_audit_logs(env: Env) -> Vec<AuditLogEntry> {
@@ -1511,6 +1660,10 @@ impl TrustBridgeContract {
     /// - [`ContractError::Paused`] if the contract is paused.
     /// - [`ContractError::InvalidBatchSize`] if `usernames` is empty or exceeds
     ///   the configured maximum batch size.
+    /// - [`ContractError::DualControlRequired`] if `usernames.len()` exceeds
+    ///   the configured dual-control threshold (Issue #219, `0` by default,
+    ///   which disables this check) — use `propose_batch_remove` /
+    ///   `execute_batch_remove` for a batch this size instead.
     ///
     /// # Per-entry outcomes (counted in BatchSummary)
     ///
@@ -1541,6 +1694,254 @@ impl TrustBridgeContract {
             return Err(ContractError::NotAuthorized);
         }
 
+        // Issue #219: above the configured threshold, a single admin
+        // signature is not enough — route through propose/execute instead.
+        if crate::storage::requires_batch_remove_dual_control(&env, usernames.len()) {
+            return Err(ContractError::DualControlRequired);
+        }
+
+        let summary = Self::apply_batch_remove(&env, &caller, &usernames);
+        Ok(summary)
+    }
+
+    /// Proposes a large `batch_remove` for dual-control execution
+    /// (Issue #219). First of the two steps required once `usernames.len()`
+    /// exceeds the configured threshold (`set_batch_remove_threshold`) —
+    /// `batch_remove` itself refuses a batch that size with
+    /// `DualControlRequired`.
+    ///
+    /// Records the exact username list and who proposed it. A **different**
+    /// admin-equivalent address must call `execute_batch_remove` to actually
+    /// remove them — one signature alone can never delete a large batch.
+    ///
+    /// Only one proposal may be pending at a time; call `cancel_batch_remove`
+    /// first to replace one. A proposal not executed within
+    /// `BATCH_REMOVE_PROPOSAL_TTL_SECS` (24 hours) is treated as gone the
+    /// next time anyone calls `execute_batch_remove`.
+    ///
+    /// Emits [`BatchRemoveProposedEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::InvalidBatchSize`] if `usernames` is empty or exceeds
+    ///   the configured maximum batch size.
+    /// - [`ContractError::NotAuthorized`] if `caller` is not the contract admin.
+    /// - [`ContractError::BatchRemoveProposalPending`] if a proposal is
+    ///   already pending.
+    pub fn propose_batch_remove(
+        env: Env,
+        caller: Address,
+        usernames: Vec<String>,
+    ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+
+        let config = BatchConfig::for_writes();
+        if !config.is_valid_batch_size(usernames.len()) {
+            return Err(ContractError::InvalidBatchSize);
+        }
+
+        caller.require_auth();
+
+        let admin = get_admin(&env)?;
+        if caller != admin {
+            return Err(ContractError::NotAuthorized);
+        }
+
+        if let Some(existing) = crate::storage::get_pending_batch_remove(&env) {
+            if !crate::storage::is_batch_remove_proposal_expired(&env, &existing) {
+                return Err(ContractError::BatchRemoveProposalPending);
+            }
+        }
+
+        let timestamp = env.ledger().timestamp();
+        let count = usernames.len();
+        crate::storage::set_pending_batch_remove(
+            &env,
+            &PendingBatchRemove {
+                usernames,
+                proposed_by: caller.clone(),
+                proposed_at: timestamp,
+            },
+        );
+
+        BatchRemoveProposedEvent {
+            proposed_by: caller,
+            count,
+            timestamp,
+            domain: event_domain(&env),
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Executes the pending large `batch_remove` proposal. Second step of
+    /// dual control (Issue #219).
+    ///
+    /// `caller` must be a **different** address than whoever proposed the
+    /// batch, and must itself be admin-equivalent — the contract admin or
+    /// any address currently holding `Role::Admin` (see `set_role`). This is
+    /// what makes the control "dual": neither address alone can remove the
+    /// batch. An operator relying on this must provision at least one
+    /// `Role::Admin` holder distinct from the contract admin ahead of time —
+    /// see `docs/SECURITY.md#dual-control-batch_remove-issue-219`.
+    ///
+    /// A proposal older than `BATCH_REMOVE_PROPOSAL_TTL_SECS` is treated as
+    /// gone (cleared, `NoPendingBatchRemove`) rather than executed.
+    ///
+    /// Same partial-success semantics as `batch_remove`: one bad entry does
+    /// not block the rest. Emits [`BatchRemoveExecutedEvent`] plus a
+    /// [`RemovedEvent`] per removed username.
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from `caller`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NoPendingBatchRemove`] if nothing is proposed, or
+    ///   the pending proposal has expired.
+    /// - [`ContractError::NotAuthorized`] if `caller` is not admin-equivalent,
+    ///   or is the same address that proposed the batch.
+    pub fn execute_batch_remove(env: Env, caller: Address) -> Result<BatchSummary, ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+
+        caller.require_auth();
+
+        let proposal = crate::storage::get_pending_batch_remove(&env)
+            .ok_or(ContractError::NoPendingBatchRemove)?;
+
+        if crate::storage::is_batch_remove_proposal_expired(&env, &proposal) {
+            crate::storage::clear_pending_batch_remove(&env);
+            return Err(ContractError::NoPendingBatchRemove);
+        }
+
+        let admin = get_admin(&env)?;
+        let is_admin_equivalent =
+            caller == admin || storage_get_role(&env, &caller) == Some(Role::Admin);
+        if !is_admin_equivalent || caller == proposal.proposed_by {
+            return Err(ContractError::NotAuthorized);
+        }
+
+        crate::storage::clear_pending_batch_remove(&env);
+
+        let count = proposal.usernames.len();
+        let summary = Self::apply_batch_remove(&env, &caller, &proposal.usernames);
+
+        BatchRemoveExecutedEvent {
+            executed_by: caller,
+            proposed_by: proposal.proposed_by,
+            count,
+            successful: summary.successful,
+            timestamp: env.ledger().timestamp(),
+            domain: event_domain(&env),
+        }
+        .publish(&env);
+
+        Ok(summary)
+    }
+
+    /// Cancels the pending large `batch_remove` proposal without executing
+    /// it (Issue #219). Available even while paused — an abort path should
+    /// not itself be blockable by the same emergency that might motivate
+    /// using it.
+    ///
+    /// Emits [`BatchRemoveCancelledEvent`].
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if `caller` is not the contract admin.
+    /// - [`ContractError::NoPendingBatchRemove`] if nothing is proposed.
+    pub fn cancel_batch_remove(env: Env, caller: Address) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        caller.require_auth();
+
+        let admin = get_admin(&env)?;
+        if caller != admin {
+            return Err(ContractError::NotAuthorized);
+        }
+
+        let proposal = crate::storage::get_pending_batch_remove(&env)
+            .ok_or(ContractError::NoPendingBatchRemove)?;
+
+        crate::storage::clear_pending_batch_remove(&env);
+
+        BatchRemoveCancelledEvent {
+            cancelled_by: caller,
+            proposed_by: proposal.proposed_by,
+            timestamp: env.ledger().timestamp(),
+            domain: event_domain(&env),
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Returns the pending large-batch proposal, if one exists — regardless
+    /// of whether it has already expired (Issue #219). Read-only; no auth
+    /// required; works while paused, so a holder of either key can always
+    /// see what is queued.
+    #[must_use]
+    pub fn get_pending_batch_remove(env: Env) -> Option<PendingBatchRemove> {
+        crate::storage::get_pending_batch_remove(&env)
+    }
+
+    /// Sets the `batch_remove` dual-control size threshold. Admin-only
+    /// (Issue #219).
+    ///
+    /// `0` (the default) disables dual control entirely — every
+    /// `batch_remove` call executes directly regardless of size, matching
+    /// pre-#219 behavior. A non-zero value requires any batch strictly
+    /// larger than it to go through `propose_batch_remove` /
+    /// `execute_batch_remove` instead.
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
+    pub fn set_batch_remove_threshold(env: Env, threshold: u32) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        crate::storage::set_batch_remove_threshold(&env, threshold);
+        Ok(())
+    }
+
+    /// Returns the configured `batch_remove` dual-control size threshold —
+    /// `0` if dual control is disabled (the default) (Issue #219).
+    ///
+    /// Read-only; no auth required.
+    #[must_use]
+    pub fn get_batch_remove_threshold(env: Env) -> u32 {
+        crate::storage::get_batch_remove_threshold(&env)
+    }
+
+    /// Shared removal loop for `batch_remove` and `execute_batch_remove`
+    /// (Issue #219). `caller` is the signer of the transaction actually
+    /// performing the removals — the admin for a direct `batch_remove`, or
+    /// the executing address for a dual-control batch — and is what gets
+    /// recorded on each `RemovedEvent` / audit entry.
+    fn apply_batch_remove(env: &Env, caller: &Address, usernames: &Vec<String>) -> BatchSummary {
         let total = usernames.len();
         let mut successful: u32 = 0;
         let mut removed: u32 = 0;
@@ -1549,18 +1950,16 @@ impl TrustBridgeContract {
         for username in usernames.iter() {
             // Attempt the remove. Silently skip failures (not registered, etc.)
             // so one bad entry does not kill the whole batch.
-            let record = match get_record(&env, &username) {
+            let record = match get_record(env, &username) {
                 Some(r) => r,
                 None => continue, // not registered — count as failure below
             };
 
-            // With admin auth, the auth check inside single remove would pass,
-            // but we replicate the full logic here to be explicit.
             let timestamp = env.ledger().timestamp();
             let stellar_address = record.stellar_address.clone();
 
-            remove_record(&env, &username);
-            remove_from_index(&env, &username);
+            remove_record(env, &username);
+            remove_from_index(env, &username);
 
             // Counters are accumulated and written once after the loop, so
             // `count` and `vcount` move together exactly once per batch rather
@@ -1574,12 +1973,12 @@ impl TrustBridgeContract {
                 github_username: username.clone(),
                 stellar_address: stellar_address.clone(),
                 timestamp,
-                domain: event_domain(&env),
+                domain: event_domain(env),
             }
-            .publish(&env);
+            .publish(env);
 
             push_audit_entry(
-                &env,
+                env,
                 AuditLogEntry::new(AuditEventType::UserRemoved, timestamp, Some(caller.clone()))
                     .with_username(username.clone())
                     .with_address(stellar_address),
@@ -1593,16 +1992,16 @@ impl TrustBridgeContract {
         // operations per entry, and left `count` and `vcount` briefly
         // inconsistent with each other partway through.
         if removed > 0 {
-            set_count(&env, get_count(&env).saturating_sub(removed));
+            set_count(env, get_count(env).saturating_sub(removed));
         }
         if unverified > 0 {
             set_verified_count(
-                &env,
-                storage_get_verified_count(&env).saturating_sub(unverified),
+                env,
+                storage_get_verified_count(env).saturating_sub(unverified),
             );
         }
 
-        Ok(BatchSummary::new(total, successful))
+        BatchSummary::new(total, successful)
     }
 
     /// Looks up the `ContributorRecord` for `github_username`. Returns `None` if not registered.
@@ -1809,6 +2208,60 @@ impl TrustBridgeContract {
         get_registered_paginated_internal(&env, cursor, limit)
     }
 
+    /// Returns a signed export attestation for one page of the registry.
+    /// Admin-only (Issue #223).
+    ///
+    /// Same `cursor`/`limit` pagination as `get_registered_paginated` — this
+    /// wraps the identical [`ExportPage`] with a SHA-256 digest over it, the
+    /// contract's schema version, and the ledger sequence the read happened
+    /// at. `scripts/export_registry.sh` (or any offline tool) can hash the
+    /// same page bytes it just downloaded and compare against `digest`
+    /// without any further network round-trip — the point for air-gapped
+    /// audits, where the auditor may not have live RPC access at all.
+    ///
+    /// An empty registry is not an error: `page.records` is empty, `total`
+    /// is `0`, and `digest` is still a real hash over that (empty) page —
+    /// deterministic and comparable like any other page.
+    ///
+    /// This does **not** replace `get_registered_paginated` /
+    /// `get_all_registered` for the actual bulk export — it is a companion
+    /// attestation over the same data. Admin auth for the underlying export
+    /// is unchanged; this adds a binding on top, it does not relax anything.
+    ///
+    /// Unaffected by the normal pause flag, matching
+    /// `get_registered_paginated` / `get_all_registered`: admin export and
+    /// audit tooling stays available during a maintenance window.
+    ///
+    /// # Auth
+    ///
+    /// Requires auth from the contract admin.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
+    pub fn export_attestation(
+        env: Env,
+        cursor: u32,
+        limit: u32,
+    ) -> Result<ExportAttestation, ContractError> {
+        require_initialized(&env)?;
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        let page = get_registered_paginated_internal(&env, cursor, limit)?;
+        let digest = crate::storage::build_export_digest(&env, &page);
+        let version = storage_get_version(&env).unwrap_or_else(|| CONTRACT_VERSION.to_tuple());
+        let ledger = env.ledger().sequence();
+
+        Ok(ExportAttestation {
+            page,
+            digest,
+            version: soroban_sdk::vec![&env, version.0, version.1, version.2],
+            ledger,
+        })
+    }
+
     /// Public paginated read for indexers and dashboard consumers.
     ///
     /// Same cursor/limit semantics as `get_registered_paginated` but requires no auth,
@@ -1900,13 +2353,21 @@ impl TrustBridgeContract {
     /// Callable by the contract admin **or** any address assigned the
     /// `Role::Verifier` role (Issue #12 — verifier role separation).
     ///
+    /// If `config_verification` set a non-zero `expires_in` and this
+    /// username's **previous** verification has expired, `verify` treats it
+    /// as not-currently-verified and renews it — recording a fresh
+    /// verification timestamp — rather than returning `AlreadyVerified`
+    /// (Issue #218). A verification that is still active (not expired) is
+    /// unaffected by this and still rejects a duplicate call.
+    ///
     /// # Errors
     ///
     /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
     /// - [`ContractError::Paused`] if the contract is paused.
     /// - [`ContractError::NotAuthorized`] if `caller` is not an admin or verifier.
     /// - [`ContractError::NotRegistered`] if `github_username` is not registered.
-    /// - [`ContractError::AlreadyVerified`] if the record is already verified.
+    /// - [`ContractError::AlreadyVerified`] if the record is verified and that
+    ///   verification has not expired.
     pub fn verify(env: Env, caller: Address, github_username: String) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
@@ -1925,18 +2386,32 @@ impl TrustBridgeContract {
 
         let mut record = get_record(&env, &github_username).ok_or(ContractError::NotRegistered)?;
 
-        if record.verified {
+        // Issue #218: an expired prior verification does not block a fresh
+        // one — only a still-active verification does.
+        let was_active =
+            record.verified && !crate::storage::is_verification_expired(&env, &github_username);
+        if was_active {
             return Err(ContractError::AlreadyVerified);
         }
 
+        let was_verified = record.verified;
         record.verified = true;
         set_record(&env, &github_username, &record);
-        set_verified_count(&env, storage_get_verified_count(&env).saturating_add(1));
-        bump_ever_verified_count(&env);
+        let timestamp = env.ledger().timestamp();
+        crate::storage::set_verified_at(&env, &github_username, timestamp);
+
+        // Only a genuine false→true transition is a new verification for
+        // counting purposes — renewing an expired-but-never-revoked
+        // verification does not touch `verified_count` a second time, since
+        // it was never decremented when the previous grant expired (expiry
+        // is lazy; see `is_verification_expired`).
+        if !was_verified {
+            set_verified_count(&env, storage_get_verified_count(&env).saturating_add(1));
+            bump_ever_verified_count(&env);
+        }
 
         // Clear pending reverify flag upon successful verification
         clear_pending_reverify(&env, &github_username);
-        let timestamp = env.ledger().timestamp();
         VerifiedEvent {
             github_username: github_username.clone(),
             stellar_address: record.stellar_address.clone(),
@@ -1959,6 +2434,10 @@ impl TrustBridgeContract {
     ///
     /// Callable by the contract admin **or** any address assigned the
     /// `Role::Verifier` role. `Role::Revoker` does not grant this permission.
+    ///
+    /// Same expired-verification renewal behavior as `verify` (Issue #218):
+    /// an entry whose prior verification has expired is treated as pending,
+    /// not skipped, and gets a fresh verification timestamp.
     ///
     /// # Auth
     ///
@@ -2004,13 +2483,17 @@ impl TrustBridgeContract {
         //
         // Skipping duplicates matters for the counter: the same username twice
         // in one batch would otherwise be counted twice against `vcount` even
-        // though only one record changes.
+        // though only one record changes. A record whose verification is
+        // still active (verified and not expired, Issue #218) is skipped the
+        // same way `verify` skips it; an expired one is treated as pending.
         let mut pending: Vec<String> = Vec::new(&env);
         for username in usernames.iter() {
             let Some(record) = get_record(&env, &username) else {
                 continue;
             };
-            if record.verified {
+            let active =
+                record.verified && !crate::storage::is_verification_expired(&env, &username);
+            if active {
                 continue;
             }
             if pending.iter().any(|u| u == username) {
@@ -2021,6 +2504,11 @@ impl TrustBridgeContract {
 
         // ── Phase 2: apply ──────────────────────────────────────────────────
         let mut successful: u32 = 0;
+        // Only entries making a genuine false→true transition count toward
+        // `verified_count` / `ever_verified_count` — renewing an
+        // expired-but-never-revoked entry does not, since it was never
+        // decremented when its previous grant expired (expiry is lazy).
+        let mut newly_verified: u32 = 0;
         for username in pending.iter() {
             // Re-read rather than carrying the record from phase 1: cloning a
             // record per pending entry would hold the whole batch in memory,
@@ -2030,10 +2518,14 @@ impl TrustBridgeContract {
                 continue;
             };
 
+            let was_verified = record.verified;
             record.verified = true;
             set_record(&env, &username, &record);
-            set_verified_count(&env, storage_get_verified_count(&env).saturating_add(1));
-            bump_ever_verified_count(&env);
+            crate::storage::set_verified_at(&env, &username, timestamp);
+            if !was_verified {
+                newly_verified = newly_verified.saturating_add(1);
+                bump_ever_verified_count(&env);
+            }
             clear_pending_reverify(&env, &username);
 
             VerifiedEvent {
@@ -2062,10 +2554,10 @@ impl TrustBridgeContract {
         // per entry. That is 2 storage operations rather than 2N, and it means
         // `vcount` moves exactly once — there is no intermediate state in which
         // it has been advanced for some entries but not others.
-        if successful > 0 {
+        if newly_verified > 0 {
             set_verified_count(
                 &env,
-                storage_get_verified_count(&env).saturating_add(successful),
+                storage_get_verified_count(&env).saturating_add(newly_verified),
             );
         }
 
@@ -2124,6 +2616,12 @@ impl TrustBridgeContract {
         record.verified = false;
         set_record(&env, &github_username, &record);
         set_verified_count(&env, storage_get_verified_count(&env).saturating_sub(1));
+        // A revoked record has no verification left to expire — clear the
+        // timestamp so a later fresh `verify()` is not compared against a
+        // stale grant (Issue #218). Also covers the "expired but not
+        // revoked" case cleanly: revoking still works off the raw `verified`
+        // flag regardless of expiry, and this leaves nothing behind either way.
+        crate::storage::clear_verified_at(&env, &github_username);
 
         let timestamp = env.ledger().timestamp();
         VerificationRevokedEvent {
@@ -8774,5 +9272,786 @@ mod test {
         assert!(authorized_addresses.contains(&sponsor));
         assert!(authorized_addresses.contains(&user2));
         assert!(authorized_addresses.contains(&user1));
+    }
+
+    // ── Role expiry (Issue #221) ────────────────────────────────────────────
+
+    #[test]
+    fn test_set_role_with_expiry_active_before_expiry() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_role_with_expiry(
+                env.clone(),
+                user.clone(),
+                Role::Verifier,
+                Some(2_000),
+            )
+            .unwrap();
+            assert_eq!(
+                TrustBridgeContract::get_role(env.clone(), user.clone()),
+                Some(Role::Verifier)
+            );
+            assert!(TrustBridgeContract::has_role(
+                env.clone(),
+                user.clone(),
+                Role::Verifier
+            ));
+            assert_eq!(
+                TrustBridgeContract::get_role_expiry(env.clone(), user.clone()),
+                Some(2_000)
+            );
+        });
+    }
+
+    #[test]
+    fn test_role_expires_lazily_get_role_returns_none_after_expiry() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_role_with_expiry(
+                env.clone(),
+                user.clone(),
+                Role::Verifier,
+                Some(2_000),
+            )
+            .unwrap();
+        });
+
+        env.ledger().set_timestamp(2_500);
+        env.as_contract(&contract_id, || {
+            assert_eq!(TrustBridgeContract::get_role(env.clone(), user.clone()), None);
+            assert!(!TrustBridgeContract::has_role(
+                env.clone(),
+                user.clone(),
+                Role::Verifier
+            ));
+            // Lazy expiry: the raw timestamp is still readable even though the
+            // grant no longer resolves as held.
+            assert_eq!(
+                TrustBridgeContract::get_role_expiry(env.clone(), user.clone()),
+                Some(2_000)
+            );
+        });
+    }
+
+    #[test]
+    fn test_role_expiry_boundary_exactly_now_is_expired() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_role_with_expiry(
+                env.clone(),
+                user.clone(),
+                Role::Verifier,
+                Some(2_000),
+            )
+            .unwrap();
+        });
+
+        // One ledger second before expires_at: still active.
+        env.ledger().set_timestamp(1_999);
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::get_role(env.clone(), user.clone()),
+                Some(Role::Verifier)
+            );
+        });
+
+        // Exactly at expires_at: `is_role_expired` uses `>=`, so this reads as
+        // already expired.
+        env.ledger().set_timestamp(2_000);
+        env.as_contract(&contract_id, || {
+            assert_eq!(TrustBridgeContract::get_role(env.clone(), user.clone()), None);
+        });
+    }
+
+    #[test]
+    fn test_set_role_default_never_expires() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_role(env.clone(), user.clone(), Role::Verifier).unwrap();
+            assert_eq!(
+                TrustBridgeContract::get_role_expiry(env.clone(), user.clone()),
+                None
+            );
+        });
+
+        env.ledger().set_timestamp(1_000_000_000);
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::get_role(env.clone(), user.clone()),
+                Some(Role::Verifier)
+            );
+        });
+    }
+
+    #[test]
+    fn test_remove_role_clears_expiry() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_role_with_expiry(
+                env.clone(),
+                user.clone(),
+                Role::Verifier,
+                Some(5_000),
+            )
+            .unwrap();
+            TrustBridgeContract::remove_role(env.clone(), user.clone()).unwrap();
+            assert_eq!(TrustBridgeContract::get_role(env.clone(), user.clone()), None);
+            assert_eq!(
+                TrustBridgeContract::get_role_expiry(env.clone(), user.clone()),
+                None
+            );
+        });
+    }
+
+    #[test]
+    fn test_admin_role_grant_with_expiry_does_not_affect_admin_identity() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            // Explicitly (and unusually) expire the admin's own RBAC
+            // Role::Admin grant — this must never touch `has_admin_role`.
+            TrustBridgeContract::set_role_with_expiry(
+                env.clone(),
+                admin.clone(),
+                Role::Admin,
+                Some(1_100),
+            )
+            .unwrap();
+        });
+
+        env.ledger().set_timestamp(2_000);
+        env.as_contract(&contract_id, || {
+            // The RBAC grant has lapsed...
+            assert_eq!(TrustBridgeContract::get_role(env.clone(), admin.clone()), None);
+            // ...but the admin's real identity (ADMIN_KEY) is untouched.
+            assert!(TrustBridgeContract::has_admin_role(env.clone(), admin.clone()));
+            // Admin-gated calls still work.
+            TrustBridgeContract::set_cooldown(env.clone(), 42).unwrap();
+            assert_eq!(TrustBridgeContract::get_cooldown(env.clone()), 42);
+        });
+    }
+
+    #[test]
+    fn test_expired_verifier_role_cannot_verify() {
+        let env = Env::default();
+        let (admin, user, verifier, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+            TrustBridgeContract::set_role_with_expiry(
+                env.clone(),
+                verifier.clone(),
+                Role::Verifier,
+                Some(2_000),
+            )
+            .unwrap();
+        });
+
+        env.ledger().set_timestamp(1_500);
+        env.as_contract(&contract_id, || {
+            // Still active: the expired-role holder can verify normally.
+            TrustBridgeContract::verify(env.clone(), verifier.clone(), username(&env, "octocat"))
+                .unwrap();
+            TrustBridgeContract::revoke_verification(
+                env.clone(),
+                admin.clone(),
+                username(&env, "octocat"),
+                1,
+            )
+            .unwrap();
+        });
+
+        env.ledger().set_timestamp(2_500);
+        env.as_contract(&contract_id, || {
+            let res = TrustBridgeContract::verify(
+                env.clone(),
+                verifier.clone(),
+                username(&env, "octocat"),
+            );
+            assert_eq!(res, Err(ContractError::NotAuthorized));
+        });
+    }
+
+    // ── Time-bounded verification (Issue #218) ──────────────────────────────
+
+    #[test]
+    fn test_verify_expires_after_configured_window() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+            TrustBridgeContract::config_verification(
+                env.clone(),
+                admin.clone(),
+                soroban_sdk::Symbol::new(&env, "github_att"),
+                1_000,
+                1,
+            )
+            .unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+            assert!(TrustBridgeContract::is_verification_active(
+                env.clone(),
+                username(&env, "octocat")
+            ));
+        });
+
+        // Exactly at the expiry boundary.
+        env.ledger().set_timestamp(2_000);
+        env.as_contract(&contract_id, || {
+            assert!(!TrustBridgeContract::is_verification_active(
+                env.clone(),
+                username(&env, "octocat")
+            ));
+            // Lazy expiry: the raw flag is untouched.
+            let record =
+                TrustBridgeContract::get_address(env.clone(), username(&env, "octocat")).unwrap();
+            assert!(record.verified);
+        });
+    }
+
+    #[test]
+    fn test_verify_renews_after_expiry_instead_of_already_verified() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+            TrustBridgeContract::config_verification(
+                env.clone(),
+                admin.clone(),
+                soroban_sdk::Symbol::new(&env, "github_att"),
+                1_000,
+                1,
+            )
+            .unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+
+        // Still active: a duplicate verify is rejected as before this issue.
+        env.ledger().set_timestamp(1_500);
+        env.as_contract(&contract_id, || {
+            let res =
+                TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"));
+            assert_eq!(res, Err(ContractError::AlreadyVerified));
+        });
+
+        // Past expiry: verify renews instead of erroring, and does not
+        // double-count `verified_count` / `ever_verified_count`.
+        env.ledger().set_timestamp(2_500);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+            assert!(TrustBridgeContract::is_verification_active(
+                env.clone(),
+                username(&env, "octocat")
+            ));
+            assert_verified_parity(&env, 1);
+            assert_eq!(TrustBridgeContract::get_ever_verified_count(env.clone()), 1);
+        });
+    }
+
+    #[test]
+    fn test_verification_without_config_never_expires() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+
+        env.ledger().set_timestamp(1_000_000_000);
+        env.as_contract(&contract_id, || {
+            assert!(TrustBridgeContract::is_verification_active(
+                env.clone(),
+                username(&env, "octocat")
+            ));
+        });
+    }
+
+    #[test]
+    fn test_verified_count_not_decremented_by_expiry_only_by_revoke() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+            TrustBridgeContract::config_verification(
+                env.clone(),
+                admin.clone(),
+                soroban_sdk::Symbol::new(&env, "github_att"),
+                1_000,
+                1,
+            )
+            .unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+
+        // Expire without revoking. Stats definition (Issue #218): the raw
+        // counters count the raw `verified` flag, not the expiry-aware
+        // status, so they do not move on their own.
+        env.ledger().set_timestamp(5_000);
+        env.as_contract(&contract_id, || {
+            assert!(!TrustBridgeContract::is_verification_active(
+                env.clone(),
+                username(&env, "octocat")
+            ));
+            assert_verified_parity(&env, 1);
+
+            TrustBridgeContract::revoke_verification(
+                env.clone(),
+                admin.clone(),
+                username(&env, "octocat"),
+                1,
+            )
+            .unwrap();
+            assert_verified_parity(&env, 0);
+        });
+    }
+
+    #[test]
+    fn test_get_verification_expiry_none_without_config() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+            assert_eq!(
+                TrustBridgeContract::get_verification_expiry(
+                    env.clone(),
+                    username(&env, "octocat")
+                ),
+                None
+            );
+        });
+    }
+
+    #[test]
+    fn test_get_verification_expiry_some_when_configured() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+            TrustBridgeContract::config_verification(
+                env.clone(),
+                admin.clone(),
+                soroban_sdk::Symbol::new(&env, "github_att"),
+                500,
+                1,
+            )
+            .unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+            assert_eq!(
+                TrustBridgeContract::get_verification_expiry(
+                    env.clone(),
+                    username(&env, "octocat")
+                ),
+                Some(1_500)
+            );
+        });
+    }
+
+    // ── Signed export attestation (Issue #223) ──────────────────────────────
+
+    #[test]
+    fn test_export_attestation_empty_registry() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            let attestation = TrustBridgeContract::export_attestation(env.clone(), 0, 10).unwrap();
+            assert_eq!(attestation.page.records.len(), 0);
+            assert_eq!(attestation.page.total, 0);
+            assert!(!attestation.page.has_more);
+
+            // Deterministic even for an empty page.
+            let again = TrustBridgeContract::export_attestation(env.clone(), 0, 10).unwrap();
+            assert_eq!(attestation.digest, again.digest);
+        });
+    }
+
+    #[test]
+    fn test_export_attestation_digest_deterministic_across_calls() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+            let a = TrustBridgeContract::export_attestation(env.clone(), 0, 10).unwrap();
+            let b = TrustBridgeContract::export_attestation(env.clone(), 0, 10).unwrap();
+            assert_eq!(a.digest, b.digest);
+            assert_eq!(a.page, b.page);
+        });
+    }
+
+    #[test]
+    fn test_export_attestation_digest_changes_with_data() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+        });
+
+        let before = env.as_contract(&contract_id, || {
+            TrustBridgeContract::export_attestation(env.clone(), 0, 10).unwrap()
+        });
+
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+
+        let after = env.as_contract(&contract_id, || {
+            TrustBridgeContract::export_attestation(env.clone(), 0, 10).unwrap()
+        });
+
+        assert_ne!(before.digest, after.digest);
+    }
+
+    #[test]
+    fn test_export_attestation_matches_registered_paginated_page() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+            let attestation = TrustBridgeContract::export_attestation(env.clone(), 0, 10).unwrap();
+            let page = TrustBridgeContract::get_registered_paginated(env.clone(), 0, 10).unwrap();
+            assert_eq!(attestation.page, page);
+        });
+    }
+
+    #[test]
+    fn test_export_attestation_reports_version_and_ledger() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            let attestation = TrustBridgeContract::export_attestation(env.clone(), 0, 10).unwrap();
+            assert_eq!(attestation.version, soroban_sdk::vec![&env, 1u32, 0u32, 0u32]);
+            assert_eq!(attestation.ledger, env.ledger().sequence());
+        });
+    }
+
+    // ── Dual-control batch_remove (Issue #219) ──────────────────────────────
+
+    /// Registers `count` fresh usernames (each to its own generated address)
+    /// and returns them, for building batch_remove test fixtures.
+    fn register_batch(env: &Env, contract_id: &Address, count: u32) -> Vec<String> {
+        env.mock_all_auths();
+        let mut names: Vec<String> = Vec::new(env);
+        for i in 0..count {
+            let addr = Address::generate(env);
+            let name = username(env, &format!("user{}", i));
+            env.as_contract(contract_id, || {
+                TrustBridgeContract::register(env.clone(), name.clone(), addr.clone(), Vec::new(env))
+                    .unwrap();
+            });
+            names.push_back(name);
+        }
+        names
+    }
+
+    #[test]
+    fn test_batch_remove_at_or_below_threshold_unchanged() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        let names = register_batch(&env, &contract_id, 3);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_batch_remove_threshold(env.clone(), 3).unwrap();
+            // size == threshold: still direct, single-step.
+            let summary =
+                TrustBridgeContract::batch_remove(env.clone(), admin.clone(), names.clone())
+                    .unwrap();
+            assert_eq!(summary.successful, 3);
+            assert_eq!(TrustBridgeContract::get_stats(env.clone()).total, 0);
+        });
+    }
+
+    #[test]
+    fn test_batch_remove_above_threshold_requires_dual_control() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        let names = register_batch(&env, &contract_id, 4);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_batch_remove_threshold(env.clone(), 3).unwrap();
+            // size == threshold + 1: rejected, must use propose/execute.
+            let res = TrustBridgeContract::batch_remove(env.clone(), admin.clone(), names.clone());
+            assert_eq!(res, Err(ContractError::DualControlRequired));
+            // Registry untouched — the fail-before-write property.
+            assert_eq!(TrustBridgeContract::get_stats(env.clone()).total, 4);
+        });
+    }
+
+    #[test]
+    fn test_batch_remove_threshold_zero_disables_dual_control() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        let names = register_batch(&env, &contract_id, 20);
+        env.as_contract(&contract_id, || {
+            assert_eq!(TrustBridgeContract::get_batch_remove_threshold(env.clone()), 0);
+            let summary =
+                TrustBridgeContract::batch_remove(env.clone(), admin.clone(), names.clone())
+                    .unwrap();
+            assert_eq!(summary.successful, 20);
+        });
+    }
+
+    #[test]
+    fn test_propose_then_execute_batch_remove_by_second_admin() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        let second_admin = Address::generate(&env);
+        let names = register_batch(&env, &contract_id, 4);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_batch_remove_threshold(env.clone(), 3).unwrap();
+            TrustBridgeContract::set_role(env.clone(), second_admin.clone(), Role::Admin).unwrap();
+
+            TrustBridgeContract::propose_batch_remove(env.clone(), admin.clone(), names.clone())
+                .unwrap();
+            let pending = TrustBridgeContract::get_pending_batch_remove(env.clone()).unwrap();
+            assert_eq!(pending.usernames.len(), 4);
+            assert_eq!(pending.proposed_by, admin);
+
+            let summary =
+                TrustBridgeContract::execute_batch_remove(env.clone(), second_admin.clone())
+                    .unwrap();
+            assert_eq!(summary.successful, 4);
+            assert_eq!(TrustBridgeContract::get_stats(env.clone()).total, 0);
+            assert!(TrustBridgeContract::get_pending_batch_remove(env.clone()).is_none());
+        });
+    }
+
+    #[test]
+    fn test_execute_batch_remove_same_proposer_rejected() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        let names = register_batch(&env, &contract_id, 4);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_batch_remove_threshold(env.clone(), 3).unwrap();
+            TrustBridgeContract::propose_batch_remove(env.clone(), admin.clone(), names.clone())
+                .unwrap();
+            // Same admin tries to execute their own proposal — dual control
+            // means one signature alone is never enough.
+            let res = TrustBridgeContract::execute_batch_remove(env.clone(), admin.clone());
+            assert_eq!(res, Err(ContractError::NotAuthorized));
+            assert!(TrustBridgeContract::get_pending_batch_remove(env.clone()).is_some());
+        });
+    }
+
+    #[test]
+    fn test_execute_batch_remove_without_admin_equivalent_role_rejected() {
+        let env = Env::default();
+        let (admin, _user, bystander, contract_id) = setup(&env);
+        let names = register_batch(&env, &contract_id, 4);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_batch_remove_threshold(env.clone(), 3).unwrap();
+            TrustBridgeContract::propose_batch_remove(env.clone(), admin.clone(), names.clone())
+                .unwrap();
+            let res = TrustBridgeContract::execute_batch_remove(env.clone(), bystander.clone());
+            assert_eq!(res, Err(ContractError::NotAuthorized));
+        });
+    }
+
+    #[test]
+    fn test_propose_batch_remove_rejects_second_proposal_while_pending() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        let names = register_batch(&env, &contract_id, 4);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_batch_remove_threshold(env.clone(), 3).unwrap();
+            TrustBridgeContract::propose_batch_remove(env.clone(), admin.clone(), names.clone())
+                .unwrap();
+            let res = TrustBridgeContract::propose_batch_remove(
+                env.clone(),
+                admin.clone(),
+                names.clone(),
+            );
+            assert_eq!(res, Err(ContractError::BatchRemoveProposalPending));
+        });
+    }
+
+    #[test]
+    fn test_cancel_batch_remove_clears_proposal_and_allows_new_one() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        let names = register_batch(&env, &contract_id, 4);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_batch_remove_threshold(env.clone(), 3).unwrap();
+            TrustBridgeContract::propose_batch_remove(env.clone(), admin.clone(), names.clone())
+                .unwrap();
+            TrustBridgeContract::cancel_batch_remove(env.clone(), admin.clone()).unwrap();
+            assert!(TrustBridgeContract::get_pending_batch_remove(env.clone()).is_none());
+
+            // A fresh proposal is now allowed.
+            TrustBridgeContract::propose_batch_remove(env.clone(), admin.clone(), names.clone())
+                .unwrap();
+            assert!(TrustBridgeContract::get_pending_batch_remove(env.clone()).is_some());
+        });
+    }
+
+    #[test]
+    fn test_cancel_batch_remove_available_while_paused() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        let names = register_batch(&env, &contract_id, 4);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_batch_remove_threshold(env.clone(), 3).unwrap();
+            TrustBridgeContract::propose_batch_remove(env.clone(), admin.clone(), names.clone())
+                .unwrap();
+            TrustBridgeContract::pause(env.clone(), 1).unwrap();
+            // Cancel still works while paused — the abort path must not be
+            // blockable by the same freeze that might motivate using it.
+            TrustBridgeContract::cancel_batch_remove(env.clone(), admin.clone()).unwrap();
+            assert!(TrustBridgeContract::get_pending_batch_remove(env.clone()).is_none());
+        });
+    }
+
+    #[test]
+    fn test_execute_batch_remove_blocked_while_paused() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        let second_admin = Address::generate(&env);
+        let names = register_batch(&env, &contract_id, 4);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_batch_remove_threshold(env.clone(), 3).unwrap();
+            TrustBridgeContract::set_role(env.clone(), second_admin.clone(), Role::Admin).unwrap();
+            TrustBridgeContract::propose_batch_remove(env.clone(), admin.clone(), names.clone())
+                .unwrap();
+            TrustBridgeContract::pause(env.clone(), 1).unwrap();
+
+            let res = TrustBridgeContract::execute_batch_remove(env.clone(), second_admin.clone());
+            assert_eq!(res, Err(ContractError::Paused));
+
+            // The proposal survives the pause — the second key can still
+            // execute once unpaused.
+            TrustBridgeContract::unpause(env.clone(), 4).unwrap();
+            let summary =
+                TrustBridgeContract::execute_batch_remove(env.clone(), second_admin.clone())
+                    .unwrap();
+            assert_eq!(summary.successful, 4);
+        });
+    }
+
+    #[test]
+    fn test_execute_batch_remove_after_proposal_expired() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        let second_admin = Address::generate(&env);
+        let names = register_batch(&env, &contract_id, 4);
+        env.ledger().set_timestamp(1_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_batch_remove_threshold(env.clone(), 3).unwrap();
+            TrustBridgeContract::set_role(env.clone(), second_admin.clone(), Role::Admin).unwrap();
+            TrustBridgeContract::propose_batch_remove(env.clone(), admin.clone(), names.clone())
+                .unwrap();
+        });
+
+        // Past BATCH_REMOVE_PROPOSAL_TTL_SECS (24h).
+        env.ledger().set_timestamp(1_000 + 86_400 + 1);
+        env.as_contract(&contract_id, || {
+            let res = TrustBridgeContract::execute_batch_remove(env.clone(), second_admin.clone());
+            assert_eq!(res, Err(ContractError::NoPendingBatchRemove));
+            // Expired proposal was cleared and never executed.
+            assert_eq!(TrustBridgeContract::get_stats(env.clone()).total, 4);
+            assert!(TrustBridgeContract::get_pending_batch_remove(env.clone()).is_none());
+
+            // A fresh proposal is possible immediately after.
+            TrustBridgeContract::propose_batch_remove(env.clone(), admin.clone(), names.clone())
+                .unwrap();
+        });
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,7 +2,7 @@
 //! behavior are documented in `docs/STORAGE_RENT.md` — read that before
 //! changing `TTL_THRESHOLD` / `TTL_BUMP` or adding a new persistent key.
 
-use soroban_sdk::{symbol_short, Address, BytesN, Env, String, Symbol, Vec};
+use soroban_sdk::{symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 
 use crate::ContractError;
 
@@ -115,6 +115,32 @@ pub const ADMIN_TRANSFER_KEY: Symbol = symbol_short!("adm_xfr");
 
 /// Key for whether WASM attestation is required before upgrade (Issue #198).
 pub const ATTEST_REQUIRED_KEY: Symbol = symbol_short!("att_req");
+
+/// Key prefix for a role assignment's expiry timestamp (Issue #221).
+///
+/// Absent (no entry) means the role granted at `ROLE_KEY` for that address
+/// never expires — the pre-existing behavior. Present means the grant is only
+/// valid while `env.ledger().timestamp() < expires_at`.
+pub const ROLE_EXPIRY_KEY: Symbol = symbol_short!("role_exp");
+
+/// Key prefix for the ledger timestamp a username was last `verify()`'d
+/// (Issue #218).
+pub const VERIFIED_AT_KEY: Symbol = symbol_short!("vfy_at");
+
+/// Key for the `batch_remove` dual-control size threshold (Issue #219).
+/// `0` (the default) disables dual control — every batch is executed
+/// directly by a single admin call, matching pre-#219 behavior.
+pub const BATCH_REMOVE_THRESHOLD_KEY: Symbol = symbol_short!("brm_thr");
+
+/// Key for the single pending large-`batch_remove` proposal (Issue #219).
+/// Only one proposal may be live at a time.
+pub const PENDING_BATCH_REMOVE_KEY: Symbol = symbol_short!("brm_pend");
+
+/// Seconds a `batch_remove` dual-control proposal stays valid before
+/// `execute_batch_remove` treats it as gone (Issue #219). Prevents a stale
+/// proposal from being executed long after the operator context that
+/// justified it has passed.
+pub const BATCH_REMOVE_PROPOSAL_TTL_SECS: u64 = 86_400; // 24 hours
 
 // ── Pagination constants ─────────────────────────────────────────────────────
 
@@ -386,6 +412,32 @@ pub struct ExportPage {
     pub total: u32,
     /// `true` if there are more records after this page.
     pub has_more: bool,
+}
+
+/// A signed export attestation binding one [`ExportPage`] to a deterministic
+/// digest, the contract's schema version, and the ledger it was read at
+/// (Issue #223).
+///
+/// Intended for air-gapped audits: an auditor who receives the JSON produced
+/// by `scripts/export_registry.sh` alongside this struct can recompute the
+/// same digest offline from the raw page contents and compare it byte for
+/// byte, without ever reconnecting to the network — the digest is the only
+/// thing they need to trust the export matches what the contract actually
+/// held at `ledger`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[soroban_sdk::contracttype]
+pub struct ExportAttestation {
+    /// The page this attestation covers — identical to what
+    /// `get_registered_paginated` would return for the same `cursor`/`limit`.
+    pub page: ExportPage,
+    /// SHA-256 digest over `page`'s XDR encoding. See
+    /// [`build_export_digest`] for exactly what is hashed.
+    pub digest: BytesN<32>,
+    /// Contract schema version `(major, minor, patch)` as a flat `Vec<u32>`,
+    /// read the same way `get_version` resolves it.
+    pub version: Vec<u32>,
+    /// Ledger sequence the page and digest were computed at.
+    pub ledger: u32,
 }
 
 /// On-chain health snapshot returned by `get_health` (Issue #210).
@@ -810,6 +862,22 @@ pub fn get_registered_paginated_internal(
     })
 }
 
+/// Builds the deterministic digest used by [`ExportAttestation`] (Issue #223).
+///
+/// Hashes `page`'s full XDR encoding with SHA-256. XDR encoding of a
+/// `#[contracttype]` struct is deterministic for a given value — same
+/// records, same cursor state, same total, same bytes in, same bytes out —
+/// so two calls against unchanged state always produce the same digest, and
+/// any change to a single record, the total, or the pagination cursor
+/// changes it. The exact byte layout is XDR, not part of this contract's
+/// public surface; callers should treat the digest as opaque and compare it
+/// byte for byte rather than parse it.
+#[must_use]
+pub fn build_export_digest(env: &Env, page: &ExportPage) -> BytesN<32> {
+    let encoded: Bytes = page.clone().to_xdr(env);
+    env.crypto().sha256(&encoded).into()
+}
+
 // ── Stats ────────────────────────────────────────────────────────────────────
 
 // Wave #41: build_stats is the single centralized constructor for `Stats`.
@@ -1119,20 +1187,104 @@ pub fn is_in_cooldown(env: &Env, github_username: &String) -> bool {
 
 // ── Role-based access control ─────────────────────────────────────────────────
 
-pub fn get_role(env: &Env, address: &Address) -> Option<Role> {
-    env.storage().persistent().get(&(ROLE_KEY, address.clone()))
+/// Raw existence check against `ROLE_KEY`, ignoring expiry (Issue #221).
+///
+/// Used only to decide whether `set_role_with_expiry` is granting a brand new
+/// role (and therefore needs an index entry) versus refreshing one that
+/// already has an index entry, possibly expired. An expired-but-not-yet-
+/// `remove_role`'d entry must **not** be treated as new, or re-granting it
+/// would append a duplicate to the enumeration index.
+fn role_key_exists(env: &Env, address: &Address) -> bool {
+    env.storage().persistent().has(&(ROLE_KEY, address.clone()))
 }
 
-/// Grants `role` to `address` and keeps the enumeration index in step.
+/// The expiry timestamp for `address`'s current role grant, or `None` if it
+/// was granted with no expiry (the default via `set_role`), or if `address`
+/// holds no role at all (Issue #221).
+#[must_use]
+pub fn get_role_expiry(env: &Env, address: &Address) -> Option<u64> {
+    env.storage()
+        .persistent()
+        .get(&(ROLE_EXPIRY_KEY, address.clone()))
+}
+
+/// `true` once `address`'s role grant has an expiry and the ledger clock has
+/// reached or passed it (Issue #221). A grant with no expiry never expires.
+#[must_use]
+pub fn is_role_expired(env: &Env, address: &Address) -> bool {
+    match get_role_expiry(env, address) {
+        Some(expires_at) => env.ledger().timestamp() >= expires_at,
+        None => false,
+    }
+}
+
+/// Returns `address`'s currently active role, or `None` if it holds no role
+/// **or** its grant has expired (Issue #221).
+///
+/// Expiry is lazy: an expired grant's `ROLE_KEY` / `ROLE_EXPIRY_KEY` entries
+/// are left in storage untouched — only `remove_role` deletes them and drops
+/// the address from `get_role_holders`. Every role check in this contract
+/// (`verify`, `revoke_verification`, `batch_verify`, `get_role_holders`,
+/// `has_role_or_admin`) is built on this function, so a lapsed grant reads as
+/// "no role" everywhere without each call site re-checking expiry itself.
+pub fn get_role(env: &Env, address: &Address) -> Option<Role> {
+    let role: Option<Role> = env.storage().persistent().get(&(ROLE_KEY, address.clone()));
+    let role = role?;
+    if is_role_expired(env, address) {
+        return None;
+    }
+    Some(role)
+}
+
+/// Grants `role` to `address` with no expiry and keeps the enumeration index
+/// in step. Equivalent to `set_role_with_expiry(env, address, role, None)`.
 ///
 /// Re-granting to an address that already holds a role overwrites the role but
 /// must **not** append a second index entry, or the address would be reported
 /// twice by `get_role_holders`.
 pub fn set_role(env: &Env, address: &Address, role: &Role) {
-    let is_new = get_role(env, address).is_none();
+    set_role_with_expiry(env, address, role, None);
+}
+
+/// Grants `role` to `address`, optionally expiring at `expires_at` (a ledger
+/// timestamp) so a contractor or bot key cannot linger as a live `Verifier`
+/// or `Revoker` after off-boarding (Issue #221).
+///
+/// `expires_at: None` grants a role that never expires — identical to
+/// `set_role`. `Some(ts)` in the past or exactly `env.ledger().timestamp()`
+/// grants a role that reads as already expired the moment this call
+/// returns; the grant is still recorded (and still shows up, unexpired-index-
+/// wise, in `get_role_holders`) — it just never resolves as held by
+/// `get_role`. This is deliberate: it is simpler for callers to reason about
+/// than a validation error, and mirrors how the rest of this contract treats
+/// boundary timestamps (`is_role_expired` uses `>=`).
+///
+/// Re-granting to an address that already has a `ROLE_KEY` entry (expired or
+/// not) overwrites the role and expiry but does not touch the enumeration
+/// index a second time.
+///
+/// The contract admin's authority is never affected by this: `is_admin_caller`
+/// and `get_admin` read `ADMIN_KEY`, a separate, immutable storage slot that
+/// this function never touches — only the `Role::Admin` RBAC entry granted
+/// alongside it in `initialize` can expire, and only if a caller explicitly
+/// grants `Role::Admin` with an expiry through this function.
+pub fn set_role_with_expiry(env: &Env, address: &Address, role: &Role, expires_at: Option<u64>) {
+    let is_new = !role_key_exists(env, address);
     env.storage()
         .persistent()
         .set(&(ROLE_KEY, address.clone()), role);
+
+    let expiry_key = (ROLE_EXPIRY_KEY, address.clone());
+    match expires_at {
+        Some(ts) => {
+            env.storage().persistent().set(&expiry_key, &ts);
+            env.storage()
+                .persistent()
+                .extend_ttl(&expiry_key, TTL_THRESHOLD, TTL_BUMP);
+        }
+        None => env.storage().persistent().remove(&expiry_key),
+    }
+
     if is_new {
         add_to_role_index(env, address);
     }
@@ -1143,6 +1295,9 @@ pub fn remove_role(env: &Env, address: &Address) {
     env.storage()
         .persistent()
         .remove(&(ROLE_KEY, address.clone()));
+    env.storage()
+        .persistent()
+        .remove(&(ROLE_EXPIRY_KEY, address.clone()));
     remove_from_role_index(env, address);
 }
 
@@ -1207,7 +1362,11 @@ fn remove_from_role_index(env: &Env, address: &Address) {
 /// reported with a placeholder role: the index is maintained in lockstep with
 /// the role entries, so a miss means the two have drifted, and inventing a
 /// role for a stale index entry would hand the dashboard a privileged address
-/// that does not exist on chain.
+/// that does not exist on chain. Because the lookup goes through
+/// [`get_role`], an address whose grant has **expired** (Issue #221) is
+/// skipped the same way — expired role holders silently drop out of this
+/// listing until `remove_role` compacts the index, matching `get_role`'s
+/// "expired reads as absent" semantics.
 #[must_use]
 pub fn get_role_holders_internal(env: &Env, offset: u32, limit: u32) -> Vec<RoleHolder> {
     let capped = if limit == 0 || limit > MAX_ROLE_PAGE_LIMIT {
@@ -1282,6 +1441,75 @@ pub fn set_verification_config(env: &Env, attestation: Symbol, expires_in: u64, 
         threshold,
     };
     env.storage().instance().set(&VER_CFG_KEY, &config);
+}
+
+// ── Time-bounded verification (Issue #218) ───────────────────────────────────
+//
+// `config_verification`'s `expires_in` used to be stored and never read. A
+// stolen or transferred GitHub account stayed `verified` forever unless an
+// admin noticed and called `revoke_verification` — a verify-once-forever
+// flag keeps paying out an attacker indefinitely. This wires `expires_in`
+// into an actual expiry check, keyed off the ledger timestamp `verify()`
+// last ran at.
+//
+// Expiry here is **lazy**, the same policy `Role` expiry (Issue #221) uses:
+// `ContributorRecord.verified` is not flipped back to `false` in storage when
+// the window lapses. Instead, `is_verification_expired` is the source of
+// truth callers check alongside the raw flag; `is_verification_active` (in
+// `lib.rs`) combines the two into the single effective read. This keeps
+// `verified_count` / `get_stats` a cheap O(1) counter rather than a full
+// registry scan on every read — see the doc comment on `get_stats` for what
+// that counter does and does not include.
+
+/// Ledger timestamp `github_username` was last `verify()`'d, or `None` if it
+/// has never been verified (or `revoke_verification` cleared it) (Issue #218).
+#[must_use]
+pub fn get_verified_at(env: &Env, github_username: &String) -> Option<u64> {
+    env.storage()
+        .persistent()
+        .get(&(VERIFIED_AT_KEY, github_username.clone()))
+}
+
+/// Records the ledger timestamp of a successful `verify()` call.
+pub fn set_verified_at(env: &Env, github_username: &String, timestamp: u64) {
+    let key = (VERIFIED_AT_KEY, github_username.clone());
+    env.storage().persistent().set(&key, &timestamp);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+}
+
+/// Clears the recorded verification timestamp. Called by
+/// `revoke_verification` so a later fresh `verify()` is not compared against
+/// a stale timestamp from a previous, since-revoked grant.
+pub fn clear_verified_at(env: &Env, github_username: &String) {
+    env.storage()
+        .persistent()
+        .remove(&(VERIFIED_AT_KEY, github_username.clone()));
+}
+
+/// `true` once `github_username`'s verification has passed the configured
+/// `expires_in` window (Issue #218).
+///
+/// `false` whenever expiry cannot apply: verification was never configured
+/// (`config_verification` was never called), `expires_in == 0` (configured
+/// with no expiry), or the username has no recorded verification timestamp.
+/// Callers combine this with the raw `ContributorRecord.verified` flag —
+/// this function does not check `verified` itself, so it says nothing about
+/// whether the username is verified at all, only whether a **prior**
+/// verification's clock has run out.
+#[must_use]
+pub fn is_verification_expired(env: &Env, github_username: &String) -> bool {
+    let Some(config) = get_verification_config(env) else {
+        return false;
+    };
+    if config.expires_in == 0 {
+        return false;
+    }
+    let Some(verified_at) = get_verified_at(env, github_username) else {
+        return false;
+    };
+    env.ledger().timestamp() >= verified_at.saturating_add(config.expires_in)
 }
 
 // ── Audit log persistence ──────────────────────────────────────────────────
@@ -1557,4 +1785,94 @@ pub fn has_pending_rotation(env: &Env, github_username: &String) -> bool {
     env.storage()
         .persistent()
         .has(&(PENDING_ROT_KEY, github_username.clone()))
+}
+
+// ── Dual-control batch_remove (Issue #219) ───────────────────────────────────
+//
+// `batch_remove` used to be single-auth: one admin signature could delete up
+// to `MAX_WRITE_BATCH` registrations in one invocation. Above a configurable
+// size threshold, that single signature is no longer enough — the batch must
+// be proposed by one admin-equivalent address and executed by a *different*
+// one. Below the threshold, `batch_remove` is untouched.
+
+/// A large `batch_remove` proposed for dual-control execution.
+///
+/// Created by `propose_batch_remove`, consumed by `execute_batch_remove`
+/// (which performs the actual removals), and discardable at any time via
+/// `cancel_batch_remove`. Only one proposal may be pending at a time.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[soroban_sdk::contracttype]
+pub struct PendingBatchRemove {
+    /// The exact usernames to remove once executed.
+    pub usernames: Vec<String>,
+    /// The admin-equivalent address that proposed the batch. `execute_batch_remove`
+    /// rejects a caller equal to this address — dual control requires a
+    /// *second* key.
+    pub proposed_by: Address,
+    /// Ledger timestamp `propose_batch_remove` was called.
+    pub proposed_at: u64,
+}
+
+/// The configured `batch_remove` dual-control size threshold (Issue #219).
+///
+/// `0` (the default) disables dual control entirely: every batch, regardless
+/// of size, is executed directly by `batch_remove`'s single-admin path —
+/// identical to pre-#219 behavior. A non-zero threshold means any
+/// `batch_remove` call whose `usernames.len()` exceeds it must instead go
+/// through `propose_batch_remove` → `execute_batch_remove`.
+#[must_use]
+pub fn get_batch_remove_threshold(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&BATCH_REMOVE_THRESHOLD_KEY)
+        .unwrap_or(0)
+}
+
+pub fn set_batch_remove_threshold(env: &Env, threshold: u32) {
+    env.storage()
+        .instance()
+        .set(&BATCH_REMOVE_THRESHOLD_KEY, &threshold);
+}
+
+/// `true` when a batch of `batch_size` usernames must go through the
+/// propose/execute dual-control flow instead of `batch_remove` directly.
+///
+/// Strictly greater-than: a batch exactly *at* the threshold is still
+/// "below or at" and unaffected, matching `batch_remove`'s pre-#219 shape
+/// check (`size > 0 && size <= max_batch_size`) — only batches *above* the
+/// threshold require the second signature.
+#[must_use]
+pub fn requires_batch_remove_dual_control(env: &Env, batch_size: u32) -> bool {
+    let threshold = get_batch_remove_threshold(env);
+    threshold > 0 && batch_size > threshold
+}
+
+/// The pending large-batch proposal, if one exists — regardless of whether it
+/// has expired. `execute_batch_remove` is responsible for treating an expired
+/// proposal as gone; this raw getter just reports what is in storage.
+#[must_use]
+pub fn get_pending_batch_remove(env: &Env) -> Option<PendingBatchRemove> {
+    env.storage().instance().get(&PENDING_BATCH_REMOVE_KEY)
+}
+
+pub fn set_pending_batch_remove(env: &Env, proposal: &PendingBatchRemove) {
+    env.storage()
+        .instance()
+        .set(&PENDING_BATCH_REMOVE_KEY, proposal);
+}
+
+pub fn clear_pending_batch_remove(env: &Env) {
+    env.storage().instance().remove(&PENDING_BATCH_REMOVE_KEY);
+}
+
+/// `true` once a pending proposal's `BATCH_REMOVE_PROPOSAL_TTL_SECS` window
+/// has elapsed. A stale proposal that nobody executed or cancelled should not
+/// remain executable indefinitely — the operational context that justified
+/// the specific username list may no longer hold.
+#[must_use]
+pub fn is_batch_remove_proposal_expired(env: &Env, proposal: &PendingBatchRemove) -> bool {
+    env.ledger().timestamp()
+        >= proposal
+            .proposed_at
+            .saturating_add(BATCH_REMOVE_PROPOSAL_TTL_SECS)
 }


### PR DESCRIPTION
…h_remove

Time-bounded verification that expires stale verified flags Fixes #218

Dual-control for `batch_remove` above a size threshold Fixes #219

Role expiry timestamps so stale verifiers cannot linger Fixes #221

Signed export attestation helper for air-gapped audits Fixes #223