### PR TITLE
Add role-grant timelock, guardian docs/events, and provenance digests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ FUTURENET_DRY_RUN ?= false
 .PHONY: help build build-legacy test test-rehearsal fuzz bench bench-export bench-username bench-double-verify bench-register-budget fmt lint docs docs-check abi check ci clean \
         deploy-testnet deploy-mainnet bindings bindings-build invoke-version require-contract-id \
         invoke-register invoke-lookup invoke-init invoke-stats install-target invoke-extend-ttl \
-	export-registry validate-registry dr-test futurenet-smoke
+	export-registry validate-registry dr-test futurenet-smoke assert-build
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
@@ -363,3 +363,10 @@ export-registry: require-contract-id ## Export full registry to JSON (admin) —
 
 validate-registry: require-contract-id ## Validate a registry export JSON against live state, no writes (CONTRACT_ID, EXPORT_FILE, ADMIN_SOURCE=admin for full diff)
 	CONTRACT_ID=$(CONTRACT_ID) SOURCE=$(SOURCE) ADMIN_SOURCE=$(ADMIN_SOURCE) NETWORK=$(NETWORK) ./scripts/validate_registry.sh $(EXPORT_FILE)
+
+assert-build: require-contract-id ## Verify a locally built WASM hash matches stored provenance (WASM_HASH, CONTRACT_ID)
+	@test -n "$(WASM_HASH)" || (echo "WASM_HASH is required — run 'stellar contract build' and hash the artifact" && exit 1)
+	$(STELLAR) contract invoke \
+		--id $(CONTRACT_ID) \
+		--network $(NETWORK) \
+		-- assert_build --hash $(WASM_HASH)

--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -2294,3 +2294,74 @@ Read-only; no auth; works while paused.
 `usernames.len()` exceeds the configured threshold, instead of executing —
 below the threshold, or with the default threshold of `0`, `batch_remove`'s
 behavior is completely unchanged.
+
+## Timelocked role grants (Issue #220)
+
+### `set_role_delay(secs: u64) -> Result<(), ContractError>`
+
+Admin-only. Seconds a future `set_role` grant must wait before activation.
+`0` (the default) keeps grants instant, so existing deployments are unchanged.
+
+### `get_role_delay() -> u64`
+
+Current delay in seconds.
+
+### `set_role(target: Address, role: Role) -> Result<(), ContractError>`
+
+Unchanged when the delay is `0`. When the delay is non-zero the grant is queued
+instead of applied, and `RoleGrantPendingEvent` is emitted in place of
+`RoleGrantedEvent`. The admin address itself is stored separately and is never
+subject to this delay.
+
+### `get_pending_role(target: Address) -> Option<PendingRoleGrant>`
+
+`PendingRoleGrant { role: Role, activate_at: u64 }` — the queued grant, if any.
+
+### `activate_role(target: Address) -> Result<(), ContractError>`
+
+Admin-only. Applies a queued grant once `activate_at` has passed and emits the
+normal `RoleGrantedEvent`.
+
+- `NoPendingRoleGrant` (34) — nothing queued for `target`.
+- `RoleGrantNotReady` (35) — timelock has not elapsed.
+
+### `cancel_role_grant(target: Address) -> Result<(), ContractError>`
+
+Admin-only. Drops a queued grant and emits `RoleGrantCancelledEvent`.
+`remove_role` also drops any queued grant for the same address.
+
+### Events
+
+| Event | Fields |
+|-------|--------|
+| `RoleGrantPendingEvent` | `address` (topic), `role`, `admin`, `activate_at`, `timestamp` |
+| `RoleGrantCancelledEvent` | `address` (topic), `admin`, `timestamp` |
+| `GuardianChangedEvent` | `guardian: Option<Address>`, `admin`, `timestamp` |
+
+## Provenance digests and build verification (Issues #224, #225)
+
+`WasmProvenance` gains two optional digests:
+
+```rust
+pub struct WasmProvenance {
+    // ... existing fields ...
+    pub sbom_hash: Option<BytesN<32>>,
+    pub source_hash: Option<BytesN<32>>,
+}
+```
+
+### `set_provenance_digests(sbom_hash: Option<BytesN<32>>, source_hash: Option<BytesN<32>>) -> Result<(), ContractError>`
+
+Admin-only. Records the digests for the currently deployed WASM. A `None`
+argument leaves the stored value untouched. Fails with `ProvenanceMissing` (36)
+when no provenance record exists.
+
+### `assert_build(hash: BytesN<32>) -> Result<(), ContractError>`
+
+Read-only pre-upgrade check comparing `hash` to `provenance.wasm_hash`.
+
+- `ProvenanceMissing` (36) — nothing deployed via `upgrade` yet.
+- `ProvenanceMismatch` (37) — hashes differ.
+
+`upgrade` still checks the WASM hash exactly as before; `assert_build` is an
+independent read that neither requires nor consumes an attestation.

