### PR TITLE
fix: remove unenforced record_action cooldown trap (#296)

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -1482,6 +1482,31 @@ unable to detect the drift, so the bump is a review blocker.
 
 ---
 
+## Registration cooldown (Issue #4 / #296)
+
+The per-username registration cooldown is **enforced by the contract itself** —
+there is no helper an integrator has to remember to call.
+
+- `set_cooldown(seconds)` (admin-only) configures the window; `0` disables it.
+- On a **successful** mutation, `register`, `verify`, and the
+  username/address-change paths stamp the username's last-action timestamp.
+- While the window is open, a follow-up mutation on that username fails with
+  `CooldownActive` (code 8). A username with no prior recorded action is never
+  in cooldown, so first-time registration always succeeds immediately.
+- `is_registration_in_cooldown(github_username) -> bool` is the **read-only**
+  view of that state, for dashboards, the action runner, and cross-contract
+  callers.
+
+There is **no `record_action` entry point.** An earlier build exported a
+public, unauthenticated `record_action(github_username)` that simply wrote the
+current timestamp. Because it took no auth, any caller could push an arbitrary
+username into cooldown and block its registration — a griefing vector — and it
+was redundant once enforcement moved inline. It was removed in Issue #296. If
+you called it, delete the call: the cooldown is applied automatically by the
+mutating functions above.
+
+---
+
 ## Cross-Contract Read Interface
 
 Sibling TrustBridge contracts (payout, attestation, and future Waves) can

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -159,8 +159,15 @@ The contract enforces per-username action rate-limiting during `register()`:
 
 - When `cooldown` is non-zero, `register()` checks whether `is_in_cooldown()` is true for `github_username`.
 - If the configured cooldown window has not elapsed since the username's last mutating action, `register()` fails with `CooldownActive` (code 8).
-- Upon a successful `register()`, the username's last action timestamp is updated via `set_last_action()`.
+- Upon a successful `register()`, the username's last action timestamp is updated via `set_last_action()`. `verify()` and the username/address-change paths stamp it the same way.
 - First-time registrations have no recorded prior action timestamp (0), allowing initial registration to succeed immediately.
+
+**Enforcement is inline and automatic.** There is no public `record_action`
+entry point. An earlier build exported an unauthenticated
+`record_action(github_username)` timestamp setter; because it required no auth,
+any caller could push an arbitrary username into cooldown and block its
+registration. It was removed in Issue #296. `is_registration_in_cooldown()`
+remains as the read-only view of the enforced state.
 
 ---
 

--- a/docs/STORAGE_FOOTPRINT.md
+++ b/docs/STORAGE_FOOTPRINT.md
@@ -70,10 +70,11 @@ or the target network's resource config changes:
 - **Role grants:** 1 (the initial admin — `initialize` calls `set_role` for
   it). Each additional `set_role` call adds one fixed-size persistent entry,
   independent of N.
-- **Cooldown tracking (`lastact`):** 0 by default. These entries are only
-  created when `record_action` is called for a username, so they track a
-  subset of active users, not all N — add `52 bytes × (tracked usernames)`
-  if cooldown enforcement is in active use.
+- **Cooldown tracking (`lastact`):** 0 by default. An entry is created the
+  first time a username completes a mutating action (`register`, `verify`, or a
+  username/address change) while a non-zero cooldown is configured, so they
+  track a subset of active users, not all N — add `52 bytes × (tracked
+  usernames)` if cooldown enforcement is in active use.
 - **All N registrations are live** (none removed). A `remove` frees its
   `(reg, *)` and chunk-slot bytes but the flat `idx` rewrite cost (see below)
   is the same regardless of net growth or churn.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2876,19 +2876,19 @@ impl TrustBridgeContract {
         is_admin_caller(&env, &caller)
     }
 
-    /// Records that `github_username` performed a registry-mutating action at the current
-    /// ledger timestamp, for use by cooldown enforcement logic.
-    ///
-    /// Off-chain callers use this alongside `is_registration_in_cooldown` to implement
-    /// per-contributor rate limiting without requiring a contract upgrade.
-    pub fn record_action(env: Env, github_username: String) {
-        set_last_action(&env, &github_username, env.ledger().timestamp());
-    }
-
     /// Returns `true` if `github_username` is still within the registration cooldown window.
     ///
     /// Read-only; no auth required. The cooldown period is set by `set_cooldown`. Returns
-    /// `false` if no action has been recorded or the cooldown has elapsed.
+    /// `false` if no mutating action has been recorded for the username or the cooldown has
+    /// elapsed.
+    ///
+    /// The cooldown is enforced **automatically** by the contract: `register`, `verify`,
+    /// and the username/address change paths stamp the username's last-action timestamp on
+    /// success and reject a follow-up mutation with [`ContractError::CooldownActive`] until
+    /// the window elapses. This function is the read-only view of that state for off-chain
+    /// tooling and cross-contract callers — there is no separate `record_action` entry
+    /// point to call (it was removed in Issue #296: an unauthenticated public timestamp
+    /// setter let any caller push an arbitrary username into cooldown).
     #[must_use]
     pub fn is_registration_in_cooldown(env: Env, github_username: String) -> bool {
         is_in_cooldown(&env, &github_username)
@@ -7965,6 +7965,61 @@ mod test {
             // After cooldown elapses, re-registration succeeds
             TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user2.clone(), Vec::new(&env))
                 .unwrap();
+        });
+    }
+
+    // Issue #296: `is_registration_in_cooldown` is the read-only view of the
+    // cooldown that `register` enforces inline. It must flip to `true` purely as
+    // a side effect of a successful `register` — with no `record_action` call,
+    // which no longer exists — and back to `false` once the window elapses.
+    #[test]
+    fn test_is_registration_in_cooldown_tracks_auto_enforcement() {
+        let env = Env::default();
+        let (_admin, user1, user2, contract_id) = setup(&env);
+
+        env.ledger().set_timestamp(5_000);
+        env.mock_all_auths();
+
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_cooldown(env.clone(), 100).unwrap();
+
+            // Unknown username: never in cooldown.
+            assert!(!TrustBridgeContract::is_registration_in_cooldown(
+                env.clone(),
+                username(&env, "octocat")
+            ));
+
+            // A successful register stamps the cooldown with no extra call.
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user1.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+            assert!(TrustBridgeContract::is_registration_in_cooldown(
+                env.clone(),
+                username(&env, "octocat")
+            ));
+
+            // And the enforced mutation agrees with the read.
+            assert_eq!(
+                TrustBridgeContract::register(
+                    env.clone(),
+                    username(&env, "octocat"),
+                    user2.clone(),
+                    Vec::new(&env),
+                ),
+                Err(ContractError::CooldownActive)
+            );
+        });
+
+        env.ledger().set_timestamp(5_000 + 101);
+        env.as_contract(&contract_id, || {
+            assert!(!TrustBridgeContract::is_registration_in_cooldown(
+                env.clone(),
+                username(&env, "octocat")
+            ));
         });
     }
 


