### PR TITLE
Sorted-chunk skip optimization for has_record at registry scale (#291)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,6 +84,16 @@ pub enum EntityType {
 
 - **`idx` index:** Soroban does not support iterating arbitrary storage keys. The username index enables `get_all_registered()` without scanning the entire ledger.
 - **`vcount` counter:** Maintained incrementally so `get_stats()` is O(1) rather than scanning all records.
+- **Single-record reads are O(1) (Issue #291):** `has_record`, `get_address`,
+  and `get_record_proof` resolve through a direct persistent-key lookup on
+  `(REG_KEY, github_username)`. They never walk the flat `idx` index or the
+  chunked index, so their cost is independent of the number of registrations
+  and the number of chunks — a registry with 10k users across 200 chunks reads
+  a single username in exactly the same number of storage operations as an
+  empty one. The chunked index is only consulted by the explicitly paginated
+  export paths (`get_public_paginated`, `get_registered_page`), never by point
+  lookups. `has_record` additionally skips deserialization and the TTL bump
+  that `get_record` performs.
 - **Re-registration:** Updating an existing username overwrites the record. If the Stellar address changes, `verified` resets to `false` unless the address is unchanged.
 - **Rent / Wave budgeting:** Dashboard UIs that estimate storage rent from N
   users should consume the versioned estimator inputs in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1609,19 +1609,27 @@ impl TrustBridgeContract {
     ///
     /// Read-only; no auth required. Use this for payout address resolution in GitHub Actions
     /// and dashboard lookups.
+    ///
+    /// **Complexity: O(1).** Resolved by a single direct persistent-key read of
+    /// `(REG_KEY, github_username)`; it never scans the flat or chunked username
+    /// index, so its cost is independent of registry size or chunk count
+    /// (Issue #291).
     #[must_use]
     pub fn get_address(env: Env, github_username: String) -> Option<ContributorRecord> {
-        if has_record(&env, &github_username) {
-            get_record(&env, &github_username)
-        } else {
-            None
-        }
+        // One direct-key read. `get_record` already returns `None` for a missing
+        // entry, so the previous `has_record` pre-check only doubled the storage
+        // work (Issue #291).
+        get_record(&env, &github_username)
     }
 
     /// Returns `true` if `github_username` is registered, without deserializing the full record.
     ///
     /// Read-only; no auth required. Use this when callers only need existence confirmation
     /// and do not need the [`ContributorRecord`] fields.
+    ///
+    /// **Complexity: O(1).** A direct persistent-key `has` on
+    /// `(REG_KEY, github_username)` — no index scan, no deserialization, no TTL
+    /// bump (Issue #291).
     #[must_use]
     pub fn has_record(env: Env, github_username: String) -> bool {
         has_record(&env, &github_username)
@@ -8245,6 +8253,64 @@ mod test {
             TrustBridgeContract::register(env.clone(), username(&env, "user050"), addr51, Vec::new(&env)).unwrap();
             let chunk_count_at_51 = crate::storage::get_chunk_count(&env);
             assert_eq!(chunk_count_at_51, 2, "51st entry must create a second chunk");
+        });
+    }
+
+    /// Issue #291: `has_record` / `get_address` must resolve by direct persistent
+    /// key and never scan the chunked index, so they stay correct — and O(1) —
+    /// with the registry spread across many chunks.
+    #[test]
+    fn test_has_record_is_direct_key_across_many_chunks() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+
+        // Enough users to fill several chunks (CHUNK_SIZE == 50).
+        const N: u32 = 260;
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            for i in 0..N {
+                let name = format!("user{i:04}");
+                let addr = Address::generate(&env);
+                TrustBridgeContract::register(
+                    env.clone(),
+                    username(&env, &name),
+                    addr,
+                    Vec::new(&env),
+                )
+                .unwrap();
+            }
+
+            // The index really is chunked now.
+            assert!(
+                crate::storage::get_chunk_count(&env) >= 5,
+                "expected the registry to span multiple chunks"
+            );
+
+            // A user in the very first chunk, one in the last, and one in the
+            // middle all resolve — a chunk scan that stopped early would miss
+            // some of these.
+            for name in ["user0000", "user0130", &format!("user{:04}", N - 1)] {
+                assert!(
+                    TrustBridgeContract::has_record(env.clone(), username(&env, name)),
+                    "has_record must find '{name}' regardless of which chunk holds it"
+                );
+                assert!(
+                    TrustBridgeContract::get_address(env.clone(), username(&env, name)).is_some(),
+                    "get_address must find '{name}' regardless of which chunk holds it"
+                );
+            }
+
+            // A never-registered username must report absent without scanning
+            // every chunk looking for it.
+            assert!(
+                !TrustBridgeContract::has_record(env.clone(), username(&env, "ghost")),
+                "has_record must not report a phantom record"
+            );
+            assert!(
+                TrustBridgeContract::get_address(env.clone(), username(&env, "ghost")).is_none(),
+                "get_address must return None for an unregistered username"
+            );
         });
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -530,8 +530,18 @@ pub fn remove_record(env: &Env, github_username: &String) {
     env.storage().persistent().remove(&key);
 }
 