--- a/docs/ADMIN_RUNBOOK.md
+++ b/docs/ADMIN_RUNBOOK.md
@@ -824,3 +824,75 @@ stellar contract invoke \
 
 Available even while paused, so a stuck or mistaken proposal is never
 trapped behind the same freeze that might be the reason to cancel it.
+
+## Watchtower guardian (Issue #222)
+
+The guardian is a **pause-only** key. It exists so incident response does not
+require the upgrade key: whoever can freeze the contract cannot change its code.
+
+| Action | Admin | Guardian |
+|--------|-------|----------|
+| `emergency_pause` | yes | **yes** |
+| `clear_emergency_pause` | yes | no |
+| `upgrade` | yes | no |
+| `set_role` / `activate_role` | yes | no |
+| `set_guardian` / `remove_guardian` | yes | no |
+
+Every change to the guardian address emits `GuardianChangedEvent` (with
+`guardian: None` on removal), so a rotation is visible to indexers.
+
+### Designate or rotate the guardian
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID --source-account admin-identity --network testnet --send=yes \
+  -- set_guardian --guardian $GUARDIAN_ADDRESS
+```
+
+Setting a guardian replaces the previous one; the old address loses the ability
+to pause on the same transaction.
+
+### Freeze during an incident
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID --source-account guardian-identity --network testnet --send=yes \
+  -- emergency_pause --caller $GUARDIAN_ADDRESS
+```
+
+Unfreezing is admin-only (`clear_emergency_pause`) — a compromised guardian key
+can cost availability, never a silent resumption.
+
+### Remove the guardian
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID --source-account admin-identity --network testnet --send=yes \
+  -- remove_guardian
+```
+
+## Timelocked role grants (Issue #220)
+
+`set_role` is instant while `get_role_delay()` is `0`. Once the admin sets a
+delay, a grant is only *queued*: it is visible as `RoleGrantPendingEvent` and via
+`get_pending_role(target)`, and takes effect only when `activate_role(target)` is
+called after `activate_at`. `cancel_role_grant(target)` drops a queued grant, and
+`remove_role(target)` drops it too.
+
+The **admin role itself is the documented exception**: the admin address is
+stored separately and is not granted through `set_role`, so it is never subject
+to this delay.
+
+```bash
+# Opt in to a 24h delay on all future role grants
+stellar contract invoke \
+  --id $CONTRACT_ID --source-account admin-identity --network testnet --send=yes \
+  -- set_role_delay --secs 86400
+
+# Queue, inspect, then activate after the window
+stellar contract invoke --id $CONTRACT_ID --source-account admin-identity --network testnet --send=yes \
+  -- set_role --target $TARGET --role Verifier
+stellar contract invoke --id $CONTRACT_ID --network testnet -- get_pending_role --target $TARGET
+stellar contract invoke --id $CONTRACT_ID --source-account admin-identity --network testnet --send=yes \
+  -- activate_role --target $TARGET
+```

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -719,3 +719,60 @@ If intentional feature growth pushes the binary past 200 KB:
    - `.github/workflows/ci.yml` — the `WASM_SIZE_LIMIT:` env variable
 4. Document the new limit and the feature that required the bump in this table.
 5. Include before/after sizes in the PR description.
+
+## Provenance digests: SBOM and source (Issue #224)
+
+`WasmProvenance` carries two digests beyond `wasm_hash`:
+
+| Field | Meaning |
+|-------|---------|
+| `sbom_hash` | SHA-256 of the SBOM generated for this build |
+| `source_hash` | SHA-256 of the source tree the WASM was built from |
+
+Both are `Option<BytesN<32>>`. `upgrade` writes them as `None` — the chain cannot
+know them — and the operator backfills them right after the upgrade:
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID --source-account admin-identity --network testnet --send=yes \
+  -- set_provenance_digests --sbom_hash $SBOM_SHA256 --source_hash $SOURCE_SHA256
+```
+
+Passing `None` for either argument leaves the stored value untouched, so the two
+can be filled in independently.
+
+**Migration.** Provenance records written before these fields existed decode with
+both digests absent, which reads as "not recorded" rather than "verified empty".
+The migration is one `set_provenance_digests` call per deployed instance; there is
+no automatic backfill, because only the operator holds the build outputs.
+
+Suggested way to produce the values:
+
+```bash
+sha256sum target/wasm32v1-none/release/trustbridge_contract.wasm   # wasm_hash
+sha256sum sbom.spdx.json                                           # sbom_hash
+git archive --format=tar HEAD | sha256sum                          # source_hash
+```
+
+## Pre-upgrade reproducible-build check (Issue #225)
+
+`assert_build(hash)` compares a locally built hash against the hash in stored
+provenance and fails with a typed error instead of a mismatched deploy:
+
+| Situation | Result |
+|-----------|--------|
+| Hash equals stored provenance | `Ok(())` |
+| No provenance recorded yet (never upgraded) | `ProvenanceMissing` (36) |
+| Hash differs | `ProvenanceMismatch` (37) |
+
+It is a read-only check on **provenance only**. It does not read, require, or
+consume an upgrade attestation — `attest_upgrade` remains a separate, optional
+control over the *next* upgrade, while `assert_build` describes what is deployed
+*now*. On a contract that has never been upgraded there is nothing to compare
+against, and the check fails closed rather than passing.
+
+```bash
+stellar contract build
+HASH=$(sha256sum target/wasm32v1-none/release/trustbridge_contract.wasm | cut -d' ' -f1)
+make assert-build CONTRACT_ID=$CONTRACT_ID WASM_HASH=$HASH
+```

