### PR TITLE
Allowlist of verifier addresses with on-chain expiry (#293)

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -146,6 +146,9 @@ struct ChallengeRecord {
 | 19 | `ChallengeNotResolvable` | `complete_challenge` called before the delay has elapsed |
 | 20 | `ChallengeActive` | `register` attempted while a challenge is active on the username |
 | 21 | `NetworkMismatch` | Instance state was initialized on a different network than the one executing (Issue #231) |
+| 31 | `VerifierAllowlistFull` | `add_verifier` would exceed the `MAX_VERIFIERS` cap (Issue #293) |
+| 32 | `VerifierNotAllowlisted` | `remove_verifier` for an address not on the allowlist (Issue #293) |
+| 33 | `VerifierExpiryInPast` | `add_verifier` given a non-zero `expires_at` not in the future (Issue #293) |
 
 `ContractError::from_code(u32)` maps every code in this table back to the typed
 variant and returns `None` for any unrecognized code. Every code round-trips
@@ -160,6 +163,14 @@ tests in `src/lib.rs` (`test_error_from_code_is_inverse_of_code`).
 |-------|------|-------|
 | `address` | `Address` | Address holding the role |
 | `role` | `Role` | Role held, as the `Role` discriminant |
+
+### VerifierAllowEntry (Issue #293)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `address` | `Address` | Allowlisted verifier |
+| `expires_at` | `u64` | Ledger timestamp after which the entry is inactive; `0` = no expiry |
+| `added_at` | `u64` | Ledger timestamp the entry was added or last refreshed |
 
 ### EventDomain (Issue #226)
 
@@ -980,6 +991,70 @@ Configures the WASM upgrade timelock cooldown period in seconds. Admin-only.
 ### `get_cooldown() -> u64`
 
 Returns the current WASM upgrade timelock cooldown period in seconds.
+
+---
+
+### `add_verifier(verifier: Address, expires_at: u64) -> Result<(), ContractError>`
+
+Adds `verifier` to the campaign allowlist and grants it `Role::Verifier`
+(Issue #293). Admin-only.
+
+- **Cap:** at most `MAX_VERIFIERS` (10) concurrently active members. A new
+  address over the cap → `VerifierAllowlistFull`. Expired entries are pruned
+  before the check, so a lapsed member never blocks a new one.
+- **Expiry:** `expires_at` is a ledger timestamp after which the entry stops
+  authorizing `verify` / `batch_verify`. `0` = no expiry. A non-zero value not
+  in the future → `VerifierExpiryInPast`.
+- **Refresh:** calling again for an address already listed updates its
+  `expires_at` in place and does **not** consume another slot.
+- **`set_role` interaction:** composes, does not duplicate. `add_verifier` also
+  calls `set_role(verifier, Verifier)`. **Once the allowlist has been populated
+  at least once**, `verify` / `batch_verify` require the caller to be an
+  *active* allowlist member — a bare `set_role(Verifier)` grant is no longer
+  sufficient. Before the first `add_verifier` call the contract stays in pure
+  role-based mode (backward compatible). There is only one expiry mechanism in
+  the contract — this one.
+
+| **Errors** | `NotInitialized`, `Paused`, `NotAuthorized`, `VerifierExpiryInPast`, `VerifierAllowlistFull` |
+
+---
+
+### `remove_verifier(verifier: Address) -> Result<(), ContractError>`
+
+Removes `verifier` from the allowlist and revokes its `Role::Verifier`.
+Admin-only. Not listed → `VerifierNotAllowlisted`.
+
+| **Errors** | `NotInitialized`, `Paused`, `NotAuthorized`, `VerifierNotAllowlisted` |
+
+---
+
+### `get_verifiers() -> Vec<VerifierAllowEntry>`
+
+The allowlist as `{ address, expires_at, added_at }` entries, including any that
+have expired but not yet been pruned. Read-only; no auth.
+
+---
+
+### `is_active_verifier(verifier: Address) -> bool`
+
+`true` if `verifier` is on the allowlist and not expired as of the current
+ledger. Read-only; no auth.
+
+---
+
+### `verifier_slots_remaining() -> u32`
+
+Allowlist slots free before the `MAX_VERIFIERS` cap, counting only active
+(non-expired) members. Read-only; no auth.
+
+---
+
+### `prune_expired_verifiers() -> Result<u32, ContractError>`
+
+Drops every expired allowlist entry, returning how many were removed. Callable
+by anyone — it only removes entries that are already inactive.
+
+| **Errors** | `NotInitialized` |
 
 ---
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,9 @@ use soroban_sdk::contracterror;
 /// | 19 | `NotReserved` | `remove_reserved` |
 /// | 20 | `UsernameReserved` | `register` |
 /// | 21 | `ReservedListFull` | `add_reserved` |
+/// | 31 | `VerifierAllowlistFull` | `add_verifier` |
+/// | 32 | `VerifierNotAllowlisted` | `remove_verifier` |
+/// | 33 | `VerifierExpiryInPast` | `add_verifier` |
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -96,6 +99,13 @@ pub enum ContractError {
     NoPendingAdminTransfer = 28,
     /// `upgrade` was called without a required attestation (attestation-required mode is on).
     AttestationRequired = 29,
+    /// `add_verifier` would exceed the `MAX_VERIFIERS` allowlist cap (Issue #293).
+    VerifierAllowlistFull = 31,
+    /// `remove_verifier` was called for an address not on the allowlist (Issue #293).
+    VerifierNotAllowlisted = 32,
+    /// `add_verifier` was given a non-zero `expires_at` that is not in the
+    /// future (Issue #293).
+    VerifierExpiryInPast = 33,
 }
 
 impl ContractError {
@@ -140,6 +150,9 @@ impl ContractError {
             27 => Some(ContractError::AdminTransferDelayActive),
             28 => Some(ContractError::NoPendingAdminTransfer),
             29 => Some(ContractError::AttestationRequired),
+            31 => Some(ContractError::VerifierAllowlistFull),
+            32 => Some(ContractError::VerifierNotAllowlisted),
+            33 => Some(ContractError::VerifierExpiryInPast),
             _ => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@ pub use events::{
 };
 pub use storage::{
     ChallengeRecord, ContributorRecord, ExportPage, HealthSnapshot, Role, Stats,
-    VerificationConfig, WasmAttestation, WasmProvenance, PauseReason,
+    VerificationConfig, VerifierAllowEntry, WasmAttestation, WasmProvenance, PauseReason,
+    MAX_VERIFIERS,
 };
 pub use version::Version;
 
@@ -69,6 +70,9 @@ use crate::storage::{
     ADMIN_KEY,
     get_guardian as storage_get_guardian,
     remove_guardian as storage_remove_guardian,
+    add_verifier as storage_add_verifier, remove_verifier as storage_remove_verifier,
+    get_verifier_allowlist, is_active_verifier as storage_is_active_verifier,
+    verifier_allowlist_active, verifier_slots_remaining, prune_expired_verifiers,
 };
 
 use crate::utils::{
@@ -689,6 +693,128 @@ impl TrustBridgeContract {
     #[must_use]
     pub fn get_role_holder_count(env: Env) -> u32 {
         storage_get_role_holder_count(&env)
+    }
+
+    /// Adds `verifier` to the campaign allowlist and grants it `Role::Verifier`
+    /// (Issue #293). Admin-only.
+    ///
+    /// The allowlist is a hard-capped (`MAX_VERIFIERS`), time-bounded companion
+    /// to `set_role(Verifier)`:
+    ///
+    /// - `expires_at` is a ledger timestamp after which the entry stops
+    ///   authorizing `verify` / `batch_verify`. `0` means no expiry. A non-zero
+    ///   value must be in the future.
+    /// - Re-calling for an address already on the list **refreshes its expiry**
+    ///   in place and does not consume another slot.
+    /// - Adding a brand-new address when the list already holds `MAX_VERIFIERS`
+    ///   active members fails with `VerifierAllowlistFull`. Expired entries are
+    ///   pruned first, so a lapsed member never blocks a new one.
+    ///
+    /// ### Interaction with `set_role`
+    ///
+    /// This does not replace `set_role`; it composes with it. `add_verifier`
+    /// also calls `set_role(verifier, Verifier)` so the two never disagree.
+    /// **Once the allowlist has been populated at least once**, `verify` and
+    /// `batch_verify` require the caller to be an *active* (non-expired)
+    /// allowlist member — a bare `set_role(Verifier)` grant is no longer
+    /// sufficient. Before the first `add_verifier` call the contract stays in
+    /// pure role-based mode, so existing deployments are unaffected until they
+    /// opt in. See `docs/ABI.md`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] / [`ContractError::Paused`]
+    /// - [`ContractError::NotAuthorized`] if the caller is not the admin.
+    /// - [`ContractError::VerifierExpiryInPast`] if `expires_at` is non-zero and
+    ///   not in the future.
+    /// - [`ContractError::VerifierAllowlistFull`] if the cap would be exceeded.
+    pub fn add_verifier(
+        env: Env,
+        verifier: Address,
+        expires_at: u64,
+    ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        let now = env.ledger().timestamp();
+        storage_add_verifier(&env, &verifier, expires_at, now)?;
+        storage_set_role(&env, &verifier, &Role::Verifier);
+
+        RoleGrantedEvent {
+            address: verifier,
+            role: Role::Verifier as u32,
+            admin,
+            timestamp: now,
+            domain: event_domain(&env),
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Removes `verifier` from the allowlist and revokes its `Role::Verifier`
+    /// (Issue #293). Admin-only.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] / [`ContractError::Paused`]
+    /// - [`ContractError::NotAuthorized`] if the caller is not the admin.
+    /// - [`ContractError::VerifierNotAllowlisted`] if `verifier` is not listed.
+    pub fn remove_verifier(env: Env, verifier: Address) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        let now = env.ledger().timestamp();
+        storage_remove_verifier(&env, &verifier, now)?;
+        storage_remove_role(&env, &verifier);
+
+        RoleRevokedEvent {
+            address: verifier,
+            admin,
+            timestamp: now,
+            domain: event_domain(&env),
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// The verifier allowlist as `(address, expires_at, added_at)` entries
+    /// (Issue #293), including any that have expired but not yet been pruned.
+    /// Read-only; no auth.
+    #[must_use]
+    pub fn get_verifiers(env: Env) -> Vec<VerifierAllowEntry> {
+        get_verifier_allowlist(&env)
+    }
+
+    /// `true` if `verifier` is on the allowlist and not expired as of the
+    /// current ledger (Issue #293). Read-only; no auth.
+    #[must_use]
+    pub fn is_active_verifier(env: Env, verifier: Address) -> bool {
+        storage_is_active_verifier(&env, &verifier, env.ledger().timestamp())
+    }
+
+    /// Allowlist slots still free before the `MAX_VERIFIERS` cap, counting only
+    /// active (non-expired) members (Issue #293). Read-only; no auth.
+    #[must_use]
+    pub fn verifier_slots_remaining(env: Env) -> u32 {
+        verifier_slots_remaining(&env, env.ledger().timestamp())
+    }
+
+    /// Drops every expired allowlist entry and returns how many were removed
+    /// (Issue #293). Anyone may call it — it only removes entries that are
+    /// already inactive. No-op return of `0` when nothing is stale.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`]
+    pub fn prune_expired_verifiers(env: Env) -> Result<u32, ContractError> {
+        require_initialized(&env)?;
+        Ok(prune_expired_verifiers(&env, env.ledger().timestamp()))
     }
 
     /// Sets the minimum number of seconds that must elapse between WASM upgrades. Admin-only.
@@ -1918,7 +2044,18 @@ impl TrustBridgeContract {
         // separated so a compromised Revoker cannot mark new accounts as
         // verified (Issue #212).
         let is_admin = is_admin_caller(&env, &caller);
-        let is_verifier = storage_get_role(&env, &caller) == Some(Role::Verifier);
+        // Verifier authorization (Issue #293): once the campaign allowlist has
+        // been populated, a non-admin caller must be an *active* (non-expired)
+        // allowlist member — a bare `set_role(Verifier)` grant no longer
+        // suffices. Until the first `add_verifier` call the contract stays in
+        // pure role-based mode, so existing deployments are unaffected.
+        let is_verifier = if is_admin {
+            false
+        } else if verifier_allowlist_active(&env) {
+            storage_is_active_verifier(&env, &caller, env.ledger().timestamp())
+        } else {
+            storage_get_role(&env, &caller) == Some(Role::Verifier)
+        };
         if !is_admin && !is_verifier {
             return Err(ContractError::NotAuthorized);
         }
@@ -1987,7 +2124,18 @@ impl TrustBridgeContract {
         caller.require_auth();
 
         let is_admin = is_admin_caller(&env, &caller);
-        let is_verifier = storage_get_role(&env, &caller) == Some(Role::Verifier);
+        // Verifier authorization (Issue #293): once the campaign allowlist has
+        // been populated, a non-admin caller must be an *active* (non-expired)
+        // allowlist member — a bare `set_role(Verifier)` grant no longer
+        // suffices. Until the first `add_verifier` call the contract stays in
+        // pure role-based mode, so existing deployments are unaffected.
+        let is_verifier = if is_admin {
+            false
+        } else if verifier_allowlist_active(&env) {
+            storage_is_active_verifier(&env, &caller, env.ledger().timestamp())
+        } else {
+            storage_get_role(&env, &caller) == Some(Role::Verifier)
+        };
         if !is_admin && !is_verifier {
             return Err(ContractError::NotAuthorized);
         }
@@ -3841,6 +3989,152 @@ mod test {
             let result =
                 TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "missing"));
             assert_eq!(result, Err(ContractError::NotRegistered));
+        });
+    }
+
+    // ── Issue #293: verifier allowlist (cap + on-chain expiry) ──────────────
+
+    #[test]
+    fn test_verifier_allowlist_cap_enforced() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            for _ in 0..MAX_VERIFIERS {
+                TrustBridgeContract::add_verifier(env.clone(), Address::generate(&env), 0).unwrap();
+            }
+            assert_eq!(TrustBridgeContract::verifier_slots_remaining(env.clone()), 0);
+            let res =
+                TrustBridgeContract::add_verifier(env.clone(), Address::generate(&env), 0);
+            assert_eq!(res, Err(ContractError::VerifierAllowlistFull));
+        });
+    }
+
+    #[test]
+    fn test_verifier_allowlist_expiry_blocks_verify() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        let verifier = Address::generate(&env);
+        env.ledger().with_mut(|li| li.timestamp = 1_000);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+            // Expires at t=2000.
+            TrustBridgeContract::add_verifier(env.clone(), verifier.clone(), 2_000).unwrap();
+            assert!(TrustBridgeContract::is_active_verifier(env.clone(), verifier.clone()));
+            TrustBridgeContract::verify(env.clone(), verifier.clone(), username(&env, "octocat"))
+                .unwrap();
+        });
+
+        // Advance past expiry; the same verifier is now inactive.
+        env.ledger().with_mut(|li| li.timestamp = 3_000);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "hubber"),
+                Address::generate(&env),
+                Vec::new(&env),
+            )
+            .unwrap();
+            assert!(!TrustBridgeContract::is_active_verifier(env.clone(), verifier.clone()));
+            let res =
+                TrustBridgeContract::verify(env.clone(), verifier.clone(), username(&env, "hubber"));
+            assert_eq!(res, Err(ContractError::NotAuthorized));
+        });
+    }
+
+    #[test]
+    fn test_verifier_expiry_in_past_rejected() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        env.ledger().with_mut(|li| li.timestamp = 5_000);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            let res =
+                TrustBridgeContract::add_verifier(env.clone(), Address::generate(&env), 4_000);
+            assert_eq!(res, Err(ContractError::VerifierExpiryInPast));
+        });
+    }
+
+    #[test]
+    fn test_expired_verifier_slot_is_reclaimed_and_pruned() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        env.ledger().with_mut(|li| li.timestamp = 1_000);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            for _ in 0..(MAX_VERIFIERS - 1) {
+                TrustBridgeContract::add_verifier(env.clone(), Address::generate(&env), 0).unwrap();
+            }
+            // One short-lived member takes the last slot.
+            TrustBridgeContract::add_verifier(env.clone(), Address::generate(&env), 2_000).unwrap();
+            assert_eq!(TrustBridgeContract::verifier_slots_remaining(env.clone()), 0);
+        });
+
+        env.ledger().with_mut(|li| li.timestamp = 3_000);
+        env.as_contract(&contract_id, || {
+            // Expired member no longer counts, so a new one fits — add_verifier
+            // prunes it on the way in.
+            TrustBridgeContract::add_verifier(env.clone(), Address::generate(&env), 0).unwrap();
+            let pruned = TrustBridgeContract::prune_expired_verifiers(env.clone()).unwrap();
+            assert_eq!(pruned, 0, "add_verifier already pruned the expired entry");
+            assert_eq!(TrustBridgeContract::get_verifiers(env.clone()).len(), MAX_VERIFIERS);
+        });
+    }
+
+    #[test]
+    fn test_add_verifier_refresh_does_not_consume_slot() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        env.ledger().with_mut(|li| li.timestamp = 1_000);
+        env.mock_all_auths();
+        let v = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::add_verifier(env.clone(), v.clone(), 2_000).unwrap();
+            TrustBridgeContract::add_verifier(env.clone(), v.clone(), 9_000).unwrap();
+            assert_eq!(TrustBridgeContract::get_verifiers(env.clone()).len(), 1);
+            assert_eq!(
+                TrustBridgeContract::verifier_slots_remaining(env.clone()),
+                MAX_VERIFIERS - 1
+            );
+        });
+    }
+
+    #[test]
+    fn test_remove_verifier_not_listed_errors() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            let res = TrustBridgeContract::remove_verifier(env.clone(), Address::generate(&env));
+            assert_eq!(res, Err(ContractError::VerifierNotAllowlisted));
+        });
+    }
+
+    #[test]
+    fn test_role_based_verify_still_works_before_allowlist_opt_in() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        let verifier = Address::generate(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_role(env.clone(), verifier.clone(), Role::Verifier).unwrap();
+            TrustBridgeContract::register(
+                env.clone(),
+                username(&env, "octocat"),
+                user.clone(),
+                Vec::new(&env),
+            )
+            .unwrap();
+            // No add_verifier call yet → pure role-based mode.
+            TrustBridgeContract::verify(env.clone(), verifier.clone(), username(&env, "octocat"))
+                .unwrap();
         });
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1257,6 +1257,185 @@ pub fn has_role_or_admin(env: &Env, address: &Address, expected_role: Role) -> b
     }
 }
 
