### PR TITLE
Rate-limit verifies per verifier per ledger to reduce griefing (#292)

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -146,6 +146,7 @@ struct ChallengeRecord {
 | 19 | `ChallengeNotResolvable` | `complete_challenge` called before the delay has elapsed |
 | 20 | `ChallengeActive` | `register` attempted while a challenge is active on the username |
 | 21 | `NetworkMismatch` | Instance state was initialized on a different network than the one executing (Issue #231) |
+| 30 | `VerifyRateLimited` | Non-admin caller exceeded the per-verifier, per-ledger verify/revoke cap (Issue #292) |
 
 `ContractError::from_code(u32)` maps every code in this table back to the typed
 variant and returns `None` for any unrecognized code. Every code round-trips
@@ -980,6 +981,31 @@ Configures the WASM upgrade timelock cooldown period in seconds. Admin-only.
 ### `get_cooldown() -> u64`
 
 Returns the current WASM upgrade timelock cooldown period in seconds.
+
+---
+
+### `set_verify_limit(limit: u32) -> Result<(), ContractError>`
+
+Sets the per-verifier, per-ledger cap on verify/revoke units (Issue #292).
+Admin-only.
+
+- `verify` and `revoke_verification` each spend 1 unit; `batch_verify` spends
+  one unit per requested username.
+- A non-admin caller exceeding `limit` units in one ledger gets
+  `VerifyRateLimited` (code 30); the call writes nothing.
+- `limit == 0` disables rate limiting. With no configured value the contract
+  uses a built-in default of 20.
+- The **admin is never rate-limited.**
+
+| **Errors** | `NotInitialized`, `NotAuthorized` |
+
+---
+
+### `get_verify_limit() -> u32`
+
+Returns the active per-verifier, per-ledger verify/revoke cap: the configured
+value when set (including `0` = disabled), otherwise the built-in default.
+Read-only; no auth.
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -562,6 +562,58 @@ The `revoke_verification` function guards:
 
 ---
 
+## Verifier Rate Limiting (Issue #292)
+
+### Threat
+
+A Verifier or Revoker key — legitimately issued, or compromised — can call
+`verify`, `revoke_verification`, and `batch_verify` as fast as it can submit
+transactions. During a Wave this bloats the contract event stream and consumes
+instruction budget for every other caller. Before this control, `pause` was the
+only brake, and `batch_verify` made the problem *worse* because one call could
+touch up to `MAX_WRITE_BATCH` records.
+
+### Control
+
+An on-chain counter caps the number of **verify/revoke units** a single
+non-admin actor may spend per ledger:
+
+| Path | Units charged |
+|------|---------------|
+| `verify` | 1 (charged after auth, before any state read — junk usernames still count) |
+| `revoke_verification` | 1 |
+| `batch_verify` | `usernames.len()` — the **requested** size, before dedup/skip, charged atomically |
+
+- **Key:** `(Symbol("vfyrate"), actor_address)` in persistent storage, value
+  `(ledger_seq, units_spent)`.
+- **Ledger rollover:** the first call in a new ledger observes a stale
+  `ledger_seq` and resets `units_spent` to 0. There is no cross-ledger carry and
+  no unbounded growth — a single entry per actor, overwritten in place.
+- **Exceed → reject whole, write nothing:** the charge is computed before the
+  write; if it would push this ledger's spend past the cap, the call returns
+  `VerifyRateLimited` (code 30) having mutated no state (no record, no counter,
+  no event).
+- **Configurable:** `set_verify_limit(limit)` (admin-only). `limit == 0`
+  disables the check. With no configured value the contract uses
+  `DEFAULT_VERIFIES_PER_LEDGER` (20). `get_verify_limit()` is a public read.
+
+### Admin bypass (documented and intentional)
+
+The **admin is never rate-limited.** Callers check `is_admin_caller` first and
+the admin path never reaches `charge_verify_rate`. Incident response — mass
+revoke after a detected fraud, mass verify to clear a backlog — must not be
+throttled by the same mechanism that throttles a griefer. An admin key is
+already the maximum-trust key in the system; adding a rate limit to it would
+only create a denial-of-service against recovery.
+
+### Not covered
+
+- **Reads are never rate-limited.** Only the mutating verify/revoke paths carry
+  the counter.
+- Off-chain / RPC-level rate limiting is out of scope for the contract.
+
+---
+
 ## Responsible Disclosure
 
 If you discover a security vulnerability:

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,7 @@ use soroban_sdk::contracterror;
 /// | 19 | `NotReserved` | `remove_reserved` |
 /// | 20 | `UsernameReserved` | `register` |
 /// | 21 | `ReservedListFull` | `add_reserved` |
+/// | 30 | `VerifyRateLimited` | `verify`, `batch_verify`, `revoke_verification` |
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -96,6 +97,10 @@ pub enum ContractError {
     NoPendingAdminTransfer = 28,
     /// `upgrade` was called without a required attestation (attestation-required mode is on).
     AttestationRequired = 29,
+    /// A non-admin caller exceeded the per-verifier, per-ledger verify/revoke
+    /// rate limit (Issue #292). Raised by `verify`, `batch_verify`, and
+    /// `revoke_verification`. The admin is exempt.
+    VerifyRateLimited = 30,
 }
 
 impl ContractError {
@@ -140,6 +145,7 @@ impl ContractError {
             27 => Some(ContractError::AdminTransferDelayActive),
             28 => Some(ContractError::NoPendingAdminTransfer),
             29 => Some(ContractError::AttestationRequired),
+            30 => Some(ContractError::VerifyRateLimited),
             _ => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@ use crate::storage::{
     ADMIN_KEY,
     get_guardian as storage_get_guardian,
     remove_guardian as storage_remove_guardian,
+    charge_verify_rate, get_verify_limit as storage_get_verify_limit,
+    set_verify_limit as storage_set_verify_limit,
 };
 
 use crate::utils::{
@@ -720,6 +722,41 @@ impl TrustBridgeContract {
     #[must_use]
     pub fn get_cooldown(env: Env) -> u64 {
         storage_get_cooldown(&env)
+    }
+
+    /// Sets the per-verifier, per-ledger cap on verify/revoke units (Issue #292).
+    /// Admin-only.
+    ///
+    /// One `verify` or `revoke_verification` call spends one unit; one
+    /// `batch_verify` spends one unit per requested username. When a non-admin
+    /// caller would exceed `limit` units in a single ledger, the call fails with
+    /// [`ContractError::VerifyRateLimited`] and writes nothing.
+    ///
+    /// `limit == 0` disables the check entirely. With no configured value the
+    /// contract uses a built-in default (`DEFAULT_VERIFIES_PER_LEDGER`).
+    ///
+    /// The admin is never rate-limited — incident response must not be throttled.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the contract admin.
+    pub fn set_verify_limit(env: Env, limit: u32) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        storage_set_verify_limit(&env, limit);
+        Ok(())
+    }
+
+    /// Returns the active per-verifier, per-ledger verify/revoke cap (Issue #292).
+    ///
+    /// This is the configured value when the admin has set one (including `0`,
+    /// meaning disabled), otherwise the built-in default. Read-only; no auth.
+    #[must_use]
+    pub fn get_verify_limit(env: Env) -> u32 {
+        storage_get_verify_limit(&env)
     }
 
     fn register_personal(env: &Env, contract_id: &soroban_sdk::Address, name: &str, addr: &Address) {
@@ -1923,6 +1960,13 @@ impl TrustBridgeContract {
             return Err(ContractError::NotAuthorized);
         }
 
+        // Per-verifier, per-ledger anti-grief cap (Issue #292). Charged before
+        // any state read so a spammer calling `verify` on junk usernames still
+        // pays into the limit. The admin is exempt.
+        if !is_admin {
+            charge_verify_rate(&env, &caller, 1)?;
+        }
+
         let mut record = get_record(&env, &github_username).ok_or(ContractError::NotRegistered)?;
 
         if record.verified {
@@ -1990,6 +2034,15 @@ impl TrustBridgeContract {
         let is_verifier = storage_get_role(&env, &caller) == Some(Role::Verifier);
         if !is_admin && !is_verifier {
             return Err(ContractError::NotAuthorized);
+        }
+
+        // A batch spends one rate-limit unit per requested username, so a batch
+        // call cannot be used to exceed the per-ledger cap a loop of single
+        // `verify` calls would hit (Issue #292). Counted on the requested size,
+        // before dedup/skip, and charged atomically: if the batch would blow the
+        // cap it is rejected whole, having written nothing. Admin is exempt.
+        if !is_admin {
+            charge_verify_rate(&env, &caller, usernames.len())?;
         }
 
         let total = usernames.len();
@@ -2113,6 +2166,13 @@ impl TrustBridgeContract {
         let is_revoker = storage_get_role(&env, &caller) == Some(Role::Revoker);
         if !is_admin && !is_revoker {
             return Err(ContractError::NotAuthorized);
+        }
+
+        // Revoke shares the per-actor, per-ledger cap with verify (Issue #292):
+        // a compromised Revoker key can bloat events just as fast by revoking.
+        // Admin is exempt.
+        if !is_admin {
+            charge_verify_rate(&env, &caller, 1)?;
         }
 
         let mut record = get_record(&env, &github_username).ok_or(ContractError::NotRegistered)?;
@@ -3841,6 +3901,156 @@ mod test {
             let result =
                 TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "missing"));
             assert_eq!(result, Err(ContractError::NotRegistered));
+        });
+    }
+
+    // ── Issue #292: per-verifier, per-ledger verify/revoke rate limit ────────
+
+    #[test]
+    fn test_verify_rate_limit_blocks_verifier_after_cap() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        let verifier = Address::generate(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_verify_limit(env.clone(), 2).unwrap();
+            TrustBridgeContract::set_role(env.clone(), verifier.clone(), Role::Verifier).unwrap();
+
+            for i in 0..3u32 {
+                let name = format!("u{i}");
+                TrustBridgeContract::register(
+                    env.clone(),
+                    username(&env, &name),
+                    Address::generate(&env),
+                    Vec::new(&env),
+                )
+                .unwrap();
+            }
+
+            // First two verifies fit the cap.
+            TrustBridgeContract::verify(env.clone(), verifier.clone(), username(&env, "u0")).unwrap();
+            TrustBridgeContract::verify(env.clone(), verifier.clone(), username(&env, "u1")).unwrap();
+
+            // Third in the same ledger is rejected, and nothing is written.
+            let res =
+                TrustBridgeContract::verify(env.clone(), verifier.clone(), username(&env, "u2"));
+            assert_eq!(res, Err(ContractError::VerifyRateLimited));
+            assert!(
+                !TrustBridgeContract::get_address(env.clone(), username(&env, "u2"))
+                    .unwrap()
+                    .verified
+            );
+        });
+    }
+
+    #[test]
+    fn test_verify_rate_limit_resets_on_next_ledger() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        let verifier = Address::generate(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_verify_limit(env.clone(), 1).unwrap();
+            TrustBridgeContract::set_role(env.clone(), verifier.clone(), Role::Verifier).unwrap();
+            for i in 0..2u32 {
+                TrustBridgeContract::register(
+                    env.clone(),
+                    username(&env, &format!("u{i}")),
+                    Address::generate(&env),
+                    Vec::new(&env),
+                )
+                .unwrap();
+            }
+
+            TrustBridgeContract::verify(env.clone(), verifier.clone(), username(&env, "u0")).unwrap();
+            assert_eq!(
+                TrustBridgeContract::verify(env.clone(), verifier.clone(), username(&env, "u1")),
+                Err(ContractError::VerifyRateLimited)
+            );
+        });
+
+        // New ledger — the per-ledger counter starts fresh.
+        env.ledger().with_mut(|li| li.sequence_number += 1);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::verify(env.clone(), verifier.clone(), username(&env, "u1")).unwrap();
+        });
+    }
+
+    #[test]
+    fn test_admin_is_exempt_from_verify_rate_limit() {
+        let env = Env::default();
+        let (admin, _user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_verify_limit(env.clone(), 1).unwrap();
+            for i in 0..4u32 {
+                let name = format!("u{i}");
+                TrustBridgeContract::register(
+                    env.clone(),
+                    username(&env, &name),
+                    Address::generate(&env),
+                    Vec::new(&env),
+                )
+                .unwrap();
+                TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, &name))
+                    .unwrap();
+            }
+        });
+    }
+
+    #[test]
+    fn test_batch_verify_counts_each_username_against_rate_limit() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        let verifier = Address::generate(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_verify_limit(env.clone(), 2).unwrap();
+            TrustBridgeContract::set_role(env.clone(), verifier.clone(), Role::Verifier).unwrap();
+
+            let mut names: Vec<String> = Vec::new(&env);
+            for i in 0..3u32 {
+                let name = format!("u{i}");
+                TrustBridgeContract::register(
+                    env.clone(),
+                    username(&env, &name),
+                    Address::generate(&env),
+                    Vec::new(&env),
+                )
+                .unwrap();
+                names.push_back(username(&env, &name));
+            }
+
+            // Batch of 3 against a cap of 2 is rejected whole.
+            assert_eq!(
+                TrustBridgeContract::batch_verify(env.clone(), verifier.clone(), names.clone()),
+                Err(ContractError::VerifyRateLimited)
+            );
+            assert_eq!(TrustBridgeContract::get_verified_count(env.clone()), 0);
+        });
+    }
+
+    #[test]
+    fn test_verify_rate_limit_disabled_when_zero() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        let verifier = Address::generate(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_verify_limit(env.clone(), 0).unwrap();
+            TrustBridgeContract::set_role(env.clone(), verifier.clone(), Role::Verifier).unwrap();
+            for i in 0..25u32 {
+                let name = format!("u{i}");
+                TrustBridgeContract::register(
+                    env.clone(),
+                    username(&env, &name),
+                    Address::generate(&env),
+                    Vec::new(&env),
+                )
+                .unwrap();
+                TrustBridgeContract::verify(env.clone(), verifier.clone(), username(&env, &name))
+                    .unwrap();
+            }
         });
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1117,6 +1117,94 @@ pub fn is_in_cooldown(env: &Env, github_username: &String) -> bool {
     env.ledger().timestamp() < last.saturating_add(cooldown)
 }
 