--- a/src/error.rs
+++ b/src/error.rs
@@ -110,6 +110,16 @@ pub enum ContractError {
     /// `add_verifier` was given a non-zero `expires_at` that is not in the
     /// future (Issue #293).
     VerifierExpiryInPast = 33,
+    /// `activate_role` / `cancel_role_grant` was called for an address with no
+    /// pending grant (Issue #220).
+    NoPendingRoleGrant = 34,
+    /// `activate_role` was called before the grant's timelock elapsed (Issue #220).
+    RoleGrantNotReady = 35,
+    /// `assert_build` was called before any provenance record exists (Issue #225).
+    ProvenanceMissing = 36,
+    /// `assert_build` was given a hash that does not match stored provenance
+    /// (Issue #225).
+    ProvenanceMismatch = 37,
 }
 
 impl ContractError {
@@ -157,6 +167,10 @@ impl ContractError {
             31 => Some(ContractError::VerifierAllowlistFull),
             32 => Some(ContractError::VerifierNotAllowlisted),
             33 => Some(ContractError::VerifierExpiryInPast),
+            34 => Some(ContractError::NoPendingRoleGrant),
+            35 => Some(ContractError::RoleGrantNotReady),
+            36 => Some(ContractError::ProvenanceMissing),
+            37 => Some(ContractError::ProvenanceMismatch),
             _ => None,
         }
     }
@@ -232,6 +246,12 @@ impl ContractError {
             ContractError::ReservedListFull => ErrorCategory::Fatal,
             ContractError::AdminTransferPending => ErrorCategory::Fatal,
             ContractError::NoPendingAdminTransfer => ErrorCategory::Fatal,
+            ContractError::NoPendingRoleGrant => ErrorCategory::Fatal,
+            ContractError::ProvenanceMissing => ErrorCategory::Fatal,
+            ContractError::ProvenanceMismatch => ErrorCategory::Fatal,
+
+            // A pending grant becomes activatable once its timelock elapses.
+            ContractError::RoleGrantNotReady => ErrorCategory::Retry,
         }
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -329,3 +329,37 @@ pub struct RenamedEvent {
     pub verification_cleared: bool,
     pub timestamp: u64,
 }