### PR DESCRIPTION
## What & why

Issue #296: `record_action` / `is_registration_in_cooldown` were exported as cooldown helpers, but the cooldown was already enforced elsewhere — integrators reading the ABI would think calling `record_action` was required to block squatting, when it does nothing of the sort.

Issue #4 has landed: the per-username registration cooldown is enforced **inline** by `register`, `verify`, and the username/address-change paths. Each checks `is_in_cooldown(username)` before mutating and calls `set_last_action(username, now)` on success; a follow-up mutation inside the window fails with `CooldownActive` (code 8).

That leaves `record_action(github_username)` as a **trap**:

- It is `pub` (a contract entry point) but takes **no auth** and just writes `env.ledger().timestamp()` to the username's last-action slot.
- Any caller could therefore push an arbitrary username into cooldown and block its registration — a griefing vector.
- It has **no internal callers** and is **not listed in `docs/ABI.md`** — it was already an undocumented, unenforced leftover.

Per the issue: "Either fully wire both paths or un-export and document internal-only." Since enforcement is already automatic and complete, the coherent choice is to remove the redundant, dangerous setter.

## Changes

- **`src/lib.rs`** — delete `record_action`. Keep `is_registration_in_cooldown` (the read-only view of the enforced state) and expand its doc comment: enforcement is automatic, there is no `record_action` entry point.
- **`docs/ABI.md`** — new "Registration cooldown (Issue #4 / #296)" section: one coherent story — `set_cooldown` configures it, the mutating functions enforce it, `is_registration_in_cooldown` reads it, and there is no `record_action`.
- **`docs/SECURITY.md`** — "Registration cooldown enforcement" updated to state enforcement is inline/automatic and record the removal.
- **`docs/STORAGE_FOOTPRINT.md`** — `lastact` entries are created by a successful mutating action, not by `record_action`.
- **Test** — `test_is_registration_in_cooldown_tracks_auto_enforcement`: the read flips to `true` purely as a side effect of a successful `register` (no `record_action` call), the enforced mutation returns `CooldownActive`, and the read returns to `false` after the window elapses.

## Scope

- **In:** remove the trap from the ABI + docs + tests.
- **Out:** a second cooldown design. One mechanism only: inline enforcement + read accessor.

## Watch-for from the issue

- **External callers already invoking `record_action`:** it was undocumented and unauthenticated; anyone relying on it was relying on a griefing primitive. The ABI/SECURITY notes tell integrators to delete the call — the cooldown now applies automatically.
- **pause / remove path:** unaffected — `remove` does not stamp the cooldown and never did.

## Notes for the reviewer

`main` does not currently compile (pre-existing: botched merge of #280/#281 corrupted `register` / `attest_upgrade` in `src/lib.rs` and duplicated discriminants in `src/error.rs`). This change only deletes one self-contained function and edits docs/tests; it does not touch the broken sites.

Closes #296
