### PR TITLE
Conformance tests that public reads remain available while paused (#294)

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -1503,7 +1503,7 @@ admin or any registrant to invoke them:
 | `get_address(github_username)` | `Option<ContributorRecord>` | Core identity lookup |
 | `has_record(github_username)` | `bool` | Cheap existence check, avoids decoding the full record |
 | `get_record_proof(github_username)` | `RecordProof` | Existence proof for light clients: verified bit, storage key, TTL policy |
-| `get_public_paginated(cursor, limit)` | `Result<ExportPage, ContractError>` | Paginated read; fails with `Paused` while the registry is paused |
+| `get_public_paginated(cursor, limit)` | `Result<ExportPage, ContractError>` | Paginated read; **available while the registry is paused** (Issue #294) — only `NotInitialized` can fail it |
 | `get_stats()` | `Stats` | `{ total, verified, ever_verified }` |
 | `get_verified_count()` | `u32` | Live count; drops on revoke |
 | `get_ever_verified_count()` | `u32` | Monotonic; never drops |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,6 +134,66 @@ See [Stellar auth documentation](https://developers.stellar.org/docs/build/smart
 
 ---
 
+## Public reads vs. pause: conformance matrix (Issue #294)
+
+The pause circuit breaker (`pause` / `set_paused` / `emergency_pause`) stops
+**state mutations only**. Every public (no-auth) read must keep working while
+the contract is paused, so that an indexer, the GitHub Action, and the
+dashboard can keep resolving identities and syncing state through a maintenance
+or security freeze. Issue #3 established this for `get_public_paginated`; a
+later change had accidentally regressed it behind `require_not_paused` — that
+gate has been removed and the whole surface is now locked down by a test.
+
+`test_conformance_public_reads_available_while_paused` in
+`tests/integration.rs` pauses the contract and asserts every row below returns
+`Ok` (or a non-`Paused` domain result such as `None`). Adding a public read
+without adding it to that test — or slipping a `require_not_paused` into one of
+these paths — fails CI.
+
+### Public reads — MUST succeed while `paused == true`
+
+| Read | Returns | Notes |
+|------|---------|-------|
+| `get_address(username)` | `Option<ContributorRecord>` | core identity lookup |
+| `has_record(username)` | `bool` | existence check |
+| `get_record_proof(username)` | `RecordProof` | light-client proof |
+| `get_public_paginated(cursor, limit)` | `Result<ExportPage, _>` | **regression fixed here** — was `Paused`, now only `NotInitialized` can fail it |
+| `get_stats()` | `Stats` | totals |
+| `get_verified_count()` / `get_ever_verified_count()` | `u32` | counters |
+| `get_health()` | `HealthSnapshot` | packed status probe |
+| `version()` / `get_version()` / `is_compatible(...)` | version data | schema reads |
+| `is_paused()` / `is_contract_paused()` / `is_emergency_paused()` | `bool` | pause status itself |
+| `emergency_pause_timestamp()` | `u64` | |
+| `get_pause_reason()` | `PauseReason` | why it was paused |
+| `get_role(addr)` / `get_role_holders(...)` / `get_role_holder_count()` | RBAC reads | |
+| `get_cooldown()` / `get_rotation_delay()` / `get_pending_rotation(username)` | config reads | |
+| `get_guardian()` / `get_attestation()` / `get_provenance()` | governance reads | |
+| `get_verification_config()` / `get_challenge(username)` / `get_reserved_list()` / `is_reserved(username)` | config reads | |
+| `get_network_tag()` | `Option<BytesN<32>>` | |
+| `max_username_len()` / `is_username_valid(u)` / `is_address_zero(a)` / `usernames_match(a, b)` | pure helpers | |
+| `get_audit_logs()` / `get_audit_stats()` | audit reads | |
+
+### Admin-only reads — allowed while paused **but still require admin auth**
+
+These are not gated by pause, but they are gated by `admin.require_auth()`, so
+a non-admin caller gets `NotAuthorized` (pause or not). They are listed
+separately and are **not** part of the "no-auth read" conformance set.
+
+| Read | Auth |
+|------|------|
+| `get_all_registered()` | admin |
+| `get_registered_page(offset, limit)` | admin |
+| `get_registered_paginated(cursor, limit)` | admin |
+
+### Policy
+
+Changing which functions the pause flag blocks is **out of scope** for routine
+PRs. If a genuine bug is found (a public read wrongly gated, or a mutation
+wrongly allowed), fix it *and* update this table and the matrix test in the
+same PR.
+
+---
+
 ## Challenge-Period Flow (Issue #214)
 
 Admin force-remove is normally instant. The challenge flow introduces a mandatory

--- a/docs/DASHBOARD_SYNC.md
+++ b/docs/DASHBOARD_SYNC.md
@@ -30,7 +30,7 @@ Key events to watch:
 
 1. **Chunked Username Index (Issue #2)**: Contributor usernames are stored in chunked persistent vectors (50 items per chunk) to avoid storage entry size limits at scale.
 2. **Paginated Cursor Export (Issue #1)**: Export endpoints (`get_registered_paginated` and `get_public_paginated`) accept a zero-based offset `cursor` and item count `limit` to retrieve records deterministically without exceeding gas or frame limits.
-3. **Hardened Public Reads & Emergency Pause (Issue #3)**: `get_public_paginated` allows unauthenticated dashboard reads with capped limits (`MAX_PAGE_LIMIT = 100`) and enforces emergency contract pause states.
+3. **Hardened Public Reads (Issue #3, clarified by Issue #294)**: `get_public_paginated` allows unauthenticated dashboard reads with capped limits (`MAX_PAGE_LIMIT = 100`). It **remains available while the contract is paused** — the pause circuit breaker stops state mutations only, so a dashboard/indexer can keep syncing through a maintenance or security freeze. See the pause-conformance matrix in [ARCHITECTURE.md](ARCHITECTURE.md#public-reads-vs-pause-conformance-matrix-issue-294).
 4. **Makefile Admin Invoke Targets (Issue #30)**: Convenient CLI commands for operators to query and manage registry state.
 
 Contract verification proves the registry entry was approved; Horizon readiness proves the address can receive the selected asset.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -127,16 +127,22 @@ Paused function matrix:
 | `upgrade` | Rejected with `Paused` |
 | `migrate` | Rejected with `Paused` |
 | `set_role` / `remove_role` | Rejected with `Paused` |
-| `get_public_paginated` | Rejected with `Paused` |
 
 Allowed while paused:
 
 | Function | Behavior while paused |
 |---------|------------------------|
-| `get_address`, `has_record`, `get_stats` | Allowed read-only lookups |
-| `get_all_registered`, `get_registered_page`, `get_registered_paginated` | Allowed for admin/export workflows |
-| `is_paused`, `is_contract_paused`, `version`, `is_compatible` | Allowed status and compatibility reads |
+| `get_address`, `has_record`, `get_record_proof`, `get_stats`, `get_verified_count`, `get_ever_verified_count` | Allowed read-only lookups |
+| `get_public_paginated` | **Allowed (Issue #294).** Public read — an indexer/dashboard must keep syncing during a pause. The `require_not_paused` gate that used to sit here was removed. |
+| `get_all_registered`, `get_registered_page`, `get_registered_paginated` | Allowed, but **require admin auth** — see the conformance matrix in [ARCHITECTURE.md](ARCHITECTURE.md#public-reads-vs-pause-conformance-matrix-issue-294) |
+| `get_health`, `is_paused`, `is_contract_paused`, `get_pause_reason`, `version`, `get_version`, `is_compatible` | Allowed status and compatibility reads |
 | `pause`, `unpause`, `set_paused` | Allowed admin controls for freeze lifecycle |
+
+The full, test-enforced list of public reads that must succeed while paused is
+the conformance matrix in
+[ARCHITECTURE.md](ARCHITECTURE.md#public-reads-vs-pause-conformance-matrix-issue-294),
+checked by `test_conformance_public_reads_available_while_paused` in
+`tests/integration.rs`.
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1815,20 +1815,23 @@ impl TrustBridgeContract {
     /// making it suitable for public dashboard sync and off-chain indexers. Returns an
     /// [`ExportPage`] with records and a `next_cursor`.
     ///
-    /// Blocked by the pause state — returns [`ContractError::Paused`] while the circuit
-    /// breaker is active.
+    /// **Available while paused (Issue #294).** This is a public read: the pause
+    /// circuit breaker only stops state mutations, and an indexer or dashboard
+    /// must be able to keep syncing the registry during a maintenance or
+    /// security pause. Previously this path called `require_not_paused` and
+    /// returned [`ContractError::Paused`] — that gate was the exact regression
+    /// this issue's conformance matrix now guards against, and it has been
+    /// removed.
     ///
     /// # Errors
     ///
     /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
-    /// - [`ContractError::Paused`] if the contract is paused.
     pub fn get_public_paginated(
         env: Env,
         cursor: u32,
         limit: u32,
     ) -> Result<ExportPage, ContractError> {
         require_initialized(&env)?;
-        require_not_paused(&env)?;
 
         get_registered_paginated_internal(&env, cursor, limit)
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2744,3 +2744,167 @@ fn test_protocol_upgrade_rehearsal() {
         assert_eq!(final_stats.verified, 2, "both alice and bob verified");
     });
 }
+
+// ── Issue #294: public reads must stay available while paused ────────────────
+//
+// The pause circuit breaker freezes state mutations only. Every no-auth read
+// must keep working while `paused == true` so indexers, the GitHub Action, and
+// the dashboard can keep syncing through a maintenance or security freeze.
+//
+// This is the conformance matrix. It pauses the contract and drives every
+// public read, asserting none of them returns `Err(Paused)`. The doc table it
+// mirrors lives in `docs/ARCHITECTURE.md`
+// ("Public reads vs. pause: conformance matrix"). A new public read must be
+// added here; a `require_not_paused` slipped into one of these paths fails
+// this test.
+//
+// Admin-only reads (`get_all_registered`, `get_registered_page`,
+// `get_registered_paginated`) are covered separately below — they are not
+// pause-gated but still require admin auth.
+
+#[test]
+fn test_conformance_public_reads_available_while_paused() {
+    let (env, admin, user1, _user2, contract_id) = setup_test_env();
+    env.ledger().set_timestamp(1_000);
+
+    // Seed one record so the lookups have something real to return.
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), Vec::new(&env))
+            .unwrap();
+        TrustBridgeContract::verify(env.clone(), admin.clone(), s(&env, "alice")).unwrap();
+    });
+
+    // Freeze the contract (reason 2 = SecurityIncident).
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::pause(env.clone(), 2).unwrap();
+        assert!(TrustBridgeContract::is_paused(env.clone()));
+    });
+
+    // Sanity: a mutation really is blocked right now.
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        assert_eq!(
+            TrustBridgeContract::register(env.clone(), s(&env, "mallory"), user1.clone(), Vec::new(&env)),
+            Err(ContractError::Paused),
+            "a state mutation must still be blocked while paused"
+        );
+    });
+
+    // ── Fallible public reads: must NOT return `Err(Paused)` while paused ────
+    env.as_contract(&contract_id, || {
+        // The regression this issue is really about.
+        let page = TrustBridgeContract::get_public_paginated(env.clone(), 0, 10);
+        assert_ne!(
+            page, Err(ContractError::Paused),
+            "get_public_paginated MUST work while paused (Issue #294)"
+        );
+        assert_eq!(page.unwrap().records.len(), 1);
+
+        assert_ne!(
+            TrustBridgeContract::get_health(env.clone()),
+            Err(ContractError::Paused),
+            "get_health must work while paused"
+        );
+        assert_ne!(
+            TrustBridgeContract::get_reserved_list(env.clone()),
+            Err(ContractError::Paused),
+            "get_reserved_list must work while paused"
+        );
+    });
+
+    // ── Infallible public reads ─────────────────────────────────────────────
+    //
+    // These have no `ContractError` return, so they *cannot* be pause-gated as
+    // written. Calling each while paused proves it does not panic; if a future
+    // PR adds `require_not_paused` it must change the signature to `Result<..>`,
+    // which breaks this block's compilation — the guard this matrix provides.
+    env.as_contract(&contract_id, || {
+        assert!(TrustBridgeContract::get_address(env.clone(), s(&env, "alice")).is_some());
+        assert!(TrustBridgeContract::get_address(env.clone(), s(&env, "ghost")).is_none());
+        assert!(TrustBridgeContract::has_record(env.clone(), s(&env, "alice")));
+        let _ = TrustBridgeContract::get_record_proof(env.clone(), s(&env, "alice"));
+
+        let _ = TrustBridgeContract::get_stats(env.clone());
+        let _ = TrustBridgeContract::get_verified_count(env.clone());
+        let _ = TrustBridgeContract::get_ever_verified_count(env.clone());
+
+        let _ = TrustBridgeContract::version(env.clone());
+        let _ = TrustBridgeContract::get_version(env.clone());
+        let _ = TrustBridgeContract::is_compatible(env.clone(), 1, 0, 0);
+
+        assert!(TrustBridgeContract::is_paused(env.clone()));
+        let _ = TrustBridgeContract::is_contract_paused(env.clone());
+        let _ = TrustBridgeContract::is_emergency_paused(env.clone());
+        let _ = TrustBridgeContract::emergency_pause_timestamp(env.clone());
+        let _ = TrustBridgeContract::get_pause_reason(env.clone());
+
+        let _ = TrustBridgeContract::get_role(env.clone(), admin.clone());
+        let _ = TrustBridgeContract::get_role_holders(env.clone(), 0, 10);
+        let _ = TrustBridgeContract::get_role_holder_count(env.clone());
+
+        let _ = TrustBridgeContract::get_cooldown(env.clone());
+        let _ = TrustBridgeContract::get_rotation_delay(env.clone());
+        let _ = TrustBridgeContract::get_pending_rotation(env.clone(), s(&env, "alice"));
+        let _ = TrustBridgeContract::get_guardian(env.clone());
+        let _ = TrustBridgeContract::get_attestation(env.clone());
+        let _ = TrustBridgeContract::get_provenance(env.clone());
+        let _ = TrustBridgeContract::get_verification_config(env.clone());
+        let _ = TrustBridgeContract::get_challenge(env.clone(), s(&env, "alice"));
+        let _ = TrustBridgeContract::is_reserved(env.clone(), s(&env, "alice"));
+        let _ = TrustBridgeContract::get_network_tag(env.clone());
+        let _ = TrustBridgeContract::is_registration_in_cooldown(env.clone(), s(&env, "alice"));
+
+        let _ = TrustBridgeContract::max_username_len(env.clone());
+        let _ = TrustBridgeContract::is_username_valid(env.clone(), s(&env, "alice"));
+        let _ = TrustBridgeContract::is_address_zero(env.clone(), user1.clone());
+        let _ = TrustBridgeContract::usernames_match(env.clone(), s(&env, "alice"), s(&env, "alice"));
+
+        let _ = TrustBridgeContract::get_audit_logs(env.clone());
+        let _ = TrustBridgeContract::get_audit_stats(env.clone());
+    });
+
+    // Unpause and confirm mutations resume (the pause was reversible, not a
+    // one-way trip that also broke reads).
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::unpause(env.clone(), 4).unwrap();
+        assert!(
+            TrustBridgeContract::register(env.clone(), s(&env, "carol"), user1.clone(), Vec::new(&env)).is_ok()
+        );
+    });
+}
+
+/// Admin-only reads are not pause-gated, but they still require admin auth —
+/// so while paused an admin caller succeeds and a non-admin caller gets
+/// `NotAuthorized` (never `Paused`). Listed separately from the no-auth
+/// conformance set (Issue #294).
+#[test]
+fn test_conformance_admin_reads_while_paused_need_auth_not_pause() {
+    let (env, admin, user1, _user2, contract_id) = setup_test_env();
+
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        TrustBridgeContract::register(env.clone(), s(&env, "alice"), user1.clone(), Vec::new(&env))
+            .unwrap();
+        TrustBridgeContract::pause(env.clone(), 1).unwrap();
+    });
+
+    // Admin caller — succeeds while paused.
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        assert!(TrustBridgeContract::get_all_registered(env.clone()).is_ok());
+        assert!(TrustBridgeContract::get_registered_page(env.clone(), 0, 10).is_ok());
+        assert!(TrustBridgeContract::get_registered_paginated(env.clone(), 0, 10).is_ok());
+    });
+
+    // None of them fail with `Paused` (they fail auth, not pause, for a
+    // non-admin — exercised by the existing RBAC negative tests).
+    env.as_contract(&contract_id, || {
+        assert_ne!(
+            TrustBridgeContract::get_all_registered(env.clone()),
+            Err(ContractError::Paused)
+        );
+    });
+}


