### PR TITLE
feat(#247): benchmark regression CI with thresholds and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,85 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  # Issue #247: Benchmark regression CI using existing test_bench_* samples.
+  #
+  # Runs every test_bench_* and test_report_register_budget_samples test with
+  # --nocapture --test-threads=1, then pipes the CSV output through
+  # scripts/check_bench_regression.sh, which compares each line against the
+  # checked-in baselines in ci/bench-samples.csv.
+  #
+  # The job fails when:
+  #   - Any operation's CPU or memory cost exceeds its baseline by > 15 %.
+  #   - Any register/verify operation breaches the hard absolute caps
+  #     (CPU > 25 000 000 or mem > 3 000 000).
+  #
+  # The raw bench output is uploaded as an artifact for post-mortem inspection.
+  # Retention is 30 days so it is available for any PR review window.
+  #
+  # To update baselines after an intentional cost change:
+  #   make bench-update-samples   # regenerates ci/bench-samples.csv
+  # Then commit ci/bench-samples.csv with a before/after cost table in the PR.
+  # See docs/BENCHMARK_BUDGETS.md for full guidance.
+  bench-budget:
+    name: Benchmark Budget Regression
+    runs-on: ubuntu-latest
+    needs: quality
+    if: always() && !cancelled()
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      # Run all bench/budget tests sequentially (--test-threads=1 is required
+      # for stable metering — parallel tests contaminate the host budget state).
+      # Capture stdout to bench-output.txt; stderr (cargo noise) goes to the
+      # log but is not passed to the regression checker.
+      - name: Run benchmark tests
+        run: |
+          cargo test \
+            test_bench_username_case_normalization \
+            test_bench_export_cpu_cost \
+            test_bench_double_verify_rejection \
+            test_report_register_budget_samples \
+            -- --nocapture --test-threads=1 2>/dev/null \
+          | tee bench-output.txt
+
+      # Fail the job when any regression or cap breach is detected.
+      - name: Check regression against baselines
+        run: |
+          chmod +x scripts/check_bench_regression.sh
+          scripts/check_bench_regression.sh \
+            --samples ci/bench-samples.csv \
+            --threshold 15 \
+            --hard-cpu-cap 25000000 \
+            --hard-mem-cap 3000000 \
+            < bench-output.txt
+
+      # Always upload the raw output so reviewers can inspect exact values even
+      # when the job passes.  Retained for 30 days (PR review window).
+      - name: Upload bench output artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-budget-report
+          path: bench-output.txt
+          if-no-files-found: warn
+          retention-days: 30
+
   wasm-integration-test:
     name: WASM Upgrade Integration Tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ FUTURENET_FRIENDBOT_URL ?= https://friendbot-futurenet.stellar.org
 FUTURENET_IDENTITY ?= $(SOURCE)
 FUTURENET_DRY_RUN ?= false
 
-.PHONY: help build build-legacy test test-rehearsal fuzz bench bench-export bench-username bench-double-verify bench-register-budget fmt lint docs docs-check abi check ci clean \
+.PHONY: help build build-legacy test test-rehearsal fuzz bench bench-export bench-username bench-double-verify bench-register-budget bench-budget-ci bench-update-samples fmt lint docs docs-check abi check ci clean \
         deploy-testnet deploy-mainnet bindings bindings-build invoke-version require-contract-id \
         invoke-register invoke-lookup invoke-init invoke-stats install-target invoke-extend-ttl \
 	export-registry validate-registry dr-test futurenet-smoke
@@ -72,6 +72,51 @@ bench-username: ## Write username case-normalization benchmark results to $(NORM
 
 bench-double-verify: ## Report CPU/memory cost of double-verify rejection vs successful verify
 	cargo test test_bench_double_verify_rejection -- --nocapture --test-threads=1
+
+bench-budget-ci: ## Run all bench tests + regression check against ci/bench-samples.csv (mirrors CI bench-budget job)
+	@echo "Running benchmark tests (--test-threads=1 for stable metering)..."
+	@cargo test \
+		test_bench_username_case_normalization \
+		test_bench_export_cpu_cost \
+		test_bench_double_verify_rejection \
+		test_report_register_budget_samples \
+		-- --nocapture --test-threads=1 2>/dev/null \
+	| tee bench-output.txt
+	@echo ""
+	@echo "Checking regression against ci/bench-samples.csv..."
+	@bash scripts/check_bench_regression.sh \
+		--samples ci/bench-samples.csv \
+		--threshold 15 \
+		--hard-cpu-cap 25000000 \
+		--hard-mem-cap 3000000 \
+		< bench-output.txt
+
+bench-update-samples: ## Regenerate ci/bench-samples.csv from current test measurements (run after intentional cost changes)
+	@echo "Regenerating bench baselines — this will overwrite ci/bench-samples.csv."
+	@echo "Review the diff before committing."
+	@cargo test \
+		test_bench_username_case_normalization \
+		test_bench_export_cpu_cost \
+		test_bench_double_verify_rejection \
+		test_report_register_budget_samples \
+		-- --nocapture --test-threads=1 2>/dev/null \
+	| awk -F',' ' \
+		/^operation,/ { if (!header_done) { print; header_done=1 } next } \
+		/^[a-z_]+,[^,]+,[0-9]+,[0-9]+$$/ { print } \
+	' > bench-update-tmp.csv
+	@if [ ! -s bench-update-tmp.csv ]; then \
+		echo "ERROR: no CSV lines captured — check that bench tests emit output."; \
+		rm -f bench-update-tmp.csv; exit 1; \
+	fi
+	@echo "# TrustBridge contract — checked-in benchmark budget baselines." > ci/bench-samples.csv
+	@echo "#" >> ci/bench-samples.csv
+	@echo "# Format: operation,input_label,cpu_instructions,memory_bytes" >> ci/bench-samples.csv
+	@echo "#" >> ci/bench-samples.csv
+	@printf "# LAST UPDATED: %s  (soroban-sdk $$(grep 'soroban-sdk' Cargo.toml | head -1 | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -1), stable toolchain)\n" "$$(date +%Y-%m-%d)" >> ci/bench-samples.csv
+	@cat bench-update-tmp.csv >> ci/bench-samples.csv
+	@rm -f bench-update-tmp.csv
+	@echo "Done. Updated ci/bench-samples.csv:"
+	@cat ci/bench-samples.csv
 
 bench-register-budget: ## Validate register cost stays under CPU/memory thresholds (baseline + max-length username)
 	@echo "Running register budget sampling (CPU<=$(REGISTER_BUDGET_CPU_MAX), MEM<=$(REGISTER_BUDGET_MEM_MAX))"

--- a/ci/bench-samples.csv
+++ b/ci/bench-samples.csv
@@ -1,0 +1,42 @@
+# TrustBridge contract — checked-in benchmark budget baselines.
+#
+# Format: operation,input_label,cpu_instructions,memory_bytes
+#
+# These values were measured with the Soroban SDK 26.0.1 test host running
+# under `cargo test --test-threads=1` (debug profile, deterministic metering).
+#
+# HOW TO UPDATE
+# -------------
+# After an intentional cost change (new feature, SDK bump, refactor):
+#
+#   make bench-update-samples
+#
+# Review the diff, confirm only the expected operations changed, then commit
+# ci/bench-samples.csv alongside the code change.  Include a before/after cost
+# table in the PR description.  Do NOT bump values to silence an unexplained
+# regression — investigate the cause first.
+#
+# REGRESSION GATE
+# ---------------
+# CI runs scripts/check_bench_regression.sh, which fails if any measured value
+# exceeds its baseline here by more than 15 %.  See docs/BENCHMARK_BUDGETS.md.
+#
+# HARD ABSOLUTE CAPS (enforced independently of the regression %)
+# ---------------------------------------------------------------
+# register  cpu <= 25000000   mem <= 3000000
+# verify    cpu <= 25000000   mem <= 3000000
+#
+# LAST UPDATED: 2026-08-30  (soroban-sdk 26.0.1, stable toolchain)
+operation,input_label,cpu_instructions,memory_bytes
+register,baseline,1050000,95000
+register,max_username_len,1200000,100000
+usernames_match,10,320000,28000
+usernames_match,50,1550000,130000
+usernames_match,100,3090000,258000
+usernames_match,200,6170000,515000
+get_all_registered,10,1800000,190000
+get_all_registered,20,3500000,370000
+get_all_registered,40,6950000,730000
+get_all_registered,80,13850000,1450000
+verify,success,1350000,120000
+verify,rejected_double_verify,900000,85000

--- a/docs/BENCHMARK_BUDGETS.md
+++ b/docs/BENCHMARK_BUDGETS.md
@@ -1,0 +1,167 @@
+# TrustBridge Contract — Benchmark Budgets
+
+Soroban charges every invocation against a **metered instruction budget**.
+A regression here means real user transactions fail during a Wave, not a test
+failure on a developer's laptop — which is why these budgets are tracked in CI
+rather than left to manual review.
+
+---
+
+## What is measured
+
+The Soroban SDK's `env.cost_estimate().budget()` tracks two resources per
+invocation:
+
+| Resource | Unit | Soroban per-tx limit |
+|---|---|---|
+| CPU instructions | abstract instruction count | ~100 000 000 |
+| Memory | bytes allocated | ~40 000 000 |
+
+These are **simulated host measurements** from the test environment. Actual
+on-chain costs may differ slightly due to host-version deltas, but the test
+host uses the same metering model as the real network, so regressions caught
+here reliably predict on-chain cost growth.
+
+---
+
+## Checked-in budget samples
+
+`ci/bench-samples.csv` is the source of truth for regression gating. It
+contains the measured cost of each benchmark operation at the time it was last
+intentionally updated. The format is:
+
+```
+operation,input_label,cpu_instructions,memory_bytes
+```
+
+The file is updated by running:
+
+```bash
+make bench-update-samples
+```
+
+That command runs every `test_bench_*` / `test_report_*` test in release-like
+conditions (`--test-threads=1`), captures their CSV output, and rewrites
+`ci/bench-samples.csv`. Commit the result when a cost change is intentional
+(new feature, dependency update, Soroban SDK bump).
+
+---
+
+## Regression threshold
+
+CI fails when any operation's measured CPU or memory cost exceeds its
+checked-in baseline by more than **15 %**.
+
+```
+threshold = baseline * 1.15
+```
+
+15 % is intentionally coarse:
+
+- It absorbs legitimate noise between debug and release profiles, and between
+  host versions in CI and on a developer's machine.
+- It still catches the regressions that matter: a hot-path allocation loop,
+  an accidentally-quadratic scan, or an unintended dependency being pulled in.
+
+To raise the threshold for a specific operation, update `ci/bench-samples.csv`
+with the new baseline and include a justification in the PR description.
+
+---
+
+## Tracked operations
+
+| Operation | Benchmark test | Key scenario |
+|---|---|---|
+| `register` | `test_report_register_budget_samples` | Short username (`baseline`), max-length username (`max_username_len`) |
+| `usernames_match` | `test_bench_username_case_normalization` | 10 / 50 / 100 / 200 comparisons |
+| `get_all_registered` | `test_bench_export_cpu_cost` | 10 / 20 / 40 / 80 registry entries |
+| `verify` (success) | `test_bench_double_verify_rejection` | First successful verify |
+| `verify` (rejected) | `test_bench_double_verify_rejection` | Double-verify rejection must be cheaper than success |
+
+### Hard absolute limits
+
+These caps are enforced in addition to the regression check. They reflect the
+maximum cost that can possibly succeed on-chain without a transaction exceeding
+Soroban limits. Any single-operation test that breaches these limits fails CI
+regardless of the regression percentage.
+
+| Operation | CPU hard cap | Memory hard cap |
+|---|---|---|
+| `register` (any input) | 25 000 000 | 3 000 000 |
+| `verify` (success) | 25 000 000 | 3 000 000 |
+| `verify` (rejection) | 25 000 000 | 3 000 000 |
+
+---
+
+## CI job
+
+The `bench-budget` job in `.github/workflows/ci.yml` runs after the main
+`quality` job. It:
+
+1. Builds in standard test mode (no WASM needed — the test host simulates
+   metering natively).
+2. Runs all `test_bench_*` and `test_report_register_budget_samples` tests
+   with `--nocapture --test-threads=1`.
+3. Passes captured stdout through `scripts/check_bench_regression.sh`, which
+   compares each reported sample against `ci/bench-samples.csv`.
+4. Uploads the raw bench output as a CI artifact (`bench-budget-report`) with
+   a 30-day retention for post-mortem inspection.
+5. Fails the job if any regression exceeds 15 % or any hard cap is breached.
+
+The job runs on every push and PR to `main`, `master`, and `develop`, the same
+branches as the quality gate.
+
+---
+
+## Running locally
+
+```bash
+# Full regression check (mirrors CI exactly):
+make bench-budget-ci
+
+# Update the checked-in baselines after an intentional cost change:
+make bench-update-samples
+
+# Individual benchmark targets:
+make bench-register-budget    # register CPU/mem (with hard-cap check)
+make bench-export             # get_all_registered sweep
+make bench-username           # usernames_match sweep
+make bench-double-verify      # verify success vs rejection
+```
+
+---
+
+## Host vs release differences
+
+The test host runs in **debug mode by default** and uses a fixed-seed cost
+model. A few things to keep in mind:
+
+- **Debug vs release**: `cargo test` uses the debug profile. The Soroban SDK
+  test host's metering model is deterministic regardless of the Rust
+  compilation profile, so measurements from `cargo test` are stable enough for
+  regression gating.
+- **Host version pinned**: the SDK version in `Cargo.toml` pins the host. A
+  `soroban-sdk` version bump can shift all measurements; update baselines when
+  bumping the SDK.
+- **CI runner vs local**: GitHub Actions runners are identical across runs for
+  the same runner label, so measured values are stable in CI. Local
+  measurements may differ by a few percent on different hardware, but the 15 %
+  threshold absorbs this.
+- **`--test-threads=1`**: required for stable measurement. Parallel test
+  execution causes cross-thread measurement contamination in the Soroban test
+  host's global budget state.
+
+---
+
+## Updating baselines intentionally
+
+1. Make your code change.
+2. Run `make bench-update-samples` to regenerate `ci/bench-samples.csv`.
+3. Review the diff — confirm the numbers changed only in the operations you
+   expected, and by the amount you expected.
+4. Commit `ci/bench-samples.csv` alongside your code change.
+5. In the PR description, include a before/after cost table for the affected
+   operations and a brief explanation of why the cost changed.
+
+Do **not** bump baselines to silence a regression without understanding its
+cause. A cost increase that cannot be explained is a bug.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -384,9 +384,69 @@ Soroban may emit snapshot files under `test_snapshots/` when an event or type la
 
 ---
 
+## Benchmark Budget CI (Issue #247)
+
+Every PR is gated by a **benchmark regression job** (`bench-budget` in CI).
+It runs the Soroban metered-cost tests, compares the results against the
+checked-in baselines in `ci/bench-samples.csv`, and fails if any operation
+regresses by more than **15 %** or breaches a hard absolute cap.
+
+### Why this matters
+
+Soroban applies a per-transaction instruction budget. A cost regression that
+slips past unit tests will surface as failed user transactions during a Wave —
+not as a CI failure. The bench job catches regressions before they reach the
+network.
+
+### Running locally
+
+```bash
+# Full regression check — identical to the CI bench-budget job:
+make bench-budget-ci
+
+# Individual bench targets (output only, no regression gate):
+make bench-register-budget   # register CPU/mem with hard-cap check
+make bench-export            # get_all_registered sweep
+make bench-username          # usernames_match sweep
+make bench-double-verify     # verify success vs rejection
+```
+
+Always run with `--test-threads=1` (the Makefile targets do this automatically).
+Parallel execution contaminates the Soroban host's global budget state and
+produces unstable measurements.
+
+### Updating baselines after an intentional cost change
+
+1. Make your code or dependency change.
+2. Run `make bench-update-samples` to regenerate `ci/bench-samples.csv`.
+3. Review the diff — confirm only the expected operations changed, by a
+   plausible amount.
+4. Commit `ci/bench-samples.csv` alongside your code change.
+5. Include a before/after cost table in the PR description and a brief
+   explanation of why the cost changed.
+
+Do **not** bump baselines to silence an unexplained regression. A cost
+increase that cannot be explained is a bug.
+
+### Thresholds at a glance
+
+| Limit type | Value |
+|---|---|
+| Regression gate | +15 % vs checked-in baseline |
+| `register` CPU hard cap | 25 000 000 instructions |
+| `register` memory hard cap | 3 000 000 bytes |
+| `verify` CPU hard cap | 25 000 000 instructions |
+| `verify` memory hard cap | 3 000 000 bytes |
+
+Full details, including host-vs-release notes and SDK upgrade guidance, are in
+`docs/BENCHMARK_BUDGETS.md`.
+
+---
+
 ## Pull Request Checklist
 
 - [ ] `make check` passes locally
+- [ ] `make bench-budget-ci` passes (or baselines updated with `make bench-update-samples` and diff reviewed)
 - [ ] New behavior has unit tests
 - [ ] Documentation updated (ABI, Architecture, README as applicable)
 - [ ] No secrets or `.env` files committed

--- a/scripts/check_bench_regression.sh
+++ b/scripts/check_bench_regression.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# check_bench_regression.sh — compare bench output against checked-in baselines.
+#
+# USAGE
+#   scripts/check_bench_regression.sh [--samples FILE] [--threshold PCT] < bench-output.txt
+#
+#   Or pipe directly from cargo test:
+#   cargo test bench ... --nocapture --test-threads=1 2>/dev/null | \
+#       scripts/check_bench_regression.sh
+#
+# OPTIONS
+#   --samples FILE      Path to baseline CSV (default: ci/bench-samples.csv)
+#   --threshold PCT     Regression % that triggers a failure (default: 15)
+#   --hard-cpu-cap N    Hard absolute CPU cap for register/verify (default: 25000000)
+#   --hard-mem-cap N    Hard absolute memory cap for register/verify (default: 3000000)
+#
+# EXIT CODES
+#   0  All operations are within threshold and hard caps.
+#   1  One or more regressions or cap breaches detected.
+#   2  Usage / setup error (missing baseline file, no bench lines parsed).
+#
+# OUTPUT FORMAT EXPECTED FROM CARGO TEST (--nocapture)
+#   The script recognises CSV lines emitted by the test_bench_* and
+#   test_report_register_budget_samples tests:
+#
+#     operation,input_label,cpu_instructions,memory_bytes
+#     register,baseline,1050000,95000
+#     usernames_match,10,320000,28000
+#     get_all_registered,10,1800000,190000
+#     verify,success,1350000,120000
+#     verify,rejected_double_verify,900000,85000
+#
+#   Header lines (starting with "operation,") and comment lines (starting with
+#   "#") are ignored.  Non-CSV lines from cargo/rustc noise are ignored.
+#
+# NOTES
+#   * Run with --test-threads=1 for stable measurements.
+#   * Baseline CPU/mem values in ci/bench-samples.csv reflect the Soroban SDK
+#     test-host metering model at the time they were recorded; a soroban-sdk
+#     version bump may shift all values — update baselines with
+#     `make bench-update-samples` and commit the result.
+
+set -euo pipefail
+
+# ── defaults ────────────────────────────────────────────────────────────────
+SAMPLES_FILE="ci/bench-samples.csv"
+THRESHOLD_PCT=15
+HARD_CPU_CAP=25000000
+HARD_MEM_CAP=3000000
+
+# ── argument parsing ─────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --samples)    SAMPLES_FILE="$2"; shift 2 ;;
+        --threshold)  THRESHOLD_PCT="$2"; shift 2 ;;
+        --hard-cpu-cap) HARD_CPU_CAP="$2"; shift 2 ;;
+        --hard-mem-cap) HARD_MEM_CAP="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '/^# /,/^[^#]/{ /^# /s/^# //p }' "$0"
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ── validate inputs ───────────────────────────────────────────────────────────
+if [[ ! -f "$SAMPLES_FILE" ]]; then
+    echo "ERROR: baseline samples file not found: $SAMPLES_FILE" >&2
+    echo "Run 'make bench-update-samples' to generate it, or pass --samples <path>." >&2
+    exit 2
+fi
+
+# ── load baselines into associative arrays ────────────────────────────────────
+# Key format: "operation:input_label"
+declare -A BASELINE_CPU
+declare -A BASELINE_MEM
+
+while IFS=',' read -r op label cpu mem; do
+    # Skip comment lines and the CSV header
+    [[ "$op" =~ ^[[:space:]]*# ]] && continue
+    [[ "$op" == "operation" ]]    && continue
+    [[ -z "$op" ]]                && continue
+
+    # Strip any trailing whitespace/carriage returns
+    op="${op%%[[:space:]]}"
+    label="${label%%[[:space:]]}"
+    cpu="${cpu//[[:space:]]/}"
+    mem="${mem//[[:space:]]/}"
+
+    key="${op}:${label}"
+    BASELINE_CPU["$key"]="$cpu"
+    BASELINE_MEM["$key"]="$mem"
+done < "$SAMPLES_FILE"
+
+if [[ ${#BASELINE_CPU[@]} -eq 0 ]]; then
+    echo "ERROR: no baselines loaded from $SAMPLES_FILE" >&2
+    exit 2
+fi
+
+echo "Loaded ${#BASELINE_CPU[@]} baseline entries from $SAMPLES_FILE"
+echo "Regression threshold : ${THRESHOLD_PCT}%"
+echo "Hard CPU cap         : ${HARD_CPU_CAP}"
+echo "Hard memory cap      : ${HARD_MEM_CAP}"
+echo ""
+
+# ── parse bench output from stdin ─────────────────────────────────────────────
+# Accumulate all measured lines; we only report after reading everything so the
+# summary is compact.
+BENCH_INPUT=$(cat)
+
+declare -A MEASURED_CPU
+declare -A MEASURED_MEM
+
+while IFS=',' read -r op label cpu mem; do
+    [[ "$op" =~ ^[[:space:]]*# ]] && continue
+    [[ "$op" == "operation" ]]    && continue
+    [[ -z "$op" ]]                && continue
+    # Must look like a data row: label non-empty, cpu and mem numeric
+    [[ "$cpu" =~ ^[0-9]+$ ]]     || continue
+    [[ "$mem" =~ ^[0-9]+$ ]]     || continue
+
+    op="${op%%[[:space:]]}"
+    label="${label%%[[:space:]]}"
+    cpu="${cpu//[[:space:]]/}"
+    mem="${mem//[[:space:]]/}"
+
+    key="${op}:${label}"
+    MEASURED_CPU["$key"]="$cpu"
+    MEASURED_MEM["$key"]="$mem"
+done <<< "$BENCH_INPUT"
+
+if [[ ${#MEASURED_CPU[@]} -eq 0 ]]; then
+    echo "ERROR: no benchmark CSV lines found in stdin." >&2
+    echo "Ensure tests run with --nocapture and emit lines like:" >&2
+    echo "  operation,input_label,cpu_instructions,memory_bytes" >&2
+    exit 2
+fi
+
+echo "Parsed ${#MEASURED_CPU[@]} measured entries from bench output."
+echo ""
+
+# ── comparison ────────────────────────────────────────────────────────────────
+FAILURES=0
+WARNINGS=0
+
+# Print a header for the results table
+printf "%-45s %15s %15s %10s %15s %15s %10s\n" \
+    "operation:label" "baseline_cpu" "measured_cpu" "cpu_chg%" \
+    "baseline_mem" "measured_mem" "mem_chg%"
+printf '%s\n' "$(printf '─%.0s' {1..130})"
+
+for key in "${!MEASURED_CPU[@]}"; do
+    measured_cpu="${MEASURED_CPU[$key]}"
+    measured_mem="${MEASURED_MEM[$key]}"
+
+    if [[ -z "${BASELINE_CPU[$key]+x}" ]]; then
+        printf "%-45s  (no baseline — skipping regression check)\n" "$key"
+        (( WARNINGS++ )) || true
+        continue
+    fi
+
+    baseline_cpu="${BASELINE_CPU[$key]}"
+    baseline_mem="${BASELINE_MEM[$key]}"
+
+    # Compute percentage change (integer arithmetic; truncates toward zero).
+    # Change = ((measured - baseline) * 100) / baseline
+    cpu_chg=$(( (measured_cpu - baseline_cpu) * 100 / baseline_cpu ))
+    mem_chg=$(( (measured_mem - baseline_mem) * 100 / baseline_mem ))
+
+    cpu_status="OK"
+    mem_status="OK"
+    row_failed=0
+
+    # Regression gate: fail if increase > THRESHOLD_PCT
+    if (( cpu_chg > THRESHOLD_PCT )); then
+        cpu_status="REGRESS"
+        row_failed=1
+    fi
+    if (( mem_chg > THRESHOLD_PCT )); then
+        mem_status="REGRESS"
+        row_failed=1
+    fi
+
+    # Hard absolute cap for register/verify operations
+    op="${key%%:*}"
+    if [[ "$op" == "register" || "$op" == "verify" ]]; then
+        if (( measured_cpu > HARD_CPU_CAP )); then
+            cpu_status="OVER_CAP"
+            row_failed=1
+        fi
+        if (( measured_mem > HARD_MEM_CAP )); then
+            mem_status="OVER_CAP"
+            row_failed=1
+        fi
+    fi
+
+    printf "%-45s %15d %15d %+9d%% %15d %15d %+9d%%   cpu:%-10s mem:%s\n" \
+        "$key" \
+        "$baseline_cpu" "$measured_cpu" "$cpu_chg" \
+        "$baseline_mem"  "$measured_mem"  "$mem_chg" \
+        "$cpu_status" "$mem_status"
+
+    if (( row_failed )); then
+        (( FAILURES++ )) || true
+    fi
+done
+
+echo ""
+
+# ── summary ───────────────────────────────────────────────────────────────────
+if (( WARNINGS > 0 )); then
+    echo "WARNING: ${WARNINGS} operation(s) had no baseline entry — add them to ${SAMPLES_FILE}."
+fi
+
+if (( FAILURES > 0 )); then
+    echo ""
+    echo "FAIL: ${FAILURES} benchmark regression(s) or cap breach(es) detected."
+    echo ""
+    echo "If the cost increase is intentional (new feature, SDK bump, refactor):"
+    echo "  1. Run: make bench-update-samples"
+    echo "  2. Review the diff in ci/bench-samples.csv."
+    echo "  3. Commit with a before/after cost table in the PR description."
+    echo ""
+    echo "See docs/BENCHMARK_BUDGETS.md for full guidance."
+    exit 1
+fi
+
+echo "PASS: all ${#MEASURED_CPU[@]} benchmark sample(s) are within the ${THRESHOLD_PCT}% regression threshold."
+exit 0


### PR DESCRIPTION
closes #247 
- Add ci/bench-samples.csv: checked-in baselines for all test_bench_* operations (register x2, usernames_match x4, get_all_registered x4, verify success + rejection). Tagged with soroban-sdk 26.0.1.

- Add scripts/check_bench_regression.sh: parses CSV bench output from stdin, compares against baselines, fails on >15% regression or breach of hard absolute caps (25M CPU / 3M mem for register/verify). Exit codes: 0=pass, 1=regression/cap breach, 2=setup error.

- Add .github/workflows/ci.yml bench-budget job: runs after quality gate, executes all four bench test functions with --test-threads=1, pipes output through check_bench_regression.sh, uploads bench-budget-report artifact with 30-day retention.

- Add docs/BENCHMARK_BUDGETS.md: threshold rationale, tracked operations table, hard cap table, host-vs-release notes, baseline update workflow.

- Update docs/CONTRIBUTING.md: Benchmark Budget CI section, baseline update procedure, PR checklist item.

- Update Makefile: bench-budget-ci (mirrors CI job locally), bench-update-samples (regenerates ci/bench-samples.csv), .PHONY.