### PR TITLE
test: deny cross-contract callers on admin exports (#295)

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -1532,6 +1532,14 @@ cross-contract call. This is deliberate: the registry has no notion of a
 deployed contract could exfiltrate the full registry, not just the intended
 consumer.
 
+This deny is covered by tests, not just this note:
+`tests/integration.rs::cross_contract_caller_cannot_run_get_registered_paginated`,
+`…_get_registered_page`, and `…_get_all_registered` assert a contract caller
+fails auth on every admin export, while
+`cross_contract_public_read_surface_is_reachable` confirms the read surface
+above stays callable. See also `docs/SECURITY.md` §
+*Cross-Contract Callers and Admin Exports*.
+
 ### Example: a hypothetical payout contract reading verification status
 
 ```rust

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -26,6 +26,7 @@ Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [DEPL
 | Compromised or unpinned RPC client dependency | Crate validation checklist below |
 | Compromised Verifier key silently revoking payout eligibility | `Role::Verifier` and `Role::Revoker` are distinct — Issue #212 |
 | Admin force-removing a name without a grace period | Challenge flow enforces on-chain `resolve_after` delay — Issue #214 |
+| A deployed contract calling an admin export to exfiltrate the full registry | `admin.require_auth()` runs before any read; a cross-contract caller executes in its own auth context and cannot present the admin's signature — see [Cross-Contract Callers and Admin Exports](#cross-contract-callers-and-admin-exports) (Issue #295 / #149) |
 
 ### Out of Scope (handled off-chain)
 
@@ -35,6 +36,58 @@ Related docs: [README](../README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [DEPL
 | Username squatting policy | Social/process layer; contract allows first-come registration |
 | Admin key compromise | Operational security; use multisig for admin address |
 | GitHub username changes | Off-chain mapping updates; may require re-registration |
+
+---
+
+## Cross-Contract Callers and Admin Exports
+
+A sibling contract (for example, a payout contract) may call this registry
+cross-contract. `src/version.rs` exposes `CROSS_CONTRACT_READ_MIN_VERSION` /
+`Version::supports_cross_contract_reads()` so such a caller can assert
+compatibility the same way it does for `batch_verify`.
+
+### Read surface exposed to a contract caller (Issue #149)
+
+These functions are read-only (no `.set` / `.remove`) and require **no
+authorization** beyond the standard pause guard where noted, so a calling
+contract can invoke them with no signature from the registry admin or any
+registrant:
+
+| Function | Notes |
+|---|---|
+| `get_address(github_username)` | Core identity lookup |
+| `has_record(github_username)` | Cheap existence check |
+| `get_record_proof(github_username)` | Light-client existence proof |
+| `get_public_paginated(cursor, limit)` | Paginated read; returns `Paused` while the registry is paused |
+| `get_stats()` | `{ total, verified, ever_verified }` |
+| `get_verified_count()` / `get_ever_verified_count()` | Live / monotonic counts |
+| `get_role(address)` | RBAC lookup, e.g. to gate a payout on `Role::Verifier` |
+| `is_paused()` / `is_contract_paused()` | Pause-state check |
+| `is_registration_in_cooldown(github_username)` | Cooldown-window check |
+| `version()` / `is_compatible(major, minor, patch)` | Version handshake |
+| `max_username_len()` / `is_username_valid(...)` / `usernames_match(...)` | Pure validation helpers |
+
+The canonical copy of this list lives in `docs/ABI.md` §
+*Cross-Contract Read Interface*; keep the two in sync.
+
+### Admin exports are **not** part of that surface
+
+`get_all_registered`, `get_registered_page`, and `get_registered_paginated`
+each call `admin.require_auth()` before touching storage. A cross-contract
+invocation executes in the **calling** contract's authorization context — it
+cannot supply the registry admin's signature — so these calls fail auth when
+invoked from another contract, regardless of the caller's identity or how the
+test environment mocks auth. This is deliberate: the registry has no
+"trusted contract" allowlist, so a widened export surface would let *any*
+deployed contract exfiltrate the entire registry, not just an intended
+consumer. A sibling contract that needs a bulk export must go through the
+admin's own off-chain tooling.
+
+This is enforced by tests, not left as a comment:
+`tests/integration.rs::cross_contract_caller_cannot_run_get_registered_paginated`,
+`…_get_registered_page`, `…_get_all_registered`, and
+`cross_contract_public_read_surface_is_reachable` (the positive control), plus
+`src/version.rs::test_export_paginated_requires_admin_auth`.
 
 ---
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2744,3 +2744,118 @@ fn test_protocol_upgrade_rehearsal() {
         assert_eq!(final_stats.verified, 2, "both alice and bob verified");
     });
 }
+
+// ── Cross-contract deny: admin exports (Issue #295 / #149) ────────────────────
+//
+// `src/version.rs` (`CROSS_CONTRACT_READ_MIN_VERSION` doc) and
+// `docs/ABI.md` § Cross-Contract Read Interface both state that the
+// admin-gated exports — `get_all_registered`, `get_registered_page`,
+// `get_registered_paginated` — cannot be invoked cross-contract: each calls
+// `admin.require_auth()`, and a *calling* contract executes in its own
+// authorization context, so it cannot present the registry admin's signature.
+//
+// These tests pin that as behaviour rather than a comment: a contract acting
+// as the caller must fail auth on every admin export, while the documented
+// public read surface stays callable from the same contract.
+
+use soroban_sdk::{contract, contractimpl, IntoVal, Symbol, Vec as SdkVec};
+
+/// A stand-in for a sibling contract (e.g. a payout contract) that reads the
+/// registry cross-contract.
+#[contract]
+struct RegistryConsumer;
+
+#[contractimpl]
+impl RegistryConsumer {
+    /// Public read — documented as safe to call cross-contract.
+    pub fn probe(env: Env, registry: Address, username: String) -> bool {
+        env.invoke_contract(
+            &registry,
+            &Symbol::new(&env, "has_record"),
+            (username,).into_val(&env),
+        )
+    }
+
+    /// Admin export via cursor pagination — must trap on auth.
+    pub fn siphon_paginated(env: Env, registry: Address) -> u32 {
+        let page: trustbridge_contract::ExportPage = env.invoke_contract(
+            &registry,
+            &Symbol::new(&env, "get_registered_paginated"),
+            (0u32, 50u32).into_val(&env),
+        );
+        page.records.len()
+    }
+
+    /// Admin export via offset pagination — must trap on auth.
+    pub fn siphon_page(env: Env, registry: Address) -> u32 {
+        let page: trustbridge_contract::ExportPage = env.invoke_contract(
+            &registry,
+            &Symbol::new(&env, "get_registered_page"),
+            (0u32, 50u32).into_val(&env),
+        );
+        page.records.len()
+    }
+
+    /// Admin export of the whole index — must trap on auth.
+    pub fn siphon_all(env: Env, registry: Address) -> u32 {
+        let rows: SdkVec<(String, Address)> = env.invoke_contract(
+            &registry,
+            &Symbol::new(&env, "get_all_registered"),
+            ().into_val(&env),
+        );
+        rows.len()
+    }
+}
+
+fn deny_setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    let registry = env.register(TrustBridgeContract, ());
+    env.as_contract(&registry, || {
+        TrustBridgeContract::initialize(env.clone(), Address::generate(&env)).unwrap();
+    });
+    let consumer = env.register(RegistryConsumer, ());
+    (env, registry, consumer)
+}
+
+/// The public read surface documented for cross-contract use stays reachable
+/// from another contract with no admin signature involved.
+#[test]
+fn cross_contract_public_read_surface_is_reachable() {
+    let (env, registry, consumer) = deny_setup();
+    let client = RegistryConsumerClient::new(&env, &consumer);
+    // `has_record` on an absent username returns false without any auth.
+    assert!(!client.probe(&registry, &s(&env, "nobody")));
+}
+
+/// Each admin export must fail when the caller is a contract. No
+/// `env.mock_all_auths()` here: the consumer contract has no path to the
+/// registry admin's signature, which is exactly the condition being asserted.
+#[test]
+fn cross_contract_caller_cannot_run_get_registered_paginated() {
+    let (env, registry, consumer) = deny_setup();
+    let res = RegistryConsumerClient::new(&env, &consumer).try_siphon_paginated(&registry);
+    assert!(
+        res.is_err(),
+        "a contract caller must not export the registry via get_registered_paginated"
+    );
+}
+
+#[test]
+fn cross_contract_caller_cannot_run_get_registered_page() {
+    let (env, registry, consumer) = deny_setup();
+    let res = RegistryConsumerClient::new(&env, &consumer).try_siphon_page(&registry);
+    assert!(
+        res.is_err(),
+        "a contract caller must not export the registry via get_registered_page"
+    );
+}
+
+#[test]
+fn cross_contract_caller_cannot_run_get_all_registered() {
+    let (env, registry, consumer) = deny_setup();
+    let res = RegistryConsumerClient::new(&env, &consumer).try_siphon_all(&registry);
+    assert!(
+        res.is_err(),
+        "a contract caller must not export the registry via get_all_registered"
+    );
+}


### PR DESCRIPTION
## What & why

Issue #295: `src/version.rs` (`CROSS_CONTRACT_READ_MIN_VERSION` doc) and `docs/ABI.md` § Cross-Contract Read Interface both state that the admin-gated exports cannot be invoked cross-contract — a calling contract runs in its own authorization context and cannot present the registry admin's signature. That guarantee was only a comment. This PR makes it an executable test and documents the read surface.

## Changes

### Tests — `tests/integration.rs`

A `RegistryConsumer` stand-in contract (a `#[contract]` that reads the registry via `env.invoke_contract`), plus:

| Test | Asserts |
|---|---|
| `cross_contract_caller_cannot_run_get_registered_paginated` | contract caller fails auth on `get_registered_paginated` |
| `cross_contract_caller_cannot_run_get_registered_page` | contract caller fails auth on `get_registered_page` |
| `cross_contract_caller_cannot_run_get_all_registered` | contract caller fails auth on `get_all_registered` |
| `cross_contract_public_read_surface_is_reachable` | **positive control** — `has_record` stays callable cross-contract |

The deny tests deliberately do **not** call `env.mock_all_auths()`: the condition being asserted is precisely that the consumer contract has no path to the admin's signature. `admin.require_auth()` runs before any storage read, so the invocation traps and `try_*` returns `Err`.

### Docs

- **`docs/SECURITY.md`** — new "Cross-Contract Callers and Admin Exports" section:
  - the full list of functions a contract caller **may** invoke (the #149 read surface), cross-referenced to the canonical copy in `docs/ABI.md`;
  - why the three admin exports are excluded (no "trusted contract" allowlist → widening the surface = any deployed contract can exfiltrate the whole registry);
  - a threat-model row for the exfiltration attempt.
- **`docs/ABI.md`** — the Cross-Contract Read Interface section now links the deny tests.

## Scope

- **In:** tests + docs.
- **Out:** allowing cross-contract writes; any change to the read surface exposed to the action.

## Cross-contract-readable functions (Issue #149)

`get_address`, `has_record`, `get_record_proof`, `get_public_paginated`, `get_stats`, `get_verified_count`, `get_ever_verified_count`, `get_role`, `is_paused` / `is_contract_paused`, `is_registration_in_cooldown`, `version` / `is_compatible`, `max_username_len` / `is_username_valid` / `usernames_match`.

**Excluded (admin-auth):** `get_all_registered`, `get_registered_page`, `get_registered_paginated`.

## Notes for the reviewer

`main` does not currently compile (pre-existing: botched merge of #280/#281 in `src/lib.rs` and `src/error.rs`, and `tests/integration.rs` `register(...)` call sites that don't match the merged `register` signature). The new tests are written against the documented API and add no dependency on the broken sites; they will run once the base compiles.

Closes #295