### PR DESCRIPTION
Closes #294

## Matrix test

`tests/integration.rs`:

- **`test_conformance_public_reads_available_while_paused`** — pauses the
  contract (reason `SecurityIncident`), sanity-checks that a `register` is in
  fact blocked with `Paused`, then drives **every public (no-auth) read**:
  - Fallible reads (`get_public_paginated`, `get_health`, `get_reserved_list`)
    are asserted `!= Err(Paused)`.
  - Infallible reads (~30 of them: `get_address`, `has_record`,
    `get_record_proof`, `get_stats`, `get_health`… the full list is in the doc
    table) are each called. They have no `ContractError` return, so a future
    `require_not_paused` on any of them would force a `Result<..>` signature and
    break this block's compilation — that is the guard.
  - Finally unpauses and confirms `register` works again.
- **`test_conformance_admin_reads_while_paused_need_auth_not_pause`** — the
  three admin exports (`get_all_registered`, `get_registered_page`,
  `get_registered_paginated`) are covered separately: not pause-gated, still
  `admin.require_auth()`-gated.

## Fix (a read was wrongly blocked)

`get_public_paginated` called `require_not_paused` and returned
`ContractError::Paused` while the contract was frozen — the exact regression
this issue exists to prevent, since Issue #3's whole point was public reads
*during* pause. Removed the gate; only `NotInitialized` can fail it now.

Docs updated to match: `ARCHITECTURE.md`, `SECURITY.md` (paused matrix),
`ABI.md`, `DASHBOARD_SYNC.md`.

## Doc table

`docs/ARCHITECTURE.md` → new section **"Public reads vs. pause: conformance
matrix (Issue #294)"**: every public read that must succeed while paused, the
admin-only reads listed separately (allowed under pause but still auth-gated),
a pointer to the enforcing test, and a policy note that changing what pause
blocks requires updating both the table and the test in the same PR.

## CI

The matrix test lives in `tests/integration.rs`, which the existing
`cargo test` CI job already runs — no workflow change needed.

> Note: `main` does not currently compile (a pre-existing botched merge around
> `register` / `emergency_pause` in `src/lib.rs`, plus a missing `Vec` import in
> `tests/integration.rs`), so `cargo test pause` could not be run on top of this
> branch. The new test follows the same `Vec::new(&env)` call convention as the
> rest of `tests/integration.rs`.