+// ── Per-verifier verify/revoke rate limit (Issue #292) ───────────────────────
+//
+// A Verifier or Revoker key can otherwise call `verify` / `revoke_verification`
+// / `batch_verify` as fast as it can submit transactions, bloating the event
+// stream and burning instruction budget during a Wave. This is an on-chain cap
+// on the number of verify/revoke *units* one actor may spend per ledger.
+//
+// - The counter is keyed per actor address and per ledger sequence. When the
+//   ledger rolls over, the first call in the new ledger sees a stale sequence
+//   and resets the count to 0 — there is no cross-ledger carry.
+// - `batch_verify` spends `usernames.len()` units, so a batch cannot be used to
+//   sidestep the per-ledger cap.
+// - The admin is exempt: callers check `is_admin_caller` first and never reach
+//   the rate check. This is deliberate — incident response must not be throttled.
+// - Reads are never rate-limited; only the mutating verify/revoke paths are.
+
+/// Instance key holding the configured per-ledger verify/revoke cap.
+/// Absent → [`DEFAULT_VERIFIES_PER_LEDGER`]. Explicitly set to 0 → disabled.
+pub const VERIFY_LIMIT_KEY: Symbol = symbol_short!("vfylimit");
+
+/// Persistent key prefix for the per-`(verifier, ledger)` spend counter.
+/// Value is `(u32 ledger_seq, u32 units_spent)`.
+pub const VERIFY_RATE_KEY: Symbol = symbol_short!("vfyrate");
+
+/// Default cap when the admin has not configured one: 20 verify/revoke units
+/// per verifier per ledger (~4 per second at 5s ledgers).
+pub const DEFAULT_VERIFIES_PER_LEDGER: u32 = 20;
+
+/// The active per-ledger verify/revoke cap. Returns the stored value when the
+/// admin has set one (including 0, which disables the limit), otherwise
+/// [`DEFAULT_VERIFIES_PER_LEDGER`].
+pub fn get_verify_limit(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&VERIFY_LIMIT_KEY)
+        .unwrap_or(DEFAULT_VERIFIES_PER_LEDGER)
+}
+
+/// Sets the per-ledger verify/revoke cap. `0` disables rate limiting entirely.
+pub fn set_verify_limit(env: &Env, limit: u32) {
+    env.storage().instance().set(&VERIFY_LIMIT_KEY, &limit);
+}
+
+/// Charges `units` against `verifier`'s allowance for the current ledger.
+///
+/// Resets the counter transparently on ledger rollover. Returns
+/// [`ContractError::VerifyRateLimited`] — without writing — if the charge would
+/// push this ledger's spend past the cap. A cap of 0 short-circuits to `Ok`.
+///
+/// The admin is expected to have been filtered out by the caller before this
+/// runs; nothing here special-cases it.
+pub fn charge_verify_rate(
+    env: &Env,
+    verifier: &Address,
+    units: u32,
+) -> Result<(), ContractError> {
+    let limit = get_verify_limit(env);
+    if limit == 0 {
+        return Ok(());
+    }
+
+    let current_seq = env.ledger().sequence();
+    let key = (VERIFY_RATE_KEY, verifier.clone());
+    let (seq, spent): (u32, u32) = env.storage().persistent().get(&key).unwrap_or((0, 0));
+
+    let spent_this_ledger = if seq == current_seq { spent } else { 0 };
+    let next = spent_this_ledger.saturating_add(units);
+    if next > limit {
+        return Err(ContractError::VerifyRateLimited);
+    }
+
+    env.storage().persistent().set(&key, &(current_seq, next));
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP);
+    Ok(())
+}
+
+/// Units `verifier` has already spent in the current ledger (0 after rollover).
+/// Read-only helper for tests and diagnostics.
+pub fn verify_units_spent(env: &Env, verifier: &Address) -> u32 {
+    let key = (VERIFY_RATE_KEY, verifier.clone());
+    match env.storage().persistent().get::<_, (u32, u32)>(&key) {
+        Some((seq, spent)) if seq == env.ledger().sequence() => spent,
+        _ => 0,
+    }
+}
+
 // ── Role-based access control ─────────────────────────────────────────────────
 
 pub fn get_role(env: &Env, address: &Address) -> Option<Role> {


### PR DESCRIPTION
Closes #292

## Limit

On-chain, per-actor, per-ledger cap on **verify/revoke units**:

| Path | Units charged | When |
|------|---------------|------|
| `verify` | 1 | after auth, before any state read (junk usernames still count) |
| `revoke_verification` | 1 | after auth |
| `batch_verify` | `usernames.len()` — the requested size, before dedup/skip | after auth, atomically |

- **Storage:** `(Symbol("vfyrate"), actor)` → `(ledger_seq, units_spent)` in
  persistent storage. One entry per actor, overwritten in place.
- **Ledger rollover:** first call in a new ledger sees a stale `ledger_seq` and
  resets `units_spent` to 0 — no cross-ledger carry, no unbounded growth.
- **Exceed → reject whole, write nothing:** the charge is computed before the
  write; over the cap returns `VerifyRateLimited` (code 30) with zero state
  mutation (no record, no counter, no event).
- **Batch cannot be used to bypass:** a `batch_verify` of N against a cap of
  M < N is rejected as a unit, not partially applied.
- **Configurable:** `set_verify_limit(limit)` (admin-only); `0` disables;
  unset → `DEFAULT_VERIFIES_PER_LEDGER` (20). `get_verify_limit()` is a public
  read.
- **Admin bypass (documented):** callers check `is_admin_caller` first and the
  admin path never reaches `charge_verify_rate`. Incident response must not be
  throttled. See SECURITY.md.
- **Reads are never rate-limited.**

New typed error `VerifyRateLimited = 30`, wired into `from_code` round-trip.

## Tests

- `test_verify_rate_limit_blocks_verifier_after_cap` — cap 2, 3rd `verify` in
  the ledger → `VerifyRateLimited`, `u2` left unverified.
- `test_verify_rate_limit_resets_on_next_ledger` — blocked at cap 1, then
  `sequence_number += 1` and the same call succeeds.
- `test_admin_is_exempt_from_verify_rate_limit` — cap 1, admin verifies 4.
- `test_batch_verify_counts_each_username_against_rate_limit` — batch of 3 vs
  cap 2 rejected whole, `verified_count == 0`.
- `test_verify_rate_limit_disabled_when_zero` — cap 0, 25 verifies by one
  verifier all succeed.

## SECURITY.md

New "Verifier Rate Limiting (Issue #292)" section: threat, control (units
table, key layout, rollover, atomic reject), the **documented and intentional
admin bypass**, and the explicit "reads are never rate-limited / off-chain is
out of scope" note. ABI.md gets the error row and the two new function entries.

> Note: `main` does not currently compile (a pre-existing botched merge around
> `register` / `emergency_pause` in `src/lib.rs`), so `cargo test rate` could
> not be run on top of this branch.