### PR TITLE
feat: verified-only lookup, reference event indexer, admin Lab recipes (closes #287, #288, #289)

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -442,6 +442,49 @@ stellar contract invoke --id $ID --source deployer --network testnet \
   -- get_address --github-username octocat
 ```
 
+> **Payout-address resolution (GitHub Action):** do **not** use `get_address`
+> for CI payouts — it returns the record whether or not `verified` is set, so an
+> unverified squatter registration would be paid. Use
+> `get_address_if_verified` instead.
+
+---
+
+### `get_address_if_verified(github_username: String) -> Result<ContributorRecord, ContractError>`
+
+Verified-only address lookup for CI payouts (Issue #287). `get_address` is left
+unchanged; this is a versioned sibling read with stricter semantics.
+
+| | |
+|---|---|
+| **Auth** | None |
+| **Mutates** | No |
+| **Works while paused** | Yes (same as `get_address`) |
+| **Errors** | `NotRegistered` (code 4), `NotVerified` (code 6) |
+
+| Registry state | Result |
+|---|---|
+| Registered **and** `verified == true` | `Ok(ContributorRecord)` |
+| Registered but `verified == false` | `Err(NotVerified)` — code `6` |
+| Never registered / removed | `Err(NotRegistered)` — code `4` |
+
+```bash
+stellar contract invoke --id $ID --source deployer --network testnet \
+  -- get_address_if_verified --github-username octocat
+```
+
+**Action-oriented ABI note.** The payout resolver in the GitHub Action must:
+
+1. Call `get_address_if_verified(github_username)`.
+2. On `Ok`, read `payout_address` (falls back to `stellar_address`) and pay.
+3. On **any** `Err` — both code `4` (`NotRegistered`) and code `6`
+   (`NotVerified`) — **do not pay**. Surface the distinction in logs only; the
+   pay/skip decision is the same for both.
+4. Pause is *not* checked by this read. If payouts should also halt while the
+   registry is frozen, gate the job on `is_paused()` separately.
+
+Contract-side behaviour is pinned by `test_verified_only_lookup_*` in
+`src/lib.rs`.
+
 ---
 
 ### `remove(caller: Address, github_username: String) -> Result<(), ContractError>`
@@ -938,6 +981,9 @@ stellar contract invoke --id $ID --source deployer --network testnet \
 ### `pause() -> Result<(), ContractError>`
 
 Pauses all state-mutating contract operations. Admin-only.
+
+Paste-ready CLI + Stellar Lab recipes for this and every other admin op:
+[ADMIN_RUNBOOK.md § Stellar Lab & CLI invoke recipes](ADMIN_RUNBOOK.md#stellar-lab--cli-invoke-recipes).
 
 ---
 

--- a/docs/ADMIN_RUNBOOK.md
+++ b/docs/ADMIN_RUNBOOK.md
@@ -4,12 +4,412 @@ The admin role exists for off-chain GitHub verification and operational recovery
 
 Related docs: [SECURITY](SECURITY.md) · [ABI](ABI.md) · [DEPLOYMENT](DEPLOYMENT.md) · [EVENT_INDEXING](EVENT_INDEXING.md)
 
+## Contents
+
+- [Routine actions](#routine-actions)
+- [Stellar Lab & CLI invoke recipes](#stellar-lab--cli-invoke-recipes) — one paste-ready
+  `stellar contract invoke` + Lab note for **every admin op**
+  - [Conventions & auth gotchas](#conventions--auth-gotchas)
+  - [Pause & freeze](#pause--freeze-recipes) · [Guardian](#guardian-recipes) ·
+    [Roles](#role-recipes) · [Verification](#verification-recipes) ·
+    [Registry maintenance](#registry-maintenance-recipes) ·
+    [Upgrade & attestation](#upgrade--attestation-recipes) ·
+    [Admin transfer](#admin-transfer-recipes) · [Export](#export-recipes)
+- [Storage TTL Maintenance (Keeper)](#storage-ttl-maintenance-keeper)
+- [Emergency Pause Lifecycle](#emergency-pause-lifecycle)
+- [Recovery notes](#recovery-notes)
+- [Guardian Circuit Breaker (Issue #196)](#guardian-circuit-breaker-issue-196)
+- [Wave Pause Checklist](#wave-pause-checklist)
+
 ## Routine actions
 
 - Verify contributors only after confirming the GitHub identity off-chain.
 - Revoke verification cleanly when contributor identities change or a registration is invalidated.
 - Export registered records before large dashboard migrations.
 - Keep the admin account in a secure wallet or multisig flow.
+
+---
+
+## Stellar Lab & CLI invoke recipes
+
+Every admin operation, with a paste-ready `stellar contract invoke` line and the
+equivalent [Stellar Lab](https://lab.stellar.org) → **Invoke Contract** note.
+Operators hit incidents by hand-assembling XDR in Lab and pasting it broken —
+these recipes remove that step.
+
+Signatures here track [`docs/ABI.md`](ABI.md). If the CLI rejects an argument
+name, print the live spec for the deployed build and match it exactly:
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --network "$NETWORK" -- --help
+stellar contract invoke --id "$CONTRACT_ID" --network "$NETWORK" -- <fn> --help
+```
+
+### Conventions & auth gotchas
+
+| Item | Rule |
+|---|---|
+| **Env** | `CONTRACT_ID=C…`, `NETWORK=testnet\|futurenet\|mainnet`, `SOURCE=<CLI identity>` (must be **funded** on that network). |
+| **Network passphrase** | The CLI derives it from `--network`. In **Lab**, set it explicitly — testnet: `Test SDF Network ; September 2015`; mainnet: `Public Global Stellar Network ; September 2015`; futurenet: `Test SDF Future Network ; October 2022`. A wrong passphrase produces a valid-looking XDR that every validator rejects. |
+| **`--source-account` vs `caller` arg** | Two independent things. `--source-account` signs and pays the transaction. Functions like `verify`, `revoke_verification`, `batch_verify`, `batch_remove`, `set_bot_status`, `execute_admin_transfer` **also** take a `caller: Address` argument that the contract checks against the admin / role holder. They must normally be the **same** identity: pass `--caller "$ADMIN"` and sign with the admin identity. |
+| **Admin is immutable** | Set once by `initialize`. It is never rotated in place — use the [admin-transfer](#admin-transfer-recipes) flow, which redeploys admin rights atomically. |
+| **Role holders** | `verify` / `batch_verify` accept the admin **or** a `Role::Verifier` holder. `revoke_verification` accepts the admin **or** a `Role::Revoker` holder. A `Verifier` cannot revoke; a `Revoker` cannot verify. Everything else is admin-only. |
+| **Pause interaction** | Most mutating admin ops return `Paused` (code 7) while the contract is paused. Exceptions that work while paused: `pause`, `unpause`, `set_paused`, `emergency_pause`, `clear_emergency_pause`, `attest_upgrade`, `clear_attestation`, `set_attestation_required`, `upgrade`, `migrate`, and all reads. |
+| **Simulate first** | Drop `--send=yes` to simulate only — the CLI prints the result and diagnostic events without submitting. In Lab, use **Simulate** before **Sign & Submit**. Always simulate a role, pause, upgrade, or admin-transfer call before sending. |
+| **WASM hash** | `upgrade` / `attest_upgrade` take the **hex** SHA-256 of the `.wasm` (`stellar contract install` prints it; `make wasm-hash-pin` checks it against `wasm-hash.pin`). Not the contract ID, not base64. |
+| **No secrets in examples** | Never paste a secret seed into Lab's request body or a shell history. Use a named CLI identity (`stellar keys …`) or a hardware/multisig signer. |
+| **Enums / tuples in CLI** | `Role` is passed by variant name: `--role Verifier`. Version tuples are JSON arrays: `--new-version '[1,1,0]'`. `Vec<String>` is a JSON array: `--usernames '["octocat","alice"]'`. |
+
+---
+
+### Pause & freeze recipes
+
+See [Emergency Pause Lifecycle](#emergency-pause-lifecycle) for the full
+procedure; these are the bare invoke lines.
+
+#### `pause` — halt all mutations
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- pause
+```
+
+- **Auth:** admin only. **Works while paused:** yes (idempotent).
+- **Lab:** Invoke Contract → `pause`, no args → Simulate → Sign with admin → Submit.
+- Emits `PausedEvent`. Confirm with `-- is_paused` (expect `true`).
+
+#### `unpause` — resume mutations
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- unpause
+```
+
+- **Auth:** admin only. Emits `UnpausedEvent`.
+- **Gotcha:** if the emergency pause is *also* set, `unpause` alone does not
+  resume writes — you must also `clear_emergency_pause`. Check both:
+  `-- is_paused` and `-- is_emergency_paused`.
+
+#### `set_paused` — idempotent pause toggle (indexer-friendly)
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- set_paused --paused true      # or --paused false
+```
+
+- **Auth:** admin only. Emits `PausedEvent` / `UnpausedEvent` **only on a state
+  change** (Issue #197) — a no-op call is silent, which is what makes it safe
+  to script.
+
+#### `emergency_pause` — guardian-capable circuit breaker
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account guardian --network "$NETWORK" --send=yes \
+  -- emergency_pause --caller "$GUARDIAN_ADDRESS"
+```
+
+- **Auth:** admin **or** the designated guardian. `--caller` must match the
+  signing identity. Emits `EmergencyPausedEvent`; idempotent.
+
+#### `clear_emergency_pause` — lift the circuit breaker
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- clear_emergency_pause
+```
+
+- **Auth:** admin **only** — the guardian deliberately cannot clear it.
+  Emits `EmergencyClearedEvent`.
+
+---
+
+### Guardian recipes
+
+#### `set_guardian`
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- set_guardian --guardian "$GUARDIAN_ADDRESS"
+```
+
+- **Auth:** admin only. Replaces any existing guardian.
+- **Lab:** the `guardian` arg is a `G…` address string; no XDR wrapping needed
+  in the Lab form.
+
+#### `remove_guardian`
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- remove_guardian
+```
+
+- **Auth:** admin only. After this, only the admin can `emergency_pause`.
+
+---
+
+### Role recipes
+
+`Role` values: `Admin`, `Upgrader`, `Verifier`, `Revoker`. Granting `Admin`
+through `set_role` does **not** change `ADMIN_KEY` — it only adds the address to
+role checks; use [admin transfer](#admin-transfer-recipes) to move the admin.
+
+#### `set_role` — grant a role
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- set_role --target "$TARGET_ADDRESS" --role Verifier
+```
+
+- **Auth:** admin only. Overwrites any existing role for `target`.
+- **Lab gotcha:** enter the role as the plain variant name `Verifier` (the Lab
+  form renders a dropdown / string field for `contracttype` enums) — not
+  `{"Verifier":{}}` and not a number.
+- Verify with `-- get_role --address "$TARGET_ADDRESS"` and
+  `-- get_role_holders --offset 0 --limit 50`.
+
+#### `remove_role` — revoke a role
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- remove_role --target "$TARGET_ADDRESS"
+```
+
+- **Auth:** admin only. No-op if the address holds no role. Compacts the role
+  index (later holders shift down one — restart any offset-based page walk).
+
+---
+
+### Verification recipes
+
+#### `verify` — mark one contributor verified
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- verify --caller "$ADMIN" --github-username octocat
+```
+
+- **Auth:** admin **or** `Role::Verifier` holder. `--caller` must equal the
+  signing identity and hold the right. Confirm GitHub identity off-chain first.
+
+#### `batch_verify` — verify a page of contributors
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- batch_verify --caller "$ADMIN" --usernames '["octocat","alice","bob-smith"]'
+```
+
+- **Auth:** admin **or** `Role::Verifier`. Capped at `MAX_WRITE_BATCH` = 25.
+- **Partial success:** unknown / already-verified entries are counted as
+  `failed` and skipped; the batch does **not** abort. Inspect the returned
+  `BatchSummary` — a `success_rate < 100` is informational, not an error.
+- For large lists use `scripts/bulk_verify.sh` (handles paging + RPC pacing).
+
+#### `revoke_verification` — withdraw verification
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- revoke_verification --caller "$ADMIN" --github-username octocat --reason-code 1
+```
+
+- **Auth:** admin **or** `Role::Revoker` holder (a `Verifier` cannot revoke).
+- `reason_code` must be a `RevokeReason` code: `1` IdentityFraud, `2`
+  CompromisedKey, `3` Regulatory, `4` DuplicateRegistration, `5` OperatorError,
+  `6` GdprErasure, `99` Other. An unknown code fails `InvalidReasonCode`.
+- Incident flow: detect → revoke → notify → audit export. Prefer this over
+  `remove` when the goal is to stop trust fast without deleting the record.
+
+#### `config_verification` — one-time verification config
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- config_verification --caller "$ADMIN" --attestation github_att --expires-in 3600 --threshold 2
+```
+
+- **Auth:** admin only, and callable **once** — a second call fails
+  `AlreadyInitialized`. `attestation` is a `Symbol` (≤ 9 chars, `[a-z0-9_]`).
+
+---
+
+### Registry maintenance recipes
+
+#### `batch_remove` — admin-only bulk de-registration
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- batch_remove --caller "$ADMIN" --usernames '["octocat","alice"]'
+```
+
+- **Auth:** strictly admin (unlike single `remove`, registrants cannot use it).
+  Capped at 25. Returns a `BatchSummary`. Decrements total and verified counters
+  for each removed record.
+
+#### `set_bot_status` — flag / unflag a CI account
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- set_bot_status --caller "$ADMIN" --github-username ci-bot --is_bot true
+```
+
+- **Auth:** admin only. Dashboards exclude `is_bot == true` records from human
+  contributor stats. Note the arg is `--is_bot` (underscore), matching the ABI.
+
+#### `adopt_network_tag` — tag a pre-network-tagging instance
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- adopt_network_tag
+```
+
+- **Auth:** admin only. Records `env.ledger().network_id()` (SHA-256 of the
+  passphrase) on an instance deployed before Issue #231. Fails
+  `NetworkMismatch` if a different tag is already recorded. Read with
+  `-- get_network_tag`.
+
+---
+
+### Upgrade & attestation recipes
+
+Full upgrade procedure: [DEPLOYMENT.md § Upgrade Window](DEPLOYMENT.md#upgrade-window-read-only-mode).
+Order: `set_paused true` → (optional `attest_upgrade`) → `upgrade` → verify →
+`set_paused false`.
+
+#### `set_cooldown` — upgrade timelock
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- set_cooldown --cooldown-seconds 86400      # 0 disables the timelock
+```
+
+- **Auth:** admin only. A non-zero cooldown makes `upgrade` fail
+  `CooldownActive` until the interval since the last upgrade elapses.
+
+#### `set_attestation_required` — require pre-declared hashes
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- set_attestation_required --required true
+```
+
+- **Auth:** admin only. When `true`, `upgrade` without a live matching
+  attestation fails `AttestationRequired` (code 20). Default `false`.
+
+#### `attest_upgrade` — declare the next hash in advance
+
+```bash
+HASH=$(stellar contract install --wasm target/wasm32v1-none/release/trustbridge_contract.wasm \
+  --source-account admin --network "$NETWORK")     # prints the hex hash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- attest_upgrade --wasm-hash "$HASH" --expires-at 1893456000
+```
+
+- **Auth:** admin only. `expires_at` is a **Unix timestamp** and must be in the
+  future (`AttestationExpired` otherwise). Single-use; publishing a new one
+  replaces the old. While live, `upgrade` accepts only this hash.
+
+#### `clear_attestation` — withdraw a pending attestation
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- clear_attestation
+```
+
+- **Auth:** admin only. No-op if none pending. Read state with `-- get_attestation`.
+
+#### `upgrade` — swap the executable
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- upgrade --new-wasm-hash "$HASH"
+```
+
+- **Auth:** admin only. Fails `CooldownActive`, `UnattestedWasm`,
+  `AttestationExpired`, or `AttestationRequired` per the rules above.
+  Records a `WasmProvenance` entry (read with `-- get_provenance`), emits
+  `UpgradedEvent`. **Simulate first** — a bad hash bricks upgrades until fixed.
+
+#### `migrate` — bump the stored schema version post-upgrade
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- migrate --new-version '[1,1,0]'
+```
+
+- **Auth:** admin only. `new_version` must be strictly greater than the current
+  (`InvalidVersion` otherwise). Runs any registered migration steps. Confirm
+  with `-- get_version`.
+
+---
+
+### Admin transfer recipes
+
+Two-step, time-delayed handover (Issue #195). The current admin stays sole admin
+for the whole window.
+
+#### `propose_admin_transfer`
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- propose_admin_transfer --new-admin "$NEW_ADMIN" --delay-seconds 172800
+```
+
+- **Auth:** current admin. Re-calling overwrites the pending proposal (fix a
+  typo'd address or delay during the window). `new_admin` cannot be the zero
+  address.
+
+#### `cancel_admin_transfer`
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" --send=yes \
+  -- cancel_admin_transfer
+```
+
+- **Auth:** current admin. No-op if nothing pending.
+
+#### `execute_admin_transfer`
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account new-admin --network "$NETWORK" --send=yes \
+  -- execute_admin_transfer --caller "$NEW_ADMIN"
+```
+
+- **Auth:** must be signed by **the proposed new admin**, and only after the
+  delay elapses (`AdminTransferDelayActive` otherwise). Atomically rotates
+  `ADMIN_KEY`, drops the old admin's `Role::Admin`, and grants it to the new
+  admin. Check the pending proposal any time with `-- get_admin_transfer`.
+
+---
+
+### Export recipes
+
+#### `get_all_registered` — full mapping in one call
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" \
+  -- get_all_registered
+```
+
+- **Auth:** admin only (read). No `--send` needed. Does not scale — use the
+  paginated form or the script below for a large registry.
+
+#### `get_registered_paginated` — cursor export with the `verified` bit
+
+```bash
+stellar contract invoke --id "$CONTRACT_ID" --source-account admin --network "$NETWORK" \
+  -- get_registered_paginated --cursor 0 --limit 100
+```
+
+- **Auth:** admin only (read). `limit` clamps to `MAX_PAGE_LIMIT` = 100. Loop
+  until `has_more == false` / `next_cursor == null`.
+
+#### `scripts/export_registry.sh` — assembled JSON snapshot
+
+```bash
+CONTRACT_ID="$CONTRACT_ID" SOURCE=admin NETWORK="$NETWORK" ./scripts/export_registry.sh
+```
+
+- Pages `get_registered_paginated` and writes a single
+  `registry-export-<network>.json`. `SOURCE` must sign as the admin. Take an
+  export **before** any bulk verify/remove or dashboard migration.
 
 ---
 

--- a/docs/EVENT_INDEXING.md
+++ b/docs/EVENT_INDEXING.md
@@ -2,6 +2,37 @@
 
 TrustBridge emits events so dashboards and indexers can build a readable contributor timeline.
 
+## Reference indexer (`scripts/event_indexer.sh`, Issue #288)
+
+A runnable reference indexer now lives in the repo. It polls the Stellar RPC
+`getEvents` method, appends events to a local JSONL file, and persists the RPC
+pagination cursor to disk so restarts resume exactly where they stopped
+(idempotent restart). It de-duplicates on the RPC event `id`, so reorgs and
+overlapping re-reads never double-write.
+
+```bash
+# follow testnet forever
+CONTRACT_ID=C... ./scripts/event_indexer.sh
+
+# drain once and exit (cron / CI)
+CONTRACT_ID=C... ONESHOT=1 ./scripts/event_indexer.sh
+
+# offline replay of a canned RPC response — no network
+MOCK_RESPONSE=./scripts/testdata/getEvents.sample.json \
+  CONTRACT_ID=C_MOCK ONESHOT=1 ./scripts/event_indexer.sh
+```
+
+State is three files under `DATA_DIR` (default `./.indexer/`):
+`events-<network>.jsonl`, `cursor-<network>.json`, `seen-<network>.txt`. No
+cloud account or database is required. See
+[`scripts/README.md`](../scripts/README.md#event_indexersh--reference-event-indexing-service)
+for the full guide, including how to validate resume behavior locally and a
+run against futurenet.
+
+This is a **reference** implementation for local sync — the filter/field
+patterns below are the spec it follows; a production hosted indexer is out of
+scope for this repo.
+
 ## Suggested consumer behavior
 
 - Treat contract storage as the source of truth.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,105 @@
+# `scripts/`
+
+Operational helper scripts for the TrustBridge registry contract. All are
+POSIX-ish `bash`, take configuration from environment variables, keep secrets
+out of the repo, and default to **testnet** (never mainnet).
+
+| Script | Purpose |
+|---|---|
+| `deploy.sh` | Build + deploy + `initialize` a fresh instance. |
+| `demo_e2e.sh` | One-shot happy path: register → verify → lookup → export. |
+| `event_indexer.sh` | **Reference event indexer** — tails contract events into local JSONL with an on-disk resume cursor (Issue #288). See below. |
+| `export_registry.sh` | Page the admin export into a single registry JSON snapshot. |
+| `validate_registry.sh` | Diff an export JSON against live on-chain state. |
+| `ttl_keeper.sh` | Walk the index and bump persistent-entry TTLs. |
+| `bulk_verify.sh` / `bulk_revoke.sh` | Batched verify / revoke from a username list, with RPC pacing. |
+| `simulate_pause.sh` | Exercise the pause / unpause lifecycle. |
+| `futurenet_smoke_test.sh` | End-to-end smoke test against futurenet. |
+
+---
+
+## `event_indexer.sh` — reference event-indexing service
+
+`docs/DASHBOARD_SYNC.md` and `docs/EVENT_INDEXING.md` describe how a dashboard
+or indexer should consume TrustBridge events, but until Issue #288 there was no
+runnable indexer in the repo — `demo_e2e.sh` is a one-shot and does not tail
+anything. This script is the missing reference implementation.
+
+### What it does
+
+1. Calls the Stellar RPC [`getEvents`](https://developers.stellar.org/docs/data/rpc/api-reference/methods/getEvents)
+   method on a loop, filtered to one `contractId`.
+2. Appends every event as one JSON object per line to
+   `.indexer/events-<network>.jsonl`.
+3. Writes the RPC pagination cursor to `.indexer/cursor-<network>.json` after
+   **every** batch (atomically, via a temp file + `mv`). A restart resumes from
+   that cursor — **idempotent restart**.
+4. De-duplicates on the RPC event `id` using `.indexer/seen-<network>.txt`, so a
+   ledger reorg or an overlapping re-read never appends the same event twice.
+5. Handles the empty stream (advances the cursor past empty windows), RPC
+   errors (linear backoff, bounded retries), and a pruned/too-old cursor
+   (falls back to a cold re-scan).
+
+It is a **reference** indexer for local dev, futurenet, and testnet. It is not
+a production hosted indexer: no cloud account, no database, no secrets — all
+state is three files under `DATA_DIR`.
+
+### Run it
+
+```bash
+# Follow testnet from ~1 day back, forever:
+CONTRACT_ID=C... ./scripts/event_indexer.sh
+
+# Drain to head once and exit (cron / CI):
+CONTRACT_ID=C... ONESHOT=1 ./scripts/event_indexer.sh
+
+# Local / futurenet RPC, explicit start ledger:
+CONTRACT_ID=C... RPC_URL=http://localhost:8000/soroban/rpc \
+  START_LEDGER=1 ONESHOT=1 ./scripts/event_indexer.sh
+
+# Offline: replay a canned RPC response, no network:
+MOCK_RESPONSE=./scripts/testdata/getEvents.sample.json \
+  CONTRACT_ID=C_MOCK ONESHOT=1 ./scripts/event_indexer.sh
+```
+
+### Verify resume behavior locally
+
+```bash
+rm -rf .indexer
+MOCK_RESPONSE=./scripts/testdata/getEvents.sample.json CONTRACT_ID=C_MOCK ONESHOT=1 ./scripts/event_indexer.sh
+wc -l .indexer/events-testnet.jsonl          # => 2
+# Run it again — the cursor on disk is replayed, nothing is double-written:
+MOCK_RESPONSE=./scripts/testdata/getEvents.sample.json CONTRACT_ID=C_MOCK ONESHOT=1 ./scripts/event_indexer.sh
+wc -l .indexer/events-testnet.jsonl          # => still 2
+```
+
+### Environment variables
+
+See the header comment of `event_indexer.sh` for the full list. The common
+ones: `CONTRACT_ID` (required), `RPC_URL`, `NETWORK`, `DATA_DIR`,
+`START_LEDGER`, `LOOKBACK`, `POLL_SECONDS`, `PAGE_LIMIT`, `ONESHOT`,
+`MOCK_RESPONSE`.
+
+### Output schema
+
+Each line of `events-<network>.jsonl`:
+
+```json
+{
+  "id": "0001000042-0000000001",
+  "ledger_sequence": 1000042,
+  "ledger_closed_at": "2026-01-15T12:00:05Z",
+  "contract_id": "C...",
+  "tx_hash": "a1b2c3...",
+  "type": "contract",
+  "topic": ["<base64 xdr>", "..."],
+  "value": "<base64 xdr>",
+  "in_successful_contract_call": true,
+  "indexed_at": "2026-08-29T00:00:00Z"
+}
+```
+
+`(ledger_sequence, tx_hash)` plus the decoded topic symbol is the idempotency
+key described in `docs/DASHBOARD_SYNC.md`. Topic/value XDR decoding is left to
+the consumer (`stellar xdr decode`, or the SDK of your dashboard's language) —
+this script is deliberately decode-agnostic so it stays dependency-light.

--- a/scripts/event_indexer.sh
+++ b/scripts/event_indexer.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# Reference event-indexing service for local dashboard sync (Issue #288).
+#
+# DASHBOARD_SYNC.md and EVENT_INDEXING.md describe an indexer that tails
+# TrustBridge contract events into a local store, but no such process lived in
+# this repo — contributors had to guess the shape. This is that reference
+# implementation: a small, dependency-light poller that
+#
+#   1. calls the Stellar RPC `getEvents` method on a loop,
+#   2. appends every event as one JSON object per line (JSONL) to a data file,
+#   3. persists the RPC pagination cursor to disk after each batch, so a
+#      restart resumes exactly where it left off (idempotent restart), and
+#   4. de-duplicates on the RPC event `id`, so a reorg or an overlapping
+#      re-read never writes the same event twice.
+#
+# It is a REFERENCE indexer for local dev / futurenet / testnet — not a
+# production hosted service. No cloud account, database, or secret is required;
+# all state is two files on disk.
+#
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+#   CONTRACT_ID=C... ./scripts/event_indexer.sh
+#
+#   # against a local / futurenet RPC, from a known ledger, one pass only:
+#   CONTRACT_ID=C... RPC_URL=http://localhost:8000/soroban/rpc \
+#     START_LEDGER=1000 ONESHOT=1 ./scripts/event_indexer.sh
+#
+#   # offline demo against a canned RPC response (no network):
+#   MOCK_RESPONSE=./scripts/testdata/getEvents.sample.json \
+#     CONTRACT_ID=C_MOCK ONESHOT=1 ./scripts/event_indexer.sh
+#
+# ---------------------------------------------------------------------------
+# Environment variables
+# ---------------------------------------------------------------------------
+#   CONTRACT_ID    Deployed contract ID to filter events for (required unless
+#                  MOCK_RESPONSE is set).
+#   RPC_URL        Stellar RPC endpoint. Default: https://soroban-testnet.stellar.org
+#                  Futurenet: https://rpc-futurenet.stellar.org
+#   NETWORK        Informational tag written into the state file (default: testnet).
+#   DATA_DIR       Directory for indexer state + output (default: ./.indexer).
+#   START_LEDGER   Ledger to start from on a COLD start (no cursor on disk).
+#                  Default: latest ledger reported by the RPC minus LOOKBACK.
+#   LOOKBACK       Ledgers to rewind from "latest" on a cold start (default: 17280,
+#                  ~1 day). Ignored once a cursor exists.
+#   POLL_SECONDS   Sleep between polls in the follow loop (default: 5).
+#   PAGE_LIMIT     Events requested per RPC page (default: 100, RPC max is 10000).
+#   ONESHOT        If set to 1, do a single drain to head and exit 0 (for CI /
+#                  cron). Otherwise follow forever until SIGINT/SIGTERM.
+#   MOCK_RESPONSE  Path to a file containing a canned getEvents JSON-RPC
+#                  response. When set, no network call is made and the loop
+#                  runs exactly once. Used by the docs' offline example and by
+#                  scripts/testdata/.
+#   MAX_RETRIES    Consecutive RPC failures tolerated before giving up (default: 5).
+#
+# ---------------------------------------------------------------------------
+# Files written under DATA_DIR
+# ---------------------------------------------------------------------------
+#   events-<network>.jsonl   append-only event log, one JSON object per line
+#   cursor-<network>.json    { "cursor": <str|null>, "last_ledger": <int>,
+#                              "last_id": <str|null>, "updated_at": <iso8601>,
+#                              "event_count": <int> }
+#   seen-<network>.txt       recent event ids (bounded) for dedup across restarts
+#
+# All three are safe to delete: removing cursor-*.json forces a cold re-scan
+# from START_LEDGER/LOOKBACK; removing seen-*.txt only weakens dedup for the
+# overlap window; removing events-*.jsonl loses the local log.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CONTRACT_ID="${CONTRACT_ID:-}"
+RPC_URL="${RPC_URL:-https://soroban-testnet.stellar.org}"
+NETWORK="${NETWORK:-testnet}"
+DATA_DIR="${DATA_DIR:-./.indexer}"
+LOOKBACK="${LOOKBACK:-17280}"
+POLL_SECONDS="${POLL_SECONDS:-5}"
+PAGE_LIMIT="${PAGE_LIMIT:-100}"
+ONESHOT="${ONESHOT:-}"
+MOCK_RESPONSE="${MOCK_RESPONSE:-}"
+MAX_RETRIES="${MAX_RETRIES:-5}"
+SEEN_MAX_LINES="${SEEN_MAX_LINES:-50000}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required." >&2
+  exit 1
+fi
+if [[ -z "$MOCK_RESPONSE" ]] && ! command -v curl >/dev/null 2>&1; then
+  echo "ERROR: curl is required (or set MOCK_RESPONSE for an offline run)." >&2
+  exit 1
+fi
+if [[ -z "$CONTRACT_ID" && -z "$MOCK_RESPONSE" ]]; then
+  echo "ERROR: set CONTRACT_ID=<C...> (or MOCK_RESPONSE=<file> for an offline run)." >&2
+  exit 1
+fi
+
+mkdir -p "$DATA_DIR"
+EVENTS_FILE="${DATA_DIR}/events-${NETWORK}.jsonl"
+CURSOR_FILE="${DATA_DIR}/cursor-${NETWORK}.json"
+SEEN_FILE="${DATA_DIR}/seen-${NETWORK}.txt"
+touch "$EVENTS_FILE" "$SEEN_FILE"
+
+now_iso() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+log() { echo "[$(now_iso)] $*" >&2; }
+
+# --- cursor persistence -----------------------------------------------------
+
+read_cursor()      { [[ -f "$CURSOR_FILE" ]] && jq -r '.cursor // empty' "$CURSOR_FILE" || true; }
+read_last_ledger() { [[ -f "$CURSOR_FILE" ]] && jq -r '.last_ledger // 0' "$CURSOR_FILE" || echo 0; }
+read_event_count() { [[ -f "$CURSOR_FILE" ]] && jq -r '.event_count // 0' "$CURSOR_FILE" || echo 0; }
+
+write_cursor() {
+  # $1 cursor (may be empty), $2 last_ledger, $3 last_id (may be empty), $4 event_count
+  local tmp
+  tmp="$(mktemp "${CURSOR_FILE}.XXXX")"
+  jq -n \
+    --arg cursor "${1:-}" \
+    --argjson last_ledger "${2:-0}" \
+    --arg last_id "${3:-}" \
+    --arg updated_at "$(now_iso)" \
+    --argjson event_count "${4:-0}" \
+    --arg network "$NETWORK" \
+    '{
+      network: $network,
+      cursor: (if $cursor == "" then null else $cursor end),
+      last_ledger: $last_ledger,
+      last_id: (if $last_id == "" then null else $last_id end),
+      updated_at: $updated_at,
+      event_count: $event_count
+    }' > "$tmp"
+  mv -f "$tmp" "$CURSOR_FILE"   # atomic replace — a crash mid-write cannot corrupt the cursor
+}
+
+have_seen() { grep -qxF "$1" "$SEEN_FILE"; }
+
+mark_seen() {
+  echo "$1" >> "$SEEN_FILE"
+  # Keep the dedup file bounded: trim to the most recent SEEN_MAX_LINES ids.
+  local lines
+  lines="$(wc -l < "$SEEN_FILE")"
+  if (( lines > SEEN_MAX_LINES )); then
+    tail -n "$SEEN_MAX_LINES" "$SEEN_FILE" > "${SEEN_FILE}.trim" && mv -f "${SEEN_FILE}.trim" "$SEEN_FILE"
+  fi
+}
+
+# --- RPC -------------------------------------------------------------------
+
+rpc_latest_ledger() {
+  curl -sS --fail --max-time 20 -X POST "$RPC_URL" \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"getLatestLedger"}' \
+    | jq -r '.result.sequence'
+}
+
+# Emits the raw JSON-RPC response for one getEvents page on stdout.
+# Args: $1 = startLedger (used only when $2 is empty), $2 = cursor
+rpc_get_events() {
+  local start_ledger="$1" cursor="$2" pagination
+  if [[ -n "$cursor" ]]; then
+    pagination="$(jq -n --arg c "$cursor" --argjson l "$PAGE_LIMIT" '{cursor:$c, limit:$l}')"
+  else
+    pagination="$(jq -n --argjson l "$PAGE_LIMIT" '{limit:$l}')"
+  fi
+
+  local req
+  req="$(jq -n \
+    --argjson start "${start_ledger:-0}" \
+    --arg cid "$CONTRACT_ID" \
+    --argjson pagination "$pagination" \
+    --arg use_start "$([[ -z "$cursor" ]] && echo yes || echo no)" \
+    '{
+      jsonrpc: "2.0", id: 1, method: "getEvents",
+      params: (
+        {
+          filters: [ { type: "contract", contractIds: [ $cid ], topics: [] } ],
+          pagination: $pagination
+        }
+        + (if $use_start == "yes" then { startLedger: $start } else {} end)
+      )
+    }')"
+
+  curl -sS --fail --max-time 30 -X POST "$RPC_URL" \
+    -H 'Content-Type: application/json' -d "$req"
+}
+
+# --- event processing ----------------------------------------------------
+
+# Reads a JSON-RPC response on stdin, appends new events to EVENTS_FILE,
+# echoes "<next_cursor>\t<max_ledger>\t<appended_count>\t<last_id>" on stdout.
+process_response() {
+  local resp="$1" err
+  err="$(jq -r '.error.message // empty' <<<"$resp")"
+  if [[ -n "$err" ]]; then
+    log "RPC error: $err"
+    return 1
+  fi
+
+  local events next_cursor latest_ledger
+  events="$(jq -c '.result.events // []' <<<"$resp")"
+  next_cursor="$(jq -r '.result.cursor // empty' <<<"$resp")"
+  latest_ledger="$(jq -r '.result.latestLedger // 0' <<<"$resp")"
+
+  local appended=0 max_ledger last_id=""
+  max_ledger="$(read_last_ledger)"
+
+  local n i
+  n="$(jq 'length' <<<"$events")"
+  for (( i = 0; i < n; i++ )); do
+    local ev id ledger
+    ev="$(jq -c ".[$i]" <<<"$events")"
+    id="$(jq -r '.id' <<<"$ev")"
+    ledger="$(jq -r '.ledger // 0' <<<"$ev")"
+
+    if have_seen "$id"; then
+      continue   # reorg / overlap re-read → already logged, skip
+    fi
+
+    # Normalize into the shape DASHBOARD_SYNC.md keys idempotency on:
+    # (ledger_sequence, tx_hash) plus the topic symbol.
+    jq -c \
+      --arg indexed_at "$(now_iso)" \
+      '{
+        id: .id,
+        ledger_sequence: (.ledger // .inSuccessfulContractCall // 0),
+        ledger_closed_at: .ledgerClosedAt,
+        contract_id: .contractId,
+        tx_hash: (.txHash // .transactionHash // null),
+        type: .type,
+        topic: (.topic // .topics),
+        value: .value,
+        in_successful_contract_call: (.inSuccessfulContractCall // true),
+        indexed_at: $indexed_at
+      }' <<<"$ev" >> "$EVENTS_FILE"
+
+    mark_seen "$id"
+    appended=$((appended + 1))
+    last_id="$id"
+    (( ledger > max_ledger )) && max_ledger="$ledger"
+  done
+
+  printf '%s\t%s\t%s\t%s\n' "$next_cursor" "$max_ledger" "$appended" "$last_id"
+}
+
+# --- main loop -----------------------------------------------------------
+
+RUNNING=1
+trap 'RUNNING=0; log "signal received — finishing current batch then exiting"' INT TERM
+
+cold_start_ledger() {
+  if [[ -n "${START_LEDGER:-}" ]]; then
+    echo "$START_LEDGER"; return
+  fi
+  local latest
+  if latest="$(rpc_latest_ledger 2>/dev/null)" && [[ "$latest" =~ ^[0-9]+$ ]]; then
+    local start=$((latest - LOOKBACK))
+    (( start < 1 )) && start=1
+    echo "$start"
+  else
+    echo 1
+  fi
+}
+
+main() {
+  local cursor start_ledger total retries=0
+  cursor="$(read_cursor)"
+  total="$(read_event_count)"
+
+  if [[ -n "$cursor" ]]; then
+    log "resuming from stored cursor (last_ledger=$(read_last_ledger), event_count=$total)"
+    start_ledger=0
+  elif [[ -n "$MOCK_RESPONSE" ]]; then
+    start_ledger=0
+  else
+    start_ledger="$(cold_start_ledger)"
+    log "cold start from ledger $start_ledger (RPC_URL=$RPC_URL, contract=$CONTRACT_ID)"
+  fi
+
+  while (( RUNNING )); do
+    local resp
+    if [[ -n "$MOCK_RESPONSE" ]]; then
+      resp="$(cat "$MOCK_RESPONSE")"
+    elif ! resp="$(rpc_get_events "$start_ledger" "$cursor")"; then
+      retries=$((retries + 1))
+      log "getEvents call failed (attempt $retries/$MAX_RETRIES)"
+      if (( retries >= MAX_RETRIES )); then
+        log "giving up after $MAX_RETRIES consecutive failures"
+        exit 1
+      fi
+      sleep $(( POLL_SECONDS * retries ))   # linear backoff
+      continue
+    fi
+    retries=0
+
+    local line next_cursor max_ledger appended last_id
+    if ! line="$(process_response "$resp")"; then
+      # RPC returned a JSON-RPC error object (e.g. cursor too old / pruned).
+      # On a pruned cursor, fall back to a cold start rather than spin.
+      if jq -e '.error.message | test("cursor"; "i") // false' <<<"$resp" >/dev/null 2>&1; then
+        log "stored cursor rejected by RPC — falling back to cold start"
+        cursor=""
+        start_ledger="$(cold_start_ledger)"
+        write_cursor "" "$start_ledger" "" "$total"
+        continue
+      fi
+      retries=$((retries + 1))
+      (( retries >= MAX_RETRIES )) && { log "repeated RPC errors — exiting"; exit 1; }
+      sleep "$POLL_SECONDS"
+      continue
+    fi
+
+    IFS=$'\t' read -r next_cursor max_ledger appended last_id <<<"$line"
+    total=$((total + appended))
+
+    # Persist progress even when appended == 0: the cursor still advances past
+    # an empty window, and re-reading it on restart must not replay it.
+    if [[ -n "$next_cursor" ]]; then
+      cursor="$next_cursor"
+      start_ledger=0
+    fi
+    write_cursor "$cursor" "${max_ledger:-0}" "$last_id" "$total"
+
+    if (( appended > 0 )); then
+      log "appended $appended event(s) → $EVENTS_FILE (total=$total, through ledger $max_ledger)"
+    fi
+
+    if [[ -n "$MOCK_RESPONSE" ]]; then
+      log "mock run complete: $appended new event(s), total=$total"
+      break
+    fi
+
+    # A short page (fewer than PAGE_LIMIT events) means we have reached head.
+    local page_len
+    page_len="$(jq -r '.result.events | length' <<<"$resp")"
+    if (( page_len < PAGE_LIMIT )); then
+      if [[ -n "$ONESHOT" ]]; then
+        log "reached head (oneshot) — total=$total, exiting 0"
+        break
+      fi
+      sleep "$POLL_SECONDS"
+    fi
+  done
+}
+
+main

--- a/scripts/testdata/getEvents.sample.json
+++ b/scripts/testdata/getEvents.sample.json
@@ -1,0 +1,34 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "events": [
+      {
+        "type": "contract",
+        "ledger": 1000042,
+        "ledgerClosedAt": "2026-01-15T12:00:05Z",
+        "contractId": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "id": "0001000042-0000000001",
+        "pagingToken": "0001000042-0000000001",
+        "inSuccessfulContractCall": true,
+        "txHash": "a1b2c3d4e5f60718293a4b5c6d7e8f900112233445566778899aabbccddeeff00",
+        "topic": ["AAAAAA==", "AAAAAA=="],
+        "value": "AAAAAA=="
+      },
+      {
+        "type": "contract",
+        "ledger": 1000045,
+        "ledgerClosedAt": "2026-01-15T12:00:20Z",
+        "contractId": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "id": "0001000045-0000000001",
+        "pagingToken": "0001000045-0000000001",
+        "inSuccessfulContractCall": true,
+        "txHash": "b2c3d4e5f60718293a4b5c6d7e8f900112233445566778899aabbccddeeff0011",
+        "topic": ["AAAAAA==", "AAAAAA=="],
+        "value": "AAAAAA=="
+      }
+    ],
+    "latestLedger": 1000046,
+    "cursor": "0001000045-0000000001"
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1618,6 +1618,51 @@ impl TrustBridgeContract {
         }
     }
 
+    /// Verified-only address lookup for CI payouts (Issue #287).
+    ///
+    /// [`Self::get_address`] returns the record whenever the username is present,
+    /// regardless of the `verified` flag. A GitHub Action that only checks
+    /// presence would therefore pay an **unverified** registration — a squatter
+    /// who registered a G-address against someone else's username but was never
+    /// confirmed off-chain. This entry point refuses that case at the contract
+    /// boundary so the action does not have to.
+    ///
+    /// Outcomes are distinct and exhaustive:
+    ///
+    /// | State | Result |
+    /// |-------|--------|
+    /// | Username registered **and** `verified == true` | `Ok(ContributorRecord)` |
+    /// | Username registered but `verified == false` | `Err(ContractError::NotVerified)` (code 6) |
+    /// | Username never registered / removed | `Err(ContractError::NotRegistered)` (code 4) |
+    ///
+    /// Read-only; no auth required; works while the contract is paused — the same
+    /// contract-call semantics as [`Self::get_address`], which is left unchanged
+    /// (Issue #287 constraint: no versioned sibling may change `get_address`).
+    /// Callers that want payout eligibility to also depend on pause state should
+    /// additionally check [`Self::is_paused`].
+    ///
+    /// # ABI note for the GitHub Action
+    ///
+    /// Resolve payout addresses with `get_address_if_verified`, not `get_address`.
+    /// Treat error code `6` (`NotVerified`) and code `4` (`NotRegistered`)
+    /// identically: **do not pay**. Only an `Ok` result carries a payable
+    /// `stellar_address` / `payout_address`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotRegistered`] if `github_username` has no record.
+    /// - [`ContractError::NotVerified`] if the record exists but is not verified.
+    pub fn get_address_if_verified(
+        env: Env,
+        github_username: String,
+    ) -> Result<ContributorRecord, ContractError> {
+        match get_record(&env, &github_username) {
+            Some(record) if record.verified => Ok(record),
+            Some(_) => Err(ContractError::NotVerified),
+            None => Err(ContractError::NotRegistered),
+        }
+    }
+
     /// Returns `true` if `github_username` is registered, without deserializing the full record.
     ///
     /// Read-only; no auth required. Use this when callers only need existence confirmation
@@ -3174,6 +3219,109 @@ mod test {
                     .stellar_address,
                 user2
             );
+        });
+    }
+
+    // ── Verified-only lookup (Issue #287) ────────────────────────────────────
+
+    /// A verified registration resolves through `get_address_if_verified` and
+    /// carries the same address `get_address` would return.
+    #[test]
+    fn test_verified_only_lookup_returns_record_when_verified() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), Vec::new(&env))
+                .unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+            let record =
+                TrustBridgeContract::get_address_if_verified(env.clone(), username(&env, "octocat"))
+                    .unwrap();
+            assert_eq!(record.stellar_address, user);
+            assert!(record.verified);
+        });
+    }
+
+    /// A registered-but-unverified username is rejected with `NotVerified` (code 6),
+    /// even though `get_address` would still return it.
+    #[test]
+    fn test_verified_only_lookup_rejects_unverified() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), Vec::new(&env))
+                .unwrap();
+            assert!(
+                TrustBridgeContract::get_address(env.clone(), username(&env, "octocat")).is_some(),
+                "get_address still returns the unverified record"
+            );
+            assert_eq!(
+                TrustBridgeContract::get_address_if_verified(env.clone(), username(&env, "octocat")),
+                Err(ContractError::NotVerified),
+            );
+        });
+    }
+
+    /// An unregistered username is rejected with `NotRegistered` (code 4),
+    /// distinct from the unverified case.
+    #[test]
+    fn test_verified_only_lookup_rejects_unregistered() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                TrustBridgeContract::get_address_if_verified(env.clone(), username(&env, "ghost")),
+                Err(ContractError::NotRegistered),
+            );
+        });
+    }
+
+    /// A revoked registration falls back to `NotVerified` — verification can be
+    /// withdrawn and the verified-only lookup tracks that immediately.
+    #[test]
+    fn test_verified_only_lookup_follows_revocation() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), Vec::new(&env))
+                .unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+            TrustBridgeContract::revoke_verification(
+                env.clone(),
+                admin.clone(),
+                username(&env, "octocat"),
+                1,
+            )
+            .unwrap();
+            assert_eq!(
+                TrustBridgeContract::get_address_if_verified(env.clone(), username(&env, "octocat")),
+                Err(ContractError::NotVerified),
+            );
+        });
+    }
+
+    /// The verified-only lookup keeps working while the contract is paused,
+    /// matching `get_address` read semantics.
+    #[test]
+    fn test_verified_only_lookup_works_while_paused() {
+        let env = Env::default();
+        let (admin, user, _other, contract_id) = setup(&env);
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::register(env.clone(), username(&env, "octocat"), user.clone(), Vec::new(&env))
+                .unwrap();
+            TrustBridgeContract::verify(env.clone(), admin.clone(), username(&env, "octocat"))
+                .unwrap();
+            TrustBridgeContract::pause(env.clone(), 1).unwrap();
+            let record =
+                TrustBridgeContract::get_address_if_verified(env.clone(), username(&env, "octocat"))
+                    .unwrap();
+            assert_eq!(record.stellar_address, user);
         });
     }
 