+
+/// Emitted when a role grant is queued behind the timelock (Issue #220).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoleGrantPendingEvent {
+    #[topic]
+    pub address: Address,
+    /// Numeric discriminant of the [`Role`][crate::storage::Role] requested.
+    pub role: u32,
+    pub admin: Address,
+    /// Ledger timestamp from which `activate_role` will succeed.
+    pub activate_at: u64,
+    pub timestamp: u64,
+}
+
+/// Emitted when a pending role grant is cancelled before activation (Issue #220).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoleGrantCancelledEvent {
+    #[topic]
+    pub address: Address,
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+/// Emitted when the guardian address is set, replaced, or removed (Issue #222).
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GuardianChangedEvent {
+    /// `None` when the guardian was removed.
+    pub guardian: Option<Address>,
+    pub admin: Address,
+    pub timestamp: u64,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,14 @@ pub use events::{
     BatchRemoveProposedEvent, ChallengeCancelledEvent, ChallengeCompletedEvent, RenamedEvent,
     RotationCancelledEvent, RotationExecutedEvent, RotationRequestedEvent,
     ChallengeStartedEvent, EmergencyClearedEvent, EmergencyPausedEvent, PausedEvent,
-    RegisteredEvent, RemovedEvent, RoleGrantedEvent, RoleRevokedEvent, UnpausedEvent,
+    GuardianChangedEvent, RegisteredEvent, RemovedEvent, RoleGrantCancelledEvent,
+    RoleGrantPendingEvent, RoleGrantedEvent, RoleRevokedEvent, UnpausedEvent,
     UpgradeAttestedEvent, UpgradedEvent, VerificationRevokedEvent, VerifiedEvent,
 };
 pub use storage::{
     ChallengeRecord, ContributorRecord, ExportPage, HealthSnapshot, Role, Stats,
-    VerificationConfig, VerifierAllowEntry, WasmAttestation, WasmProvenance, PauseReason,
+    PendingRoleGrant, VerificationConfig, VerifierAllowEntry, WasmAttestation, WasmProvenance,
+    PauseReason,
     MAX_VERIFIERS,
 };
 pub use version::Version;
@@ -68,6 +70,9 @@ use crate::storage::{
     get_guardian as storage_get_guardian,
     remove_guardian as storage_remove_guardian,
     add_verifier as storage_add_verifier, remove_verifier as storage_remove_verifier,
+    get_pending_role as storage_get_pending_role, get_role_delay as storage_get_role_delay,
+    remove_pending_role, set_pending_role, set_role_delay as storage_set_role_delay,
+    PendingRoleGrant as PendingRoleGrantRecord,
     get_verifier_allowlist, is_active_verifier as storage_is_active_verifier,
     verifier_allowlist_active, verifier_slots_remaining, prune_expired_verifiers,
 };
@@ -311,6 +316,12 @@ impl TrustBridgeContract {
         let admin = get_admin(&env)?;
         admin.require_auth();
         set_guardian_address(&env, &guardian);
+        GuardianChangedEvent {
+            guardian: Some(guardian),
+            admin,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
         Ok(())
     }
 
@@ -335,6 +346,12 @@ impl TrustBridgeContract {
         let admin = get_admin(&env)?;
         admin.require_auth();
         storage_remove_guardian(&env);
+        GuardianChangedEvent {
+            guardian: None,
+            admin,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
         Ok(())
     }
 
@@ -471,14 +488,137 @@ impl TrustBridgeContract {
         let admin = get_admin(&env)?;
         admin.require_auth();
 
-        storage_set_role(&env, &target, &role);
         let timestamp = env.ledger().timestamp();
+        let delay = storage_get_role_delay(&env);
+        if delay > 0 {
+            // Timelocked path (Issue #220): the grant is only queued here, so a
+            // stolen admin key cannot mint a Verifier/Upgrader and use it in the
+            // same transaction — the window is observable and cancellable.
+            let activate_at = timestamp.saturating_add(delay);
+            set_pending_role(
+                &env,
+                &target,
+                &PendingRoleGrantRecord {
+                    role,
+                    activate_at,
+                },
+            );
+            RoleGrantPendingEvent {
+                address: target,
+                role: role as u32,
+                admin,
+                activate_at,
+                timestamp,
+            }
+            .publish(&env);
+            return Ok(());
+        }
+
+        storage_set_role(&env, &target, &role);
         RoleGrantedEvent {
             address: target,
             role: role as u32,
             admin,
             timestamp,
             domain: event_domain(&env),
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Sets the timelock applied to future `set_role` grants, in seconds.
+    /// Admin-only. `0` restores instant grants.
+    ///
+    /// The admin address itself is stored separately and is unaffected — the
+    /// admin never has to wait out its own timelock to act (Issue #220).
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the admin.
+    pub fn set_role_delay(env: Env, secs: u64) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+        storage_set_role_delay(&env, secs);
+        Ok(())
+    }
+
+    /// Current `set_role` timelock in seconds. `0` == grants take effect immediately.
+    #[must_use]
+    pub fn get_role_delay(env: Env) -> u64 {
+        storage_get_role_delay(&env)
+    }
+
+    /// The pending (not yet active) role grant for `target`, if any.
+    #[must_use]
+    pub fn get_pending_role(env: Env, target: Address) -> Option<PendingRoleGrant> {
+        storage_get_pending_role(&env, &target)
+    }
+
+    /// Applies a pending role grant once its timelock has elapsed. Admin-only.
+    ///
+    /// Emits [`RoleGrantedEvent`] — the same event an instant grant emits, so
+    /// indexers do not need a second code path for the activated role.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::Paused`] if the contract is paused.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the admin.
+    /// - [`ContractError::NoPendingRoleGrant`] if `target` has no pending grant.
+    /// - [`ContractError::RoleGrantNotReady`] if the timelock has not elapsed.
+    pub fn activate_role(env: Env, target: Address) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        let pending =
+            storage_get_pending_role(&env, &target).ok_or(ContractError::NoPendingRoleGrant)?;
+        let timestamp = env.ledger().timestamp();
+        if timestamp < pending.activate_at {
+            return Err(ContractError::RoleGrantNotReady);
+        }
+
+        storage_set_role(&env, &target, &pending.role);
+        remove_pending_role(&env, &target);
+        RoleGrantedEvent {
+            address: target,
+            role: pending.role as u32,
+            admin,
+            timestamp,
+            domain: event_domain(&env),
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Drops a pending role grant before it activates. Admin-only.
+    ///
+    /// Emits [`RoleGrantCancelledEvent`].
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the admin.
+    /// - [`ContractError::NoPendingRoleGrant`] if `target` has no pending grant.
+    pub fn cancel_role_grant(env: Env, target: Address) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        if storage_get_pending_role(&env, &target).is_none() {
+            return Err(ContractError::NoPendingRoleGrant);
+        }
+        remove_pending_role(&env, &target);
+        RoleGrantCancelledEvent {
+            address: target,
+            admin,
+            timestamp: env.ledger().timestamp(),
         }
         .publish(&env);
 
@@ -513,6 +653,9 @@ impl TrustBridgeContract {
         admin.require_auth();
 
         storage_remove_role(&env, &target);
+        // A revoke also drops any grant still inside its timelock (Issue #220),
+        // otherwise the pending grant would resurrect the role on activation.
+        remove_pending_role(&env, &target);
         let timestamp = env.ledger().timestamp();
         RoleRevokedEvent {
             address: target,
@@ -1119,6 +1262,10 @@ impl TrustBridgeContract {
                 upgraded_at: now,
                 version: soroban_sdk::vec![&env, version.0, version.1, version.2],
                 attested,
+                // Digests are recorded out of band by the operator after the
+                // upgrade; `upgrade` itself has no way to know them (Issue #224).
+                sbom_hash: None,
+                source_hash: None,
             },
         );
 
@@ -1135,6 +1282,63 @@ impl TrustBridgeContract {
         }
         .publish(&env);
 
+        Ok(())
+    }
+
+    /// Records the SBOM and source digests for the currently deployed WASM.
+    /// Admin-only (Issue #224).
+    ///
+    /// Kept separate from `upgrade` because these digests are produced by the
+    /// build pipeline, not by the chain. Passing `None` leaves the existing
+    /// value untouched, so the two digests can be filled in independently. This
+    /// is also the migration path for provenance records written before the
+    /// fields existed — see `docs/DEPLOYMENT.md`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::NotAuthorized`] if the caller is not the admin.
+    /// - [`ContractError::ProvenanceMissing`] if no provenance record exists yet.
+    pub fn set_provenance_digests(
+        env: Env,
+        sbom_hash: Option<BytesN<32>>,
+        source_hash: Option<BytesN<32>>,
+    ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        let mut provenance = get_wasm_provenance(&env).ok_or(ContractError::ProvenanceMissing)?;
+        if sbom_hash.is_some() {
+            provenance.sbom_hash = sbom_hash;
+        }
+        if source_hash.is_some() {
+            provenance.source_hash = source_hash;
+        }
+        set_wasm_provenance(&env, &provenance);
+        Ok(())
+    }
+
+    /// Reproducible-build check: fails unless `hash` equals the WASM hash in
+    /// stored provenance (Issue #225).
+    ///
+    /// An operator runs `stellar contract build`, takes the resulting hash, and
+    /// calls this before authorising an upgrade. A read-only check by design —
+    /// it does not consume or require an attestation, and does not touch state,
+    /// so it is safe to call from a `Makefile` target or CI step.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContractError::NotInitialized`] if `initialize` has not been called.
+    /// - [`ContractError::ProvenanceMissing`] if nothing has been deployed via
+    ///   `upgrade` yet, so there is no recorded hash to compare against.
+    /// - [`ContractError::ProvenanceMismatch`] if the hashes differ.
+    pub fn assert_build(env: Env, hash: BytesN<32>) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        let provenance = get_wasm_provenance(&env).ok_or(ContractError::ProvenanceMissing)?;
+        if provenance.wasm_hash != hash {
+            return Err(ContractError::ProvenanceMismatch);
+        }
         Ok(())
     }
 
@@ -10664,6 +10868,244 @@ mod test {
             // A fresh proposal is possible immediately after.
             TrustBridgeContract::propose_batch_remove(env.clone(), admin.clone(), names.clone())
                 .unwrap();
+        });
+    }
+
+    // ── Issue #220: set_role timelock ────────────────────────────────────────
+
+    #[test]
+    fn test_set_role_is_immediate_when_delay_is_zero() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            assert_eq!(TrustBridgeContract::get_role_delay(env.clone()), 0);
+            TrustBridgeContract::set_role(env.clone(), user.clone(), Role::Verifier).unwrap();
+            assert_eq!(
+                TrustBridgeContract::get_role(env.clone(), user.clone()),
+                Some(Role::Verifier)
+            );
+        });
+    }
+
+    #[test]
+    fn test_set_role_grant_waits_out_the_timelock() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_role_delay(env.clone(), 3600).unwrap();
+            TrustBridgeContract::set_role(env.clone(), user.clone(), Role::Upgrader).unwrap();
+
+            // Queued, not active.
+            assert!(TrustBridgeContract::get_role(env.clone(), user.clone()).is_none());
+            let pending =
+                TrustBridgeContract::get_pending_role(env.clone(), user.clone()).unwrap();
+            assert_eq!(pending.role, Role::Upgrader);
+
+            // Too early.
+            assert_eq!(
+                TrustBridgeContract::activate_role(env.clone(), user.clone()),
+                Err(ContractError::RoleGrantNotReady)
+            );
+
+            env.ledger().set_timestamp(pending.activate_at);
+            TrustBridgeContract::activate_role(env.clone(), user.clone()).unwrap();
+            assert_eq!(
+                TrustBridgeContract::get_role(env.clone(), user.clone()),
+                Some(Role::Upgrader)
+            );
+            assert!(TrustBridgeContract::get_pending_role(env.clone(), user.clone()).is_none());
+        });
+    }
+
+    #[test]
+    fn test_set_role_grant_can_be_cancelled_before_activation() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_role_delay(env.clone(), 3600).unwrap();
+            TrustBridgeContract::set_role(env.clone(), user.clone(), Role::Verifier).unwrap();
+            TrustBridgeContract::cancel_role_grant(env.clone(), user.clone()).unwrap();
+
+            assert!(TrustBridgeContract::get_pending_role(env.clone(), user.clone()).is_none());
+            assert_eq!(
+                TrustBridgeContract::activate_role(env.clone(), user.clone()),
+                Err(ContractError::NoPendingRoleGrant)
+            );
+            assert_eq!(
+                TrustBridgeContract::cancel_role_grant(env.clone(), user.clone()),
+                Err(ContractError::NoPendingRoleGrant)
+            );
+        });
+    }
+
+    #[test]
+    fn test_set_role_remove_role_drops_pending_grant() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_role_delay(env.clone(), 3600).unwrap();
+            TrustBridgeContract::set_role(env.clone(), user.clone(), Role::Verifier).unwrap();
+            TrustBridgeContract::remove_role(env.clone(), user.clone()).unwrap();
+
+            assert!(TrustBridgeContract::get_pending_role(env.clone(), user.clone()).is_none());
+        });
+    }
+
+    // ── Issue #222: guardian is pause-only ───────────────────────────────────
+
+    #[test]
+    fn test_guardian_cannot_set_role_or_clear_pause() {
+        let env = Env::default();
+        let (_admin, user, _other, contract_id) = setup(&env);
+        let guardian = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            env.mock_all_auths();
+            TrustBridgeContract::set_guardian(env.clone(), guardian.clone()).unwrap();
+
+            // The guardian holds no role, so it cannot reach any Upgrader- or
+            // Verifier-gated path, and set_role stays admin-authorised.
+            assert!(TrustBridgeContract::get_role(env.clone(), guardian.clone()).is_none());
+
+            TrustBridgeContract::emergency_pause(env.clone(), guardian.clone()).unwrap();
+            // Pause is a full stop: even the admin's own set_role is blocked
+            // while the breaker is tripped, so the guardian's freeze holds.
+            assert_eq!(
+                TrustBridgeContract::set_role(env.clone(), user.clone(), Role::Verifier),
+                Err(ContractError::Paused)
+            );
+        });
+    }
+
+    #[test]
+    fn test_guardian_rotation_replaces_previous_guardian() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+        let first = Address::generate(&env);
+        let second = Address::generate(&env);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            TrustBridgeContract::set_guardian(env.clone(), first.clone()).unwrap();
+            TrustBridgeContract::set_guardian(env.clone(), second.clone()).unwrap();
+            assert_eq!(TrustBridgeContract::get_guardian(env.clone()), Some(second));
+
+            TrustBridgeContract::remove_guardian(env.clone()).unwrap();
+            assert!(TrustBridgeContract::get_guardian(env.clone()).is_none());
+            // The removed guardian can no longer freeze the contract.
+            assert_eq!(
+                TrustBridgeContract::emergency_pause(env.clone(), first.clone()),
+                Err(ContractError::NotAuthorized)
+            );
+        });
+    }
+
+    // ── Issues #224 / #225: provenance digests and build verification ────────
+
+    #[test]
+    fn test_provenance_records_sbom_and_source_digests() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            // No provenance until something has been deployed.
+            assert_eq!(
+                TrustBridgeContract::set_provenance_digests(
+                    env.clone(),
+                    Some(BytesN::from_array(&env, &[1u8; 32])),
+                    None,
+                ),
+                Err(ContractError::ProvenanceMissing)
+            );
+
+            let wasm_hash = BytesN::from_array(&env, &[7u8; 32]);
+            set_wasm_provenance(
+                &env,
+                &WasmProvenance {
+                    wasm_hash: wasm_hash.clone(),
+                    previous_wasm_hash: None,
+                    upgraded_by: get_admin(&env).unwrap(),
+                    upgraded_at: 0,
+                    version: Vec::new(&env),
+                    attested: false,
+                    // Pre-#224 records carry no digests; backfilling them is
+                    // exactly the migration this test walks through.
+                    sbom_hash: None,
+                    source_hash: None,
+                },
+            );
+
+            let sbom = BytesN::from_array(&env, &[2u8; 32]);
+            let source = BytesN::from_array(&env, &[3u8; 32]);
+            TrustBridgeContract::set_provenance_digests(
+                env.clone(),
+                Some(sbom.clone()),
+                Some(source.clone()),
+            )
+            .unwrap();
+
+            let provenance = TrustBridgeContract::get_provenance(env.clone()).unwrap();
+            assert_eq!(provenance.sbom_hash, Some(sbom.clone()));
+            assert_eq!(provenance.source_hash, Some(source));
+            assert_eq!(provenance.wasm_hash, wasm_hash);
+
+            // A None argument leaves the stored digest alone.
+            TrustBridgeContract::set_provenance_digests(env.clone(), None, None).unwrap();
+            assert_eq!(
+                TrustBridgeContract::get_provenance(env.clone())
+                    .unwrap()
+                    .sbom_hash,
+                Some(sbom)
+            );
+        });
+    }
+
+    #[test]
+    fn test_provenance_assert_build_rejects_unmatched_hash() {
+        let env = Env::default();
+        let (_admin, _user, _other, contract_id) = setup(&env);
+
+        env.mock_all_auths();
+        env.as_contract(&contract_id, || {
+            let wasm_hash = BytesN::from_array(&env, &[7u8; 32]);
+
+            // Nothing deployed yet: the check fails closed rather than passing.
+            assert_eq!(
+                TrustBridgeContract::assert_build(env.clone(), wasm_hash.clone()),
+                Err(ContractError::ProvenanceMissing)
+            );
+
+            set_wasm_provenance(
+                &env,
+                &WasmProvenance {
+                    wasm_hash: wasm_hash.clone(),
+                    previous_wasm_hash: None,
+                    upgraded_by: get_admin(&env).unwrap(),
+                    upgraded_at: 0,
+                    version: Vec::new(&env),
+                    attested: false,
+                    sbom_hash: None,
+                    source_hash: None,
+                },
+            );
+
+            TrustBridgeContract::assert_build(env.clone(), wasm_hash).unwrap();
+            assert_eq!(
+                TrustBridgeContract::assert_build(
+                    env.clone(),
+                    BytesN::from_array(&env, &[9u8; 32])
+                ),
+                Err(ContractError::ProvenanceMismatch)
+            );
         });
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -75,6 +75,14 @@ pub const NETWORK_KEY: Symbol = symbol_short!("network");
 
 pub const ROLE_KEY: Symbol = symbol_short!("role");
 
+/// Seconds a `set_role` grant must wait before it can be activated (Issue #220).
+/// 0 disables the timelock, matching the cooldown convention, so existing
+/// deployments keep their instant-grant behaviour until an admin opts in.
+pub const ROLE_DELAY_KEY: Symbol = symbol_short!("roldelay");
+
+/// Key prefix for a pending (timelocked) role grant, namespaced by address.
+pub const PENDING_ROLE_KEY: Symbol = symbol_short!("pendrole");
+
 /// Key for the enumerable index of addresses that currently hold a role
 /// (Issue #228). Maintained by [`set_role`] and [`remove_role`] so it can
 /// never drift from the per-address `ROLE_KEY` entries.
@@ -201,6 +209,17 @@ pub enum Role {
     Revoker = 4,
 }
 
+/// A role grant that has been requested but is still inside its timelock
+/// window (Issue #220). Held until `activate_role` applies it or
+/// `cancel_role_grant` drops it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[soroban_sdk::contracttype]
+pub struct PendingRoleGrant {
+    pub role: Role,
+    /// Ledger timestamp from which `activate_role` will succeed.
+    pub activate_at: u64,
+}
+
 /// Typed reason code for `pause`, `unpause`, and `set_paused` (Issue #211).
 ///
 /// Stored on-chain alongside the pause flag so incident reviewers can
@@ -316,6 +335,13 @@ pub struct WasmProvenance {
     pub version: Vec<u32>,
     /// Whether the hash had been attested before it was applied.
     pub attested: bool,
+    /// Digest of the SBOM produced for this build (Issue #224). `None` when the
+    /// operator has not recorded one — including every record written before
+    /// this field existed, which is the explicit migration path: call
+    /// `set_provenance_digests` once after upgrading to backfill it.
+    pub sbom_hash: Option<BytesN<32>>,
+    /// Digest of the source tree the WASM was built from (Issue #224).
+    pub source_hash: Option<BytesN<32>>,
 }
 
 /// An admin's advance declaration of the WASM hash they intend to deploy.
@@ -2290,4 +2316,33 @@ pub fn is_batch_remove_proposal_expired(env: &Env, proposal: &PendingBatchRemove
         >= proposal
             .proposed_at
             .saturating_add(BATCH_REMOVE_PROPOSAL_TTL_SECS)
+}
+
+// ─── Role grant timelock (Issue #220) ────────────────────────────────────────
+
+/// Seconds a `set_role` grant waits before activation. 0 == instant grants.
+pub fn get_role_delay(env: &Env) -> u64 {
+    env.storage().instance().get(&ROLE_DELAY_KEY).unwrap_or(0)
+}
+
+pub fn set_role_delay(env: &Env, secs: u64) {
+    env.storage().instance().set(&ROLE_DELAY_KEY, &secs);
+}
+
+pub fn get_pending_role(env: &Env, address: &Address) -> Option<PendingRoleGrant> {
+    env.storage()
+        .instance()
+        .get(&(PENDING_ROLE_KEY, address.clone()))
+}
+
+pub fn set_pending_role(env: &Env, address: &Address, grant: &PendingRoleGrant) {
+    env.storage()
+        .instance()
+        .set(&(PENDING_ROLE_KEY, address.clone()), grant);
+}
+
+pub fn remove_pending_role(env: &Env, address: &Address) {
+    env.storage()
+        .instance()
+        .remove(&(PENDING_ROLE_KEY, address.clone()));
 }


### PR DESCRIPTION
Closes #220: `set_role` grants can be queued behind a configurable delay. `set_role_delay(secs)` opts in (0 = today's instant behaviour), a queued grant surfaces via `get_pending_role` and `RoleGrantPendingEvent`, and `activate_role` applies it after `activate_at`. `cancel_role_grant` drops one before activation, as does `remove_role`. The admin address is stored separately and is never subject to the delay — documented as the exception.

Closes #222: guardian stays pause-only. Added `GuardianChangedEvent` on set/rotate/remove, negative tests that the guardian holds no role and cannot lift its own freeze, and an ADMIN_RUNBOOK section with the capability matrix and rotation steps.

Closes #224: `WasmProvenance` gains optional `sbom_hash` and `source_hash`. `upgrade` writes them as `None` — the chain cannot know them — and the operator backfills with the new admin-only `set_provenance_digests`, which is also the explicit migration path for pre-existing records.

Closes #225: `assert_build(hash)` compares a locally built hash to stored provenance and fails with the typed `ProvenanceMismatch`, or `ProvenanceMissing` when nothing has been deployed yet. Read-only, and independent of the attestation flow. Added a `make assert-build` target.