+/// Existence check for a single registration.
+///
+/// **Complexity: O(1).** This is a direct persistent-key `has` on
+/// `(REG_KEY, github_username)` — it never touches the flat or chunked
+/// username index, so its cost does not grow with the number of registrations
+/// or chunks (Issue #291). It also does not deserialize the
+/// [`ContributorRecord`] or extend its TTL; callers that need the record or a
+/// TTL bump must go through [`get_record`].
 pub fn has_record(env: &Env, github_username: &String) -> bool {
-    get_record(env, github_username).is_some()
+    env.storage()
+        .persistent()
+        .has(&(REG_KEY, github_username.clone()))
 }
 
 /// Build the light-client existence proof for `github_username` (Issue #230).


### PR DESCRIPTION
Closes #291

## Audit result

Every single-record read path was traced end to end:

| Entry point | Path | Index touched? |
|---|---|---|
| `get_address` | → `storage::get_record` → persistent `get(&(REG_KEY, username))` | No |
| `has_record` | → `storage::has_record` → persistent `has(&(REG_KEY, username))` | No |
| `get_record_proof` | → `storage::build_record_proof` → `storage::get_record` | No |

None of them iterate the flat `idx` index or the chunked index. The chunked
index (`get_chunk` / `get_chunk_count`) is consulted **only** by the explicitly
paginated paths (`get_public_paginated`, `get_registered_page`, compaction,
migration). So point reads are already O(1) with respect to registry size and
chunk count — a lookup against a 10k-user / 200-chunk registry costs exactly the
same number of storage ops as against an empty one. **No chunk scan exists on
these paths; no index type was added.**

## Fix

Two inefficiencies found and corrected while auditing (both strictly reduce the
register/read budget, neither changes semantics):

1. **`storage::has_record` was not actually O(1)-cheap.** It was implemented as
   `get_record(env, u).is_some()`, which deserializes the whole
   `ContributorRecord` *and* performs a TTL `extend_ttl` write — directly
   contradicting its documented "without deserializing the full record"
   contract. Now it is a bare `env.storage().persistent().has(&(REG_KEY, u))`:
   no decode, no write.

2. **`get_address` did two storage reads for one lookup** (`has_record` then
   `get_record`). Collapsed to a single `get_record`, which already returns
   `None` for a missing entry.

## Complexity documented

`docs/ARCHITECTURE.md` → Design Notes now states that `has_record`,
`get_address`, and `get_record_proof` are O(1) direct-key reads that never walk
either index, and that only the paginated export paths consult the chunked
index. The rustdoc on all three entry points carries the same **Complexity: O(1)**
note.

## Tests

`test_has_record_is_direct_key_across_many_chunks` — registers 260 users
(≥ 5 chunks at `CHUNK_SIZE == 50`) and asserts that `has_record` / `get_address`
resolve correctly for a username in the first chunk, the middle, and the last
chunk, plus a negative lookup for a never-registered name (a chunk scan that
bailed early would miss the later chunks; a scan for the absent name would walk
all of them).

> Note: `main` does not currently compile (an unrelated botched merge around
> `register` / `emergency_pause` in `src/lib.rs`), so `cargo test has_record`
> could not be executed on top of this branch. The change itself is a
> self-contained one-liner in `storage.rs` plus a docs/test addition.