### PR DESCRIPTION
## Summary

One PR resolving three registry issues. Closes #287, closes #288, closes #289.

| Issue | Area | What landed |
|---|---|---|
| #287 | Read API | `get_address_if_verified` verified-only lookup + tests + action ABI note |
| #288 | Tooling | `scripts/event_indexer.sh` reference indexer with on-disk resume cursor + docs |
| #289 | Docs | Stellar Lab / CLI invoke recipes for **every** admin op in `ADMIN_RUNBOOK.md` |

---

## #287 — Verified-only lookup mode for `get_address`

**Problem.** `get_address` returns a record whenever the username is present,
regardless of the `verified` flag. A CI payout resolver that only checks
presence would pay an unverified squatter who registered a G-address against
someone else's GitHub username.

**Change.** New read, `get_address_if_verified(github_username) -> Result<ContributorRecord, ContractError>`:

| Registry state | Result |
|---|---|
| Registered **and** `verified == true` | `Ok(ContributorRecord)` |
| Registered but `verified == false` | `Err(NotVerified)` — code `6` |
| Never registered / removed | `Err(NotRegistered)` — code `4` |

- `get_address` is left **byte-for-byte unchanged** — this is a versioned
  sibling, per the issue constraint ("Do not change `get_address` meaning
  without a versioned sibling").
- Read-only, no auth, works while paused — same call semantics as `get_address`.
  Callers that also want payouts to stop while the registry is frozen check
  `is_paused()` separately (documented).

**Tests** (`src/lib.rs`, follow existing conventions verbatim):

- `test_verified_only_lookup_returns_record_when_verified`
- `test_verified_only_lookup_rejects_unverified` (asserts `get_address` still returns it)
- `test_verified_only_lookup_rejects_unregistered`
- `test_verified_only_lookup_follows_revocation`
- `test_verified_only_lookup_works_while_paused`

Validation target: `cargo test verified_only` (also matched by `cargo test get_address`).

**ABI** (`docs/ABI.md`): new function entry + an **action-oriented note** — the
GitHub Action must resolve payouts with `get_address_if_verified`, and treat
both `NotVerified` (6) and `NotRegistered` (4) as "do not pay"; only `Ok`
carries a payable address. Implementing the action wiring is out of scope (other
repo), as stated in the issue.

---

## #288 — Reference event-indexing service under `scripts/`

`DASHBOARD_SYNC.md` / `EVENT_INDEXING.md` describe an indexer that did not exist
in-repo; `demo_e2e.sh` is a one-shot. This adds the reference implementation.

**`scripts/event_indexer.sh`**

- Polls the Stellar RPC `getEvents` method, filtered to one `contractId`.
- Appends every event as one JSON object per line to
  `.indexer/events-<network>.jsonl`.
- **Resume behaviour:** writes the RPC pagination cursor to
  `.indexer/cursor-<network>.json` after *every* batch, atomically (temp file +
  `mv`). A restart replays from that cursor. Progress is persisted even for
  empty windows so a restart never re-reads them.
- **Idempotent restart / reorg safety:** de-dups on the RPC event `id` via
  `.indexer/seen-<network>.txt` (bounded); an overlapping re-read or a reorg
  never double-writes.
- **Failure handling:** bounded linear backoff on RPC errors; a pruned/too-old
  cursor falls back to a cold re-scan instead of spinning; empty stream is a
  no-op.
- `ONESHOT=1` drains to head and exits `0` (cron/CI). `MOCK_RESPONSE=<file>`
  replays a canned RPC response with **no network** — used by the docs example.
- No cloud account, no database, no secrets — all state is three files on disk.

**`scripts/testdata/getEvents.sample.json`** — canned response for the offline
example and the local resume-behaviour check.

**Docs** — `scripts/README.md` (scripts index + indexer guide + a
copy-paste "run it twice, line count stays 2" resume check) and a pointer added
to `docs/EVENT_INDEXING.md`.

Local validation (no network):

```
rm -rf .indexer
MOCK_RESPONSE=./scripts/testdata/getEvents.sample.json CONTRACT_ID=C_MOCK ONESHOT=1 ./scripts/event_indexer.sh
wc -l .indexer/events-testnet.jsonl     # 2
MOCK_RESPONSE=./scripts/testdata/getEvents.sample.json CONTRACT_ID=C_MOCK ONESHOT=1 ./scripts/event_indexer.sh
wc -l .indexer/events-testnet.jsonl     # still 2  ← idempotent restart
```

Against futurenet/testnet: `CONTRACT_ID=C... RPC_URL=https://rpc-futurenet.stellar.org ONESHOT=1 ./scripts/event_indexer.sh`.

---

## #289 — Stellar Lab invoke recipes for every admin op

`ADMIN_RUNBOOK.md` listed procedures but no per-function invoke examples, so
operators hand-assemble XDR in Lab during incidents.

**`docs/ADMIN_RUNBOOK.md`** gains:

- A **Contents TOC** linking every section, including the new recipes.
- A **conventions & auth-gotchas** table: network passphrase per network (the
  value Lab needs), `--source-account` (signs/pays) vs the `caller: Address`
  argument (contract-side auth check) and when they must match, the
  Verifier/Revoker role matrix, which ops work while paused, WASM-hash format,
  simulate-before-send, enum/tuple CLI encoding, and no-secrets-in-Lab.
- A paste-ready `stellar contract invoke` line **+ a Lab note** for every admin
  op: `pause` / `unpause` / `set_paused` / `emergency_pause` /
  `clear_emergency_pause`, `set_guardian` / `remove_guardian`, `set_role` /
  `remove_role`, `verify` / `batch_verify` / `revoke_verification` /
  `config_verification`, `batch_remove` / `set_bot_status` /
  `adopt_network_tag`, `set_cooldown` / `set_attestation_required` /
  `attest_upgrade` / `clear_attestation` / `upgrade` / `migrate`, the
  `propose` / `cancel` / `execute_admin_transfer` flow, and the export
  reads + `export_registry.sh`.

Signatures track `docs/ABI.md`; each recipe includes a `-- <fn> --help` escape
hatch to match the live spec of a deployed build. `docs/ABI.md` `pause` links
back to the recipes.

---

## ⚠️ Baseline build note

`origin/main` (`30ff0f6`) does **not** compile — a pre-existing bad merge of an
"entity types (org/team)" feature left `src/lib.rs`, `src/storage.rs`, and
`src/error.rs` mutually inconsistent (duplicated `register` / imports, a
half-spliced `pause` body, duplicate `ContractError` discriminants, missing enum
variants, etc.). This is unrelated to the three issues here.

Per the task instruction to ignore CI and not touch the test suite, this PR is
kept **minimal and self-contained** and does not attempt that repair. `cargo
test` therefore could not be run locally against the broken baseline. The #287
code and tests are written to the existing conventions in `src/lib.rs` and are
correct in isolation; the #288/#289 deliverables are docs + a shell script and
are independent of the Rust build (the indexer was exercised locally via
`MOCK_RESPONSE`).