+// ── Verifier allowlist with on-chain expiry (Issue #293) ─────────────────────
+//
+// `set_role(Verifier)` is unbounded in both time and count. A campaign wants a
+// small, hard-capped allowlist whose members auto-expire. No generic role-expiry
+// mechanism exists in this contract, so expiry is implemented here (composed
+// into the one place it is needed) rather than as a second parallel system.
+//
+// - Stored as a single `Vec<VerifierAllowEntry>` in instance storage. The cap
+//   keeps it tiny, so a full-vector rewrite per mutation is fine.
+// - `expires_at == 0` means "no expiry" (a standing campaign verifier).
+// - Expired entries are pruned lazily on every write, so storage does not
+//   accumulate dead members; `is_active_verifier` also treats a not-yet-pruned
+//   expired entry as inactive, so a read is correct even between writes.
+
+/// Instance key for the verifier allowlist vector (Issue #293).
+pub const VERIFIER_ALLOWLIST_KEY: Symbol = symbol_short!("vfyallow");
+
+/// Hard cap on the number of concurrently allowlisted verifiers (Issue #293).
+pub const MAX_VERIFIERS: u32 = 10;
+
+/// One entry in the verifier allowlist.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[soroban_sdk::contracttype]
+pub struct VerifierAllowEntry {
+    /// The allowlisted verifier address.
+    pub address: Address,
+    /// Ledger timestamp after which this entry is inactive. `0` == no expiry.
+    pub expires_at: u64,
+    /// Ledger timestamp the entry was added or last refreshed.
+    pub added_at: u64,
+}
+
+/// The raw allowlist, including any entries that have expired but not yet been
+/// pruned. Empty when no verifier has ever been allowlisted.
+pub fn get_verifier_allowlist(env: &Env) -> Vec<VerifierAllowEntry> {
+    env.storage()
+        .instance()
+        .get(&VERIFIER_ALLOWLIST_KEY)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn set_verifier_allowlist(env: &Env, list: &Vec<VerifierAllowEntry>) {
+    env.storage()
+        .instance()
+        .set(&VERIFIER_ALLOWLIST_KEY, list);
+}
+
+/// `true` when the allowlist has ever been populated. Used to decide whether the
+/// allowlist gates `verify` or the contract is still in pure role-based mode.
+pub fn verifier_allowlist_active(env: &Env) -> bool {
+    env.storage().instance().has(&VERIFIER_ALLOWLIST_KEY)
+}
+
+/// Drop every entry whose expiry has passed. Returns how many were removed.
+pub fn prune_expired_verifiers(env: &Env, now: u64) -> u32 {
+    let list = get_verifier_allowlist(env);
+    let mut kept: Vec<VerifierAllowEntry> = Vec::new(env);
+    let mut removed = 0u32;
+    for e in list.iter() {
+        if e.expires_at != 0 && now >= e.expires_at {
+            removed += 1;
+        } else {
+            kept.push_back(e);
+        }
+    }
+    if removed > 0 {
+        set_verifier_allowlist(env, &kept);
+    }
+    removed
+}
+
+/// Number of entries that are currently active (present and not expired).
+pub fn active_verifier_count(env: &Env, now: u64) -> u32 {
+    let mut n = 0u32;
+    for e in get_verifier_allowlist(env).iter() {
+        if e.expires_at == 0 || now < e.expires_at {
+            n += 1;
+        }
+    }
+    n
+}
+
+/// `true` when `address` is on the allowlist and not expired as of `now`.
+pub fn is_active_verifier(env: &Env, address: &Address, now: u64) -> bool {
+    for e in get_verifier_allowlist(env).iter() {
+        if e.address == *address {
+            return e.expires_at == 0 || now < e.expires_at;
+        }
+    }
+    false
+}
+
+/// Add `address` to the allowlist, or refresh its expiry if already present.
+///
+/// Expired entries are pruned first (so a lapsed member does not consume a
+/// slot). Refreshing an existing member never counts against the cap; adding a
+/// brand-new member does.
+///
+/// # Errors
+///
+/// - [`ContractError::VerifierExpiryInPast`] if `expires_at` is non-zero and not
+///   strictly in the future.
+/// - [`ContractError::VerifierAllowlistFull`] if adding a new member would
+///   exceed [`MAX_VERIFIERS`].
+pub fn add_verifier(
+    env: &Env,
+    address: &Address,
+    expires_at: u64,
+    now: u64,
+) -> Result<(), ContractError> {
+    if expires_at != 0 && expires_at <= now {
+        return Err(ContractError::VerifierExpiryInPast);
+    }
+
+    prune_expired_verifiers(env, now);
+    let list = get_verifier_allowlist(env);
+
+    // Refresh path: address already listed → update expiry in place.
+    let mut next: Vec<VerifierAllowEntry> = Vec::new(env);
+    let mut refreshed = false;
+    for e in list.iter() {
+        if e.address == *address {
+            next.push_back(VerifierAllowEntry {
+                address: address.clone(),
+                expires_at,
+                added_at: now,
+            });
+            refreshed = true;
+        } else {
+            next.push_back(e);
+        }
+    }
+
+    if !refreshed {
+        if next.len() >= MAX_VERIFIERS {
+            return Err(ContractError::VerifierAllowlistFull);
+        }
+        next.push_back(VerifierAllowEntry {
+            address: address.clone(),
+            expires_at,
+            added_at: now,
+        });
+    }
+
+    set_verifier_allowlist(env, &next);
+    Ok(())
+}
+
+/// Remove `address` from the allowlist.
+///
+/// # Errors
+///
+/// - [`ContractError::VerifierNotAllowlisted`] if `address` is not on the list.
+pub fn remove_verifier(env: &Env, address: &Address, now: u64) -> Result<(), ContractError> {
+    let list = get_verifier_allowlist(env);
+    let mut next: Vec<VerifierAllowEntry> = Vec::new(env);
+    let mut found = false;
+    for e in list.iter() {
+        if e.address == *address {
+            found = true;
+        } else if e.expires_at != 0 && now >= e.expires_at {
+            // opportunistically drop other expired entries too
+        } else {
+            next.push_back(e);
+        }
+    }
+    if !found {
+        return Err(ContractError::VerifierNotAllowlisted);
+    }
+    set_verifier_allowlist(env, &next);
+    Ok(())
+}
+
+/// Slots still available before the [`MAX_VERIFIERS`] cap, counting only active
+/// (non-expired) members.
+pub fn verifier_slots_remaining(env: &Env, now: u64) -> u32 {
+    MAX_VERIFIERS.saturating_sub(active_verifier_count(env, now))
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[soroban_sdk::contracttype]
 pub struct VerificationConfig {


### PR DESCRIPTION
Closes #293

## Role-expiry check first

There is **no generic role-expiry mechanism** in the contract today — a grep for
`expir` finds only the WASM-attestation expiry. So this issue implements expiry
*inside the allowlist*, composed into the one place it is needed, rather than
standing up a second parallel expiry system (per the issue's constraint).

## Allowlist / cap

- **Storage:** a single `Vec<VerifierAllowEntry { address, expires_at, added_at }>`
  in instance storage. Hard cap `MAX_VERIFIERS = 10` active members.
- **Expiry:** `expires_at` is a ledger timestamp; `0` = no expiry; a non-zero
  value must be in the future (`VerifierExpiryInPast` otherwise).
- **Refresh:** `add_verifier` for an address already listed updates its expiry
  in place and does **not** consume another slot.
- **Expired member never blocks a new one:** every write prunes expired entries
  first; `is_active_verifier` also treats a not-yet-pruned expired entry as
  inactive, so reads are correct between writes.

## Entry points

| Function | Auth | Purpose |
|---|---|---|
| `add_verifier(verifier, expires_at)` | admin | add/refresh; also `set_role(Verifier)` |
| `remove_verifier(verifier)` | admin | remove; also `remove_role` |
| `get_verifiers()` | none | full list incl. un-pruned expired |
| `is_active_verifier(verifier)` | none | listed AND not expired now |
| `verifier_slots_remaining()` | none | free slots (active count only) |
| `prune_expired_verifiers()` | anyone | drop inactive entries, returns count |

## `set_role` interaction (composed, not duplicated)

`add_verifier` also calls `set_role(verifier, Verifier)` so the two never
disagree. **Once the allowlist has been populated at least once**,
`verify` / `batch_verify` require the caller to be an *active* (non-expired)
allowlist member — a bare `set_role(Verifier)` grant is no longer sufficient.
Before the first `add_verifier` call the contract stays in pure role-based mode,
so existing deployments are unaffected until they opt in.

## Errors

`VerifierAllowlistFull = 31`, `VerifierNotAllowlisted = 32`,
`VerifierExpiryInPast = 33` — all wired into the `from_code` round-trip.

## Tests (`cargo test verifier_allow` / `allowlist`)

- `test_verifier_allowlist_cap_enforced` — 11th add → `VerifierAllowlistFull`.
- `test_verifier_allowlist_expiry_blocks_verify` — verifier works before
  `expires_at`, `NotAuthorized` after the ledger advances past it.
- `test_verifier_expiry_in_past_rejected`.
- `test_expired_verifier_slot_is_reclaimed_and_pruned` — expired member frees a
  slot and is pruned on the next `add_verifier`.
- `test_add_verifier_refresh_does_not_consume_slot`.
- `test_remove_verifier_not_listed_errors`.
- `test_role_based_verify_still_works_before_allowlist_opt_in`.

## ABI

`docs/ABI.md`: 6 new function entries, the `VerifierAllowEntry` type, and 3 new
error-code rows.

> Note: `main` does not currently compile (a pre-existing botched merge around
> `register` / `emergency_pause` in `src/lib.rs`), so `cargo test` could not be
> run on top of this